### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -98,7 +98,7 @@ setAmbientTemperature	KEYWORD2
 # CC1101-specific
 getLQI	KEYWORD2
 setGdo0Action	KEYWORD2
-setGdo1Action KEYWORD2
+setGdo1Action	KEYWORD2
 
 # SX126x-specific
 setDio2Action	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords