### PR TITLE
ESP32 & SAMD - use HardwareSerial instead of SoftwareSerial

### DIFF
--- a/src/ISerial.cpp
+++ b/src/ISerial.cpp
@@ -9,7 +9,11 @@ void ISerial::begin(long speed) {
 }
 
 bool ISerial::listen() {
+#if defined ( ESP32 )  || defined (SAMD_SERIES)
+  return true;
+#else
   return(_mod->ModuleSerial->listen());
+#endif
 }
 
 void ISerial::end() {
@@ -17,15 +21,27 @@ void ISerial::end() {
 }
 
 bool ISerial::isListening() {
+#if defined( ESP32 ) || defined ( SAMD_SERIES )
+  return true;
+#else
   return(_mod->ModuleSerial->isListening());
+#endif
 }
 
 bool ISerial::stopListening() {
+#if defined( ESP32 ) || defined ( SAMD_SERIES )
+  return true;
+#else
   return(_mod->ModuleSerial->stopListening());
+#endif
 }
 
 bool ISerial::overflow() {
+#if defined( ESP32 ) || defined ( SAMD_SERIES )
+  return false;
+#else
   return(_mod->ModuleSerial->overflow());
+#endif
 }
 
 int ISerial::peek() {

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -1,13 +1,17 @@
 #include "Module.h"
 
-Module::Module(int rx, int tx) {
+Module::Module(int rx, int tx, HardwareSerial* useSer) {
   _cs = -1;
   _rx = rx;
   _tx = tx;
   _int0 = -1;
   _int1 = -1;
 
+#if defined(ESP32) || defined(SAMD_SERIES)
+    ModuleSerial = useSer;
+#else
   ModuleSerial = new SoftwareSerial(_rx, _tx);
+#endif
 }
 
 Module::Module(int cs, int int0, int int1, SPIClass& spi, SPISettings spiSettings) {
@@ -20,7 +24,7 @@ Module::Module(int cs, int int0, int int1, SPIClass& spi, SPISettings spiSetting
   _spiSettings = spiSettings;
 }
 
-Module::Module(int cs, int int0, int int1, int rx, int tx, SPIClass& spi, SPISettings spiSettings) {
+Module::Module(int cs, int int0, int int1, int rx, int tx, SPIClass& spi, SPISettings spiSettings, HardwareSerial* useSer) {
   _cs = cs;
   _rx = rx;
   _tx = tx;
@@ -29,7 +33,11 @@ Module::Module(int cs, int int0, int int1, int rx, int tx, SPIClass& spi, SPISet
   _spi = &spi;
   _spiSettings = spiSettings;
 
+#if defined(ESP32) || defined(SAMD_SERIES)
+  ModuleSerial = useSer;
+#else
   ModuleSerial = new SoftwareSerial(_rx, _tx);
+#endif
 }
 
 Module::Module(int cs, int int0, int int1, int int2, SPIClass& spi, SPISettings spiSettings) {
@@ -51,7 +59,11 @@ void Module::init(uint8_t interface, uint8_t gpio) {
       _spi->begin();
       break;
     case USE_UART:
+#if defined(ESP32)
+      ModuleSerial->begin(baudrate, SERIAL_8N1, _rx, _tx);
+#else
       ModuleSerial->begin(baudrate);
+#endif
       break;
     case USE_I2C:
       break;

--- a/src/Module.h
+++ b/src/Module.h
@@ -3,7 +3,10 @@
 
 #include <SPI.h>
 //#include <Wire.h>
+#if defined(ESP32) || defined(SAMD_SERIES)
+#else
 #include <SoftwareSerial.h>
+#endif
 
 #include "TypeDef.h"
 
@@ -22,8 +25,14 @@ class Module {
       \param tx Arduino pin to be used as Tx pin for SoftwareSerial communication.
 
       \param rx Arduino pin to be used as Rx pin for SoftwareSerial communication.
+
+      \param serial HardwareSerial to be used on ESP32 and SAMD. Defaults to 1
     */
-    Module(int tx, int rx);
+#if defined(ESP32) || defined(SAMD_SERIES)
+    Module(int tx, int rx, HardwareSerial* useSer = &Serial1);
+#else
+    Module(int tx, int rx, HardwareSerial* useSer = nullptr);
+#endif
 
     /*!
       \brief SPI-based module constructor.
@@ -73,15 +82,26 @@ class Module {
       \param spi SPI interface to be used. Defaults to Arduino hardware SPI interface, can also use software SPI implementations.
 
       \param spiSettings SPI interface settings. Defaults to 2 MHz clock, MSB first, mode 0.
+
+      \param serial HardwareSerial to be used on ESP32 and SAMD. Defaults to 1
     */
-    Module(int cs, int int0, int int1, int rx, int tx, SPIClass& spi = SPI, SPISettings spiSettings = SPISettings(2000000, MSBFIRST, SPI_MODE0));
+#if defined(ESP32) || defined(SAMD_SERIES)
+    Module(int cs, int int0, int int1, int rx, int tx, SPIClass& spi = SPI, SPISettings spiSettings = SPISettings(2000000, MSBFIRST, SPI_MODE0), HardwareSerial* useSer = &Serial1);
+#else
+    Module(int cs, int int0, int int1, int rx, int tx, SPIClass& spi = SPI, SPISettings spiSettings = SPISettings(2000000, MSBFIRST, SPI_MODE0), HardwareSerial* useSer = nullptr);
+#endif
+      
 
     // public member variables
 
     /*!
       \brief Internal SoftwareSerial instance.
     */
+#if defined(ESP32) || defined(SAMD_SERIES)
+    HardwareSerial* ModuleSerial;
+#else
     SoftwareSerial* ModuleSerial;
+#endif
 
     /*!
       \brief Baud rate of SoftwareSerial UART communication. Defaults to 9600 baud.


### PR DESCRIPTION
ESP32 has no working SoftwareSerial. With a simple #ifdef ESP32 || SAMD a hardware serial will be used instead.    
Minimum changes without influence on existing installations or usage.

Hope this time I did a better job.