### PR TITLE
STM32 - use HardwareSerial instead of SoftwareSerial

### DIFF
--- a/src/ISerial.cpp
+++ b/src/ISerial.cpp
@@ -9,7 +9,7 @@ void ISerial::begin(long speed) {
 }
 
 bool ISerial::listen() {
-#if defined ( ESP32 )  || defined (SAMD_SERIES)
+#if defined ( ESP32 )  || defined (SAMD_SERIES) || defined (ARDUINO_ARCH_STM32)
   return true;
 #else
   return(_mod->ModuleSerial->listen());
@@ -21,7 +21,7 @@ void ISerial::end() {
 }
 
 bool ISerial::isListening() {
-#if defined( ESP32 ) || defined ( SAMD_SERIES )
+#if defined( ESP32 ) || defined ( SAMD_SERIES ) || defined (ARDUINO_ARCH_STM32)
   return true;
 #else
   return(_mod->ModuleSerial->isListening());
@@ -29,7 +29,7 @@ bool ISerial::isListening() {
 }
 
 bool ISerial::stopListening() {
-#if defined( ESP32 ) || defined ( SAMD_SERIES )
+#if defined( ESP32 ) || defined ( SAMD_SERIES ) || defined (ARDUINO_ARCH_STM32)
   return true;
 #else
   return(_mod->ModuleSerial->stopListening());
@@ -37,7 +37,7 @@ bool ISerial::stopListening() {
 }
 
 bool ISerial::overflow() {
-#if defined( ESP32 ) || defined ( SAMD_SERIES )
+#if defined( ESP32 ) || defined ( SAMD_SERIES ) || defined (ARDUINO_ARCH_STM32)
   return false;
 #else
   return(_mod->ModuleSerial->overflow());
@@ -155,4 +155,3 @@ size_t ISerial::println(const Printable& x) {
 size_t ISerial::println(void) {
   return(_mod->ModuleSerial->println());
 }
-  

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -7,7 +7,7 @@ Module::Module(int rx, int tx, HardwareSerial* useSer) {
   _int0 = -1;
   _int1 = -1;
 
-#if defined(ESP32) || defined(SAMD_SERIES)
+#if defined(ESP32) || defined(SAMD_SERIES) || defined (ARDUINO_ARCH_STM32)
     ModuleSerial = useSer;
 #else
   ModuleSerial = new SoftwareSerial(_rx, _tx);
@@ -33,7 +33,7 @@ Module::Module(int cs, int int0, int int1, int rx, int tx, SPIClass& spi, SPISet
   _spi = &spi;
   _spiSettings = spiSettings;
 
-#if defined(ESP32) || defined(SAMD_SERIES)
+#if defined(ESP32) || defined(SAMD_SERIES) || defined (ARDUINO_ARCH_STM32)
   ModuleSerial = useSer;
 #else
   ModuleSerial = new SoftwareSerial(_rx, _tx);

--- a/src/Module.h
+++ b/src/Module.h
@@ -3,7 +3,7 @@
 
 #include <SPI.h>
 //#include <Wire.h>
-#if defined(ESP32) || defined(SAMD_SERIES)
+#if defined(ESP32) || defined(SAMD_SERIES) || defined (ARDUINO_ARCH_STM32)
 #else
 #include <SoftwareSerial.h>
 #endif
@@ -28,7 +28,7 @@ class Module {
 
       \param serial HardwareSerial to be used on ESP32 and SAMD. Defaults to 1
     */
-#if defined(ESP32) || defined(SAMD_SERIES)
+#if defined(ESP32) || defined(SAMD_SERIES) || defined (ARDUINO_ARCH_STM32)
     Module(int tx, int rx, HardwareSerial* useSer = &Serial1);
 #else
     Module(int tx, int rx, HardwareSerial* useSer = nullptr);
@@ -85,19 +85,19 @@ class Module {
 
       \param serial HardwareSerial to be used on ESP32 and SAMD. Defaults to 1
     */
-#if defined(ESP32) || defined(SAMD_SERIES)
+#if defined(ESP32) || defined(SAMD_SERIES) || defined (ARDUINO_ARCH_STM32)
     Module(int cs, int int0, int int1, int rx, int tx, SPIClass& spi = SPI, SPISettings spiSettings = SPISettings(2000000, MSBFIRST, SPI_MODE0), HardwareSerial* useSer = &Serial1);
 #else
     Module(int cs, int int0, int int1, int rx, int tx, SPIClass& spi = SPI, SPISettings spiSettings = SPISettings(2000000, MSBFIRST, SPI_MODE0), HardwareSerial* useSer = nullptr);
 #endif
-      
+
 
     // public member variables
 
     /*!
       \brief Internal SoftwareSerial instance.
     */
-#if defined(ESP32) || defined(SAMD_SERIES)
+#if defined(ESP32) || defined(SAMD_SERIES) || defined (ARDUINO_ARCH_STM32)
     HardwareSerial* ModuleSerial;
 #else
     SoftwareSerial* ModuleSerial;


### PR DESCRIPTION
Added support for STM32 based boards, using HardwareSerial instead of SoftwareSerial the same way as in https://github.com/jgromes/RadioLib/pull/39