### PR TITLE
Variable/fixed packet length mode config for RF69/SX1231

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -88,7 +88,7 @@ setDataShaping	KEYWORD2
 setOOK	KEYWORD2
 setDataShapingOOK	KEYWORD2
 setCRC	KEYWORD2
-variablePacketLengthMode KEYWORD2
+variablePacketLengthMode  KEYWORD2
 fixedPacketLengthMode KEYWORD2
 
 # RF69-specific

--- a/src/modules/RF69.cpp
+++ b/src/modules/RF69.cpp
@@ -4,6 +4,7 @@ RF69::RF69(Module* module) : PhysicalLayer(RF69_CRYSTAL_FREQ, RF69_DIV_EXPONENT,
   _mod = module;
   _tempOffset = 0;
   _packetLengthQueried = false;
+  _packetLengthConfig = RF69_PACKET_FORMAT_VARIABLE;
 }
 
 int16_t RF69::begin(float freq, float br, float rxBw, float freqDev, int8_t power) {
@@ -54,24 +55,34 @@ int16_t RF69::begin(float freq, float br, float rxBw, float freqDev, int8_t powe
     return(state);
   }
 
+  // configure bitrate
   _rxBw = 125.0;
   state = setBitRate(br);
   if(state != ERR_NONE) {
     return(state);
   }
 
+  // configure default RX bandwidth
   state = setRxBandwidth(rxBw);
   if(state != ERR_NONE) {
     return(state);
   }
 
+  // configure default frequency deviation
   state = setFrequencyDeviation(freqDev);
   if(state != ERR_NONE) {
     return(state);
   }
 
+  // configure default TX output power
   state = setOutputPower(power);
   if(state != ERR_NONE) {
+    return(state);
+  }
+
+  // set default packet length mode
+  state = variablePacketLengthMode();
+  if (state != ERR_NONE) {
     return(state);
   }
 
@@ -249,6 +260,11 @@ int16_t RF69::startTransmit(uint8_t* data, size_t len, uint8_t addr) {
 
   // set packet length
   _mod->SPIwriteRegister(RF69_REG_FIFO, len);
+
+  // optionally write packet length
+  if (_packetLengthConfig == RF69_PACKET_FORMAT_VARIABLE) {
+    SPIwriteRegister(RF69_REG_FIFO, len);
+  }
 
   // check address filtering
   uint8_t filter = _mod->SPIgetRegValue(RF69_REG_PACKET_CONFIG_1, 2, 1);
@@ -563,11 +579,61 @@ int16_t RF69::getTemperature() {
 
 size_t RF69::getPacketLength(bool update) {
   if(!_packetLengthQueried && update) {
-    _packetLength = _mod->SPIreadRegister(RF69_REG_FIFO);
+    if (_packetLengthConfig == RF69_PACKET_FORMAT_VARIABLE) {
+      _packetLength = _mod->SPIreadRegister(RF69_REG_FIFO);
+    } else {
+      _packetLength = _mod->SPIreadRegister(RF69_REG_PAYLOAD_LENGTH);
+    }
     _packetLengthQueried = true;
   }
 
   return(_packetLength);
+}
+
+int16_t RF69::fixedPacketLengthMode(uint8_t len) {
+  if (len > RF69_MAX_PACKET_LENGTH) {
+    return(ERR_PACKET_TOO_LONG);
+  }
+
+  // set to fixed packet length
+  int16_t state = _mod->SPIsetRegValue(RF69_REG_PACKET_CONFIG_1, RF69_PACKET_FORMAT_FIXED, 7, 7);
+  if (state != ERR_NONE) {
+    return(state);
+  }
+
+  // set length to register
+  state = _mod->SPIsetRegValue(RF69_REG_PAYLOAD_LENGTH, len);
+  if (state != ERR_NONE) {
+    return(state);
+  }
+
+  // all went well: cache the reg value
+  _packetLengthConfig = RF69_PACKET_FORMAT_FIXED;
+
+  return(state);
+}
+
+int16_t RF69::variablePacketLengthMode(uint8_t maxLen) {
+  if (maxLen > RF69_MAX_PACKET_LENGTH) {
+    return(ERR_PACKET_TOO_LONG);
+  }
+
+  // set to variable packet length
+  int16_t state = _mod->SPIsetRegValue(RF69_REG_PACKET_CONFIG_1, RF69_PACKET_FORMAT_VARIABLE, 7, 7);
+  if (state != ERR_NONE) {
+    return(state);
+  }
+
+  // set max length to register
+  state = _mod->SPIsetRegValue(RF69_REG_PAYLOAD_LENGTH, maxLen);
+  if (state != ERR_NONE) {
+    return(state);
+  }
+
+  // all went well: cache the reg value
+  _packetLengthConfig = RF69_PACKET_FORMAT_VARIABLE;
+
+  return(state);
 }
 
 int16_t RF69::config() {

--- a/src/modules/RF69.cpp
+++ b/src/modules/RF69.cpp
@@ -263,7 +263,7 @@ int16_t RF69::startTransmit(uint8_t* data, size_t len, uint8_t addr) {
 
   // optionally write packet length
   if (_packetLengthConfig == RF69_PACKET_FORMAT_VARIABLE) {
-    SPIwriteRegister(RF69_REG_FIFO, len);
+    _mod->SPIwriteRegister(RF69_REG_FIFO, len);
   }
 
   // check address filtering

--- a/src/modules/RF69.h
+++ b/src/modules/RF69.h
@@ -697,7 +697,7 @@ class RF69: public PhysicalLayer {
     */
     int16_t getTemperature();
 
-     /*!
+    /*!
       \brief Query modem for the packet length of received payload.
 
       \param update Update received packet length. Will return cached value when set to false.
@@ -705,6 +705,24 @@ class RF69: public PhysicalLayer {
       \returns Length of last received packet in bytes.
     */
     size_t getPacketLength(bool update = true);
+
+    /*!
+      \brief Set modem in fixed packet length mode.
+
+      \param len Packet length.
+
+      \returns \ref status_codes
+    */
+    int16_t fixedPacketLengthMode(uint8_t len = RF69_MAX_PACKET_LENGTH);
+
+     /*!
+      \brief Set modem in variable packet length mode.
+
+      \param len Maximum packet length.
+
+      \returns \ref status_codes
+    */
+    int16_t variablePacketLengthMode(uint8_t maxLen = RF69_MAX_PACKET_LENGTH);
 
   protected:
     Module* _mod;
@@ -715,6 +733,7 @@ class RF69: public PhysicalLayer {
 
     size_t _packetLength;
     bool _packetLengthQueried;
+    uint8_t _packetLengthConfig;
 
     int16_t config();
     int16_t directMode();

--- a/src/modules/SX1231.cpp
+++ b/src/modules/SX1231.cpp
@@ -53,22 +53,26 @@ int16_t SX1231::begin(float freq, float br, float rxBw, float freqDev, int8_t po
     return(state);
   }
 
+  // configure bitrate
   _rxBw = 125.0;
   state = setBitRate(br);
   if(state != ERR_NONE) {
     return(state);
   }
 
+  // configure default RX bandwidth
   state = setRxBandwidth(rxBw);
   if(state != ERR_NONE) {
     return(state);
   }
 
+  // configure default frequency deviation
   state = setFrequencyDeviation(freqDev);
   if(state != ERR_NONE) {
     return(state);
   }
 
+  // configure default TX output power
   state = setOutputPower(power);
   if(state != ERR_NONE) {
     return(state);
@@ -78,6 +82,12 @@ int16_t SX1231::begin(float freq, float br, float rxBw, float freqDev, int8_t po
   uint8_t syncWord[] = {0x2D, 0x01};
   state = setSyncWord(syncWord, 2);
   if(state != ERR_NONE) {
+    return(state);
+  }
+
+  // set default packet length mode
+  state = variablePacketLengthMode();
+  if (state != ERR_NONE) {
     return(state);
   }
 


### PR DESCRIPTION
Related idea: is it possible to just call `RF69::begin` within `SX1X1231::begin` and just add the `if (_chipRevision == SX1231_CHIP_REVISION_2_A)` block before returning?