### PR TITLE
Sx126x txpower

### DIFF
--- a/src/modules/SX1261.cpp
+++ b/src/modules/SX1261.cpp
@@ -17,10 +17,10 @@ int16_t SX1261::setOutputPower(int8_t power) {
   // set PA config for optimal consumption as described in section 13-21 of the datasheet:
   // the final column of Table 13-21 suggests that the value passed in SetTxParams is actually scaled depending on the parameters of setPaConfig. However, testing suggests this isn't the case.
   if (power > 10) {
-    state = SX126x::setPaConfig(0x04, 0x00, SX126X_PA_CONFIG_HP_MAX/*0x07*/);
+    state = SX126x::setPaConfig(0x04, SX126X_PA_CONFIG_SX1261, 0x00);
   }
   else {
-    state = SX126x::setPaConfig(0x01, 0x00, 0x05);
+    state = SX126x::setPaConfig(0x01, SX126X_PA_CONFIG_SX1261, 0x00);
   }
   if (state != ERR_NONE) {
     return(state);

--- a/src/modules/SX1261.cpp
+++ b/src/modules/SX1261.cpp
@@ -1,0 +1,40 @@
+#include "SX1261.h"
+
+// note that this is untested (lacking the hardware) and based purely on the datasheet.
+int16_t SX1261::setOutputPower(int8_t power) {  
+  // check allowed power range
+  if (!((power >= -17) && (power <= 14))) {
+    return(ERR_INVALID_OUTPUT_POWER);
+  }
+
+  // get current OCP configuration
+  uint8_t ocp = 0;
+  int16_t state = readRegister(SX126X_REG_OCP_CONFIGURATION, &ocp, 1);
+  if (state != ERR_NONE) {
+    return(state);
+  }
+
+  // set PA config for optimal consumption as described in section 13-21 of the datasheet:
+  // the final column of Table 13-21 suggests that the value passed in SetTxParams is actually scaled depending on the parameters of setPaConfig. However, testing suggests this isn't the case.
+  if (power > 10) {
+    state = SX126x::setPaConfig(0x04, 0x00, SX126X_PA_CONFIG_HP_MAX/*0x07*/);
+  }
+  else {
+    state = SX126x::setPaConfig(0x01, 0x00, 0x05);
+  }
+  if (state != ERR_NONE) {
+    return(state);
+  }
+  // TODO investigate if better power efficiency can be achieved using undocumented even lower settings
+
+  // set output power
+  // TODO power ramp time configuration
+  state = SX126x::setTxParams(power);
+  if (state != ERR_NONE) {
+    return state;
+  }
+
+
+  // restore OCP configuration
+  return(writeRegister(SX126X_REG_OCP_CONFIGURATION, &ocp, 1));
+}

--- a/src/modules/SX1261.h
+++ b/src/modules/SX1261.h
@@ -11,6 +11,19 @@
 #define SX126X_PA_CONFIG_SX1262                       0x00
 
 // TODO: implement SX1261 class
-using SX1261 = SX1262;
+class SX1261 : public SX1262 {
+public:
+  /*!
+    \brief Default constructor.
+
+    \param mod Instance of Module that will be used to communicate with the radio.
+  */
+  SX1261(Module* mod)
+    : SX1262(mod) {
+  }
+
+  int16_t setOutputPower(int8_t power);
+};
+
 
 #endif

--- a/src/modules/SX1261.h
+++ b/src/modules/SX1261.h
@@ -6,6 +6,8 @@
 #include "SX126x.h"
 #include "SX1262.h"
 
+//SX126X_CMD_SET_PA_CONFIG
+#define SX126X_PA_CONFIG_SX1261                       0x01
 
 // TODO: implement SX1261 class
 class SX1261 : public SX1262 {
@@ -15,10 +17,15 @@ class SX1261 : public SX1262 {
 
       \param mod Instance of Module that will be used to communicate with the radio.
     */
-    SX1261(Module* mod)
-      : SX1262(mod) {
-    }
+    SX1261(Module* mod);
 
+    /*!
+      \brief Sets output power. Allowed values are in range from -17 to 14 dBm.
+
+      \param power Output power to be set in dBm.
+
+      \returns \ref status_codes
+    */
     int16_t setOutputPower(int8_t power);
 
   private:

--- a/src/modules/SX1261.h
+++ b/src/modules/SX1261.h
@@ -6,23 +6,23 @@
 #include "SX126x.h"
 #include "SX1262.h"
 
-//SX126X_CMD_SET_PA_CONFIG
-#define SX126X_PA_CONFIG_SX1261                       0x01
-#define SX126X_PA_CONFIG_SX1262                       0x00
 
 // TODO: implement SX1261 class
 class SX1261 : public SX1262 {
-public:
-  /*!
-    \brief Default constructor.
+  public:
+    /*!
+      \brief Default constructor.
 
-    \param mod Instance of Module that will be used to communicate with the radio.
-  */
-  SX1261(Module* mod)
-    : SX1262(mod) {
-  }
+      \param mod Instance of Module that will be used to communicate with the radio.
+    */
+    SX1261(Module* mod)
+      : SX1262(mod) {
+    }
 
-  int16_t setOutputPower(int8_t power);
+    int16_t setOutputPower(int8_t power);
+
+  private:
+    int16_t setOptimalLowPowerPaConfig(int8_t* inOutPower);
 };
 
 

--- a/src/modules/SX1262.cpp
+++ b/src/modules/SX1262.cpp
@@ -85,7 +85,7 @@ int16_t SX1262::setFrequency(float freq, bool calibrate) {
 
 int16_t SX1262::setOutputPower(int8_t power) {
   // check allowed power range
-  if(!((power >= -17) && (power <= 22))) {
+  if(!((power >= -9) && (power <= 22))) {
     return(ERR_INVALID_OUTPUT_POWER);
   }
 
@@ -96,16 +96,31 @@ int16_t SX1262::setOutputPower(int8_t power) {
     return(state);
   }
 
-  // enable high power PA for output power higher than 14 dBm
-  if(power > 13) {
-    SX126x::setPaConfig(0x04, SX126X_PA_CONFIG_SX1262);
+  // set PA config for optimal consumption as described in section 13-21 of the datasheet:
+  // the final column of Table 13-21 suggests that the value passed in SetTxParams is actually scaled depending on the parameters of setPaConfig. However, testing suggests this isn't the case.
+  if (power >= 21) {
+    state = SX126x::setPaConfig(0x04, SX126X_PA_CONFIG_SX1262, SX126X_PA_CONFIG_HP_MAX/*0x07*/);
+  } else if (power >= 18) {
+    state = SX126x::setPaConfig(0x03, SX126X_PA_CONFIG_SX1262, 0x05);
+  } else if (power >= 15) {
+    state = SX126x::setPaConfig(0x02, SX126X_PA_CONFIG_SX1262, 0x03);
   } else {
-    SX126x::setPaConfig(0x04, SX126X_PA_CONFIG_SX1261);
+    state = SX126x::setPaConfig(0x02, SX126X_PA_CONFIG_SX1262, 0x02);
   }
+  if (state != ERR_NONE) {
+    return(state);
+  }
+  // TODO investigate if better power efficiency can be achieved using undocumented even lower settings
+
+  // note that we set SX126X_PA_CONFIG_SX1262 for all power levels - setting SX126X_PA_CONFIG_SX1261 causes no output (on the nameless module I have).
 
   // set output power
   // TODO power ramp time configuration
-  SX126x::setTxParams(power);
+  state = SX126x::setTxParams(power);
+  if (state != ERR_NONE) {
+    return state;
+  }
+
 
   // restore OCP configuration
   return(writeRegister(SX126X_REG_OCP_CONFIGURATION, &ocp, 1));

--- a/src/modules/SX1262.cpp
+++ b/src/modules/SX1262.cpp
@@ -85,7 +85,7 @@ int16_t SX1262::setFrequency(float freq, bool calibrate) {
 
 int16_t SX1262::setOutputPower(int8_t power) {
   // check allowed power range
-  if (!(power >= -17 && power <= 22)) {
+  if (!((power >= -17) && (power <= 22))) {
     return(ERR_INVALID_OUTPUT_POWER);
   }
 
@@ -97,21 +97,20 @@ int16_t SX1262::setOutputPower(int8_t power) {
   }
 
   // this function sets the optimal PA settings 
-  // and scales our requested power based
+  // and adjusts power based on the PA settings chosen
+  // so that output power matches requested power.
   state = SX126x::setOptimalHiPowerPaConfig(&power);
+  if (state != ERR_NONE) {
+    return(state);
+  }
 
   // set output power
   // TODO power ramp time configuration
-  if (state == ERR_NONE) {
-    state = SX126x::setTxParams(power);
+  state = SX126x::setTxParams(power);
+  if (state != ERR_NONE) {
+    return(state);
   }
 
   // restore OCP configuration
-  int16_t state2 = writeRegister(SX126X_REG_OCP_CONFIGURATION, &ocp, 1);
-  
-  if (state != ERR_NONE) {
-    return state;
-  } else {
-    return state2;
-  }
+  return writeRegister(SX126X_REG_OCP_CONFIGURATION, &ocp, 1);
 }

--- a/src/modules/SX1262.cpp
+++ b/src/modules/SX1262.cpp
@@ -85,27 +85,37 @@ int16_t SX1262::setFrequency(float freq, bool calibrate) {
 
 int16_t SX1262::setOutputPower(int8_t power) {
   // check allowed power range
-  if(!((power >= -9) && (power <= 22))) {
+  if (!((power >= -17) && (power <= 22))) {
     return(ERR_INVALID_OUTPUT_POWER);
   }
 
   // get current OCP configuration
   uint8_t ocp = 0;
   int16_t state = readRegister(SX126X_REG_OCP_CONFIGURATION, &ocp, 1);
-  if(state != ERR_NONE) {
+  if (state != ERR_NONE) {
     return(state);
   }
 
+  int8_t scaledPower;
   // set PA config for optimal consumption as described in section 13-21 of the datasheet:
-  // the final column of Table 13-21 suggests that the value passed in SetTxParams is actually scaled depending on the parameters of setPaConfig. However, testing suggests this isn't the case.
+  // the final column of Table 13-21 suggests that the value passed in SetTxParams 
+  // is actually scaled depending on the parameters of setPaConfig.
+  // Testing confirms this is approximately right
   if (power >= 21) {
     state = SX126x::setPaConfig(0x04, SX126X_PA_CONFIG_SX1262, SX126X_PA_CONFIG_HP_MAX/*0x07*/);
-  } else if (power >= 18) {
+    scaledPower = power;
+  }
+  else if (power >= 18) {
     state = SX126x::setPaConfig(0x03, SX126X_PA_CONFIG_SX1262, 0x05);
-  } else if (power >= 15) {
+    scaledPower = power + 2;
+  }
+  else if (power >= 15) {
     state = SX126x::setPaConfig(0x02, SX126X_PA_CONFIG_SX1262, 0x03);
-  } else {
+    scaledPower = power + 5;
+  }
+  else {
     state = SX126x::setPaConfig(0x02, SX126X_PA_CONFIG_SX1262, 0x02);
+    scaledPower = power + 8;
   }
   if (state != ERR_NONE) {
     return(state);
@@ -116,7 +126,7 @@ int16_t SX1262::setOutputPower(int8_t power) {
 
   // set output power
   // TODO power ramp time configuration
-  state = SX126x::setTxParams(power);
+  state = SX126x::setTxParams(scaledPower);
   if (state != ERR_NONE) {
     return state;
   }

--- a/src/modules/SX1262.h
+++ b/src/modules/SX1262.h
@@ -6,8 +6,6 @@
 #include "SX126x.h"
 
 //SX126X_CMD_SET_PA_CONFIG
-#define SX126X_PA_CONFIG_SX1261                       0x01
-#define SX126X_PA_CONFIG_SX1262                       0x00
 
 /*!
   \class SX1262

--- a/src/modules/SX1268.cpp
+++ b/src/modules/SX1268.cpp
@@ -78,9 +78,6 @@ int16_t SX1268::setFrequency(float freq, bool calibrate) {
 
 int16_t SX1268::setOutputPower(int8_t power) {
   // check allowed power range
-  // TODO with optimal PA config
-  // it's likely possible this could be expanded to go down to -17 just like for SX1262.
-  // but the datasheet doesn't explicitly state that and I don't have SX1268 unit to test with
   if(!((power >= -9) && (power <= 22))) {
     return(ERR_INVALID_OUTPUT_POWER);
   }
@@ -92,21 +89,19 @@ int16_t SX1268::setOutputPower(int8_t power) {
     return(state);
   }
 
-  // enable optimal PA
+  // enable optimal PA - this changes the value of power.
   state = SX126x::setOptimalHiPowerPaConfig(&power);
+  if (state != ERR_NONE) {
+    return(state);
+  }
 
   // set output power
   // TODO power ramp time configuration
-  if (state == ERR_NONE) {
-    state = SX126x::setTxParams(power);
+  state = SX126x::setTxParams(power);
+  if (state != ERR_NONE) {
+    return(state);
   }
 
   // restore OCP configuration
-  int16_t state2 = writeRegister(SX126X_REG_OCP_CONFIGURATION, &ocp, 1);
-
-  if (state != ERR_NONE) {
-    return state;
-  } else {
-    return state2;
-  }
+  return writeRegister(SX126X_REG_OCP_CONFIGURATION, &ocp, 1);
 }

--- a/src/modules/SX126x.cpp
+++ b/src/modules/SX126x.cpp
@@ -1127,29 +1127,29 @@ int16_t SX126x::setTxParams(uint8_t power, uint8_t rampTime) {
   return(SPIwriteCommand(SX126X_CMD_SET_TX_PARAMS, data, 2));
 }
 
-// set PA config for optimal consumption as described in section 13-21 of the datasheet:
-// the final column of Table 13-21 suggests that the value passed in SetTxParams 
-// is actually scaled depending on the parameters of setPaConfig.
-// Testing confirms this is approximately right
-int16_t SX126x::setOptimalHiPowerPaConfig(int8_t* inOutPower)
+// set PA config for optimal consumption as described in section 13-21 of the datasheet.
+int16_t SX126x::setOptimalHiPowerPaConfig(int8_t * inOutPower)
 {
+  // the final column of Table 13-21 suggests that the value passed in SetTxParams 
+  // is actually scaled depending on the parameters of setPaConfig.
+  // Testing confirms this is approximately right
   int16_t state;
   if (*inOutPower >= 21) {
     state = SX126x::setPaConfig(0x04, SX126X_PA_CONFIG_SX1262_8, SX126X_PA_CONFIG_HP_MAX/*0x07*/);
   }
   else if (*inOutPower >= 18) {
     state = SX126x::setPaConfig(0x03, SX126X_PA_CONFIG_SX1262_8, 0x05);
+    // datasheet instructs request 22 dBm for 20 dBm actual output power
     *inOutPower += 2;
-  }
-  else if (*inOutPower >= 15) {
+  } else if (*inOutPower >= 15) {
     state = SX126x::setPaConfig(0x02, SX126X_PA_CONFIG_SX1262_8, 0x03);
+    // datasheet instructs request 22 dBm for 17 dBm actual output power
     *inOutPower += 5;
-  }
-  else {
+  } else {
     state = SX126x::setPaConfig(0x02, SX126X_PA_CONFIG_SX1262_8, 0x02);
+    // datasheet instructs request 22 dBm for 14 dBm actual output power.
     *inOutPower += 8;
   }
-  // TODO investigate if better power efficiency can be achieved using undocumented even lower settings
   return state;
 }
 

--- a/src/modules/SX126x.h
+++ b/src/modules/SX126x.h
@@ -152,7 +152,6 @@
 //SX126X_CMD_SET_PA_CONFIG
 #define SX126X_PA_CONFIG_HP_MAX                       0x07
 #define SX126X_PA_CONFIG_PA_LUT                       0x01
-#define SX126X_PA_CONFIG_SX1261                       0x01
 #define SX126X_PA_CONFIG_SX1262_8                     0x00
 
 //SX126X_CMD_SET_RX_TX_FALLBACK_MODE

--- a/src/modules/SX126x.h
+++ b/src/modules/SX126x.h
@@ -152,6 +152,8 @@
 //SX126X_CMD_SET_PA_CONFIG
 #define SX126X_PA_CONFIG_HP_MAX                       0x07
 #define SX126X_PA_CONFIG_PA_LUT                       0x01
+#define SX126X_PA_CONFIG_SX1261                       0x01
+#define SX126X_PA_CONFIG_SX1262_8                     0x00
 
 //SX126X_CMD_SET_RX_TX_FALLBACK_MODE
 #define SX126X_RX_TX_FALLBACK_MODE_FS                 0x40        //  7     0     after Rx/Tx go to: FS mode
@@ -739,6 +741,7 @@ class SX126x: public PhysicalLayer {
     int16_t calibrateImage(uint8_t* data);
     uint8_t getPacketType();
     int16_t setTxParams(uint8_t power, uint8_t rampTime = SX126X_PA_RAMP_200U);
+    int16_t setOptimalHiPowerPaConfig(int8_t* inOutPower);
     int16_t setModulationParams(uint8_t sf, uint8_t bw, uint8_t cr, uint8_t ldro = 0xFF);
     int16_t setModulationParamsFSK(uint32_t br, uint8_t pulseShape, uint8_t rxBw, uint32_t freqDev);
     int16_t setPacketParams(uint16_t preambleLength, uint8_t crcType, uint8_t payloadLength = 0xFF, uint8_t headerType = SX126X_LORA_HEADER_EXPLICIT, uint8_t invertIQ = SX126X_LORA_IQ_STANDARD);


### PR DESCRIPTION
 - Adjusted use of setPaConfig in SX1262 setOutputPower to always use the SX1262 PA.
 - Adjusted available power output range of SX1262 to -9 to 22.
 - Implemented "PA Optimal Settings" described in datasheet section 13.1.14.1

Maybe it's a hardware issue with my devices? My (unnamed from banggood) SX1262 modules don't transmit when told to use the SX1261 PA (the logic did this for power less than or equal 14 dBm).

I also found that if I request less than -9 dBm output power, the module doesn't properly process the request and instead transmits at its maximum power.

To avoid breaking it for anyone using SX1261: Added (untested) SX1261 class to have different logic in the setOutputPower function.

Sadly when testing this I see imperfect behaviour when requested power is greater than 14 dBm:
 - More output power when 20 is requested than 22 or 21.
 - Power set by setTxParams has minimal effect; instead (approximately correct) jumps are seen when the values in setPaConfig changes.

I'm lacking the proper skills and hardware to take this further right now.