### PR TITLE
Removed memory allocation and copying from SX126X

### DIFF
--- a/src/modules/SX126x.cpp
+++ b/src/modules/SX126x.cpp
@@ -1036,18 +1036,8 @@ int16_t SX126x::setPaConfig(uint8_t paDutyCycle, uint8_t deviceSel, uint8_t hpMa
 }
 
 int16_t SX126x::writeRegister(uint16_t addr, uint8_t* data, uint8_t numBytes) {
-  #ifdef STATIC_ONLY
-    uint8_t dat[STATIC_ARRAY_SIZE + 2];
-  #else
-    uint8_t* dat = new uint8_t[2 + numBytes];
-  #endif
-  dat[0] = (uint8_t)((addr >> 8) & 0xFF);
-  dat[1] = (uint8_t)(addr & 0xFF);
-  memcpy(dat + 2, data, numBytes);
-  int16_t state = SPIwriteCommand(SX126X_CMD_WRITE_REGISTER, dat, 2 + numBytes);
-  #ifndef STATIC_ONLY
-    delete[] dat;
-  #endif
+  uint8_t cmd[] = { SX126X_CMD_WRITE_REGISTER, (uint8_t)((addr >> 8) & 0xFF), (uint8_t)(addr & 0xFF) };
+  int16_t state = SPIwriteCommand(cmd, 3, data, numBytes);
   return(state);
 }
 
@@ -1057,34 +1047,15 @@ int16_t SX126x::readRegister(uint16_t addr, uint8_t* data, uint8_t numBytes) {
 }
 
 int16_t SX126x::writeBuffer(uint8_t* data, uint8_t numBytes, uint8_t offset) {
-  #ifdef STATIC_ONLY
-    uint8_t dat[STATIC_ARRAY_SIZE + 1];
-  #else
-    uint8_t* dat = new uint8_t[1 + numBytes];
-  #endif
-  dat[0] = offset;
-  memcpy(dat + 1, data, numBytes);
-  int16_t state = SPIwriteCommand(SX126X_CMD_WRITE_BUFFER, dat, 1 + numBytes);
-  #ifndef STATIC_ONLY
-    delete[] dat;
-  #endif
+  uint8_t cmd[] = { SX126X_CMD_WRITE_BUFFER, offset };
+  int16_t state = SPIwriteCommand(cmd, 2, data, numBytes);
+
   return(state);
 }
 
 int16_t SX126x::readBuffer(uint8_t* data, uint8_t numBytes) {
-  // offset will be always set to 0 (one extra NOP is sent)
-  #ifdef STATIC_ONLY
-    uint8_t dat[STATIC_ARRAY_SIZE + 1];
-  #else
-    uint8_t* dat = new uint8_t[1 + numBytes];
-  #endif
-  dat[0] = SX126X_CMD_NOP;
-  memcpy(dat + 1, data, numBytes);
-  int16_t state = SPIreadCommand(SX126X_CMD_READ_BUFFER, dat, 1 + numBytes);
-  memcpy(data, dat + 1, numBytes);
-  #ifndef STATIC_ONLY
-    delete[] dat;
-  #endif
+  uint8_t cmd[] = { SX126X_CMD_READ_BUFFER, SX126X_CMD_NOP };
+  int16_t state = SPIreadCommand(cmd, 2, data, numBytes);
   return(state);
 }
 
@@ -1265,14 +1236,20 @@ int16_t SX126x::config(uint8_t modem) {
   return(ERR_NONE);
 }
 
+int16_t SX126x::SPIwriteCommand(uint8_t* cmd, uint8_t cmdLen, uint8_t* data, uint8_t numBytes, bool waitForBusy) {
+  return(SX126x::SPItransfer(cmd, cmdLen, true, data, NULL, numBytes, waitForBusy));
+}
+
 int16_t SX126x::SPIwriteCommand(uint8_t cmd, uint8_t* data, uint8_t numBytes, bool waitForBusy) {
-  uint8_t cmdBuffer[] = {cmd};
-  return(SX126x::SPItransfer(cmdBuffer, 1, true, data, NULL, numBytes, waitForBusy));
+  return(SX126x::SPItransfer(&cmd, 1, true, data, NULL, numBytes, waitForBusy));
+}
+
+int16_t SX126x::SPIreadCommand(uint8_t* cmd, uint8_t cmdLen, uint8_t* data, uint8_t numBytes, bool waitForBusy) {
+  return(SX126x::SPItransfer(cmd, cmdLen, false, NULL, data, numBytes, waitForBusy));
 }
 
 int16_t SX126x::SPIreadCommand(uint8_t cmd, uint8_t* data, uint8_t numBytes, bool waitForBusy) {
-  uint8_t cmdBuffer[] = {cmd};
-  return(SX126x::SPItransfer(cmdBuffer, 1, false, NULL, data, numBytes, waitForBusy));
+  return(SX126x::SPItransfer(&cmd, 1, false, NULL, data, numBytes, waitForBusy));
 }
 
 int16_t SX126x::SPItransfer(uint8_t* cmd, uint8_t cmdLen, bool write, uint8_t* dataOut, uint8_t* dataIn, uint8_t numBytes, bool waitForBusy, uint32_t timeout) {

--- a/src/modules/SX126x.h
+++ b/src/modules/SX126x.h
@@ -769,7 +769,9 @@ class SX126x: public PhysicalLayer {
 
     // common low-level SPI interface
     int16_t SPIwriteCommand(uint8_t cmd, uint8_t* data, uint8_t numBytes, bool waitForBusy = true);
+    int16_t SPIwriteCommand(uint8_t* cmd, uint8_t cmdLen, uint8_t* data, uint8_t numBytes, bool waitForBusy = true);
     int16_t SPIreadCommand(uint8_t cmd, uint8_t* data, uint8_t numBytes, bool waitForBusy = true);
+    int16_t SPIreadCommand(uint8_t* cmd, uint8_t cmdLen, uint8_t* data, uint8_t numBytes, bool waitForBusy = true);
     int16_t SPItransfer(uint8_t* cmd, uint8_t cmdLen, bool write, uint8_t* dataOut, uint8_t* dataIn, uint8_t numBytes, bool waitForBusy, uint32_t timeout = 5000);
 };
 


### PR DESCRIPTION
Extends command interface to allow multi-byte commands.

This allows functions that need to prepend some parameters onto input data to do so without allocating memory and performing a memcpy.

Benefits:
 - SX126x code can now be used without linking in operator new
 - Allows transmit and receive to be called when not much memory is available: previously these functions could allocate as much as 257 bytes when dealing with large messages.
 - Improved performance by removing memcpy