### PR TITLE
nRF24:  CRC, AutoACK and undocumented addrWidth.

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -133,6 +133,7 @@ setTransmitPipe	KEYWORD2
 setReceivePipe	KEYWORD2
 disablePipe	KEYWORD2
 getStatus	KEYWORD2
+setAutoAck	KEYWORD2
 
 # HTTP
 get	KEYWORD2

--- a/src/modules/nRF24/nRF24.cpp
+++ b/src/modules/nRF24/nRF24.cpp
@@ -481,6 +481,39 @@ size_t nRF24::getPacketLength(bool update) {
   return((size_t)length);
 }
 
+int16_t nRF24::setCrcFiltering(bool crcOn) {
+  return _mod->SPIsetRegValue(NRF24_REG_CONFIG, crcOn ? NRF24_CRC_ON : NRF24_CRC_OFF, 3, 3);
+}
+
+int16_t nRF24::setAutoAck(bool autoAckOn){
+  return _mod->SPIsetRegValue(NRF24_REG_EN_AA, autoAckOn ? NRF24_AA_ALL_ON : NRF24_AA_ALL_OFF, 5, 0);
+}
+
+int16_t nRF24::setAutoAck(uint8_t pipeNum, bool autoAckOn){
+  switch(pipeNum) {
+    case 0:
+      return _mod->SPIsetRegValue(NRF24_REG_EN_AA, autoAckOn ? NRF24_AA_P0_ON : NRF24_AA_P0_OFF, 0, 0);
+      break;
+    case 1:
+      return _mod->SPIsetRegValue(NRF24_REG_EN_AA, autoAckOn ? NRF24_AA_P1_ON : NRF24_AA_P1_OFF, 1, 1);
+      break;
+    case 2:
+      return _mod->SPIsetRegValue(NRF24_REG_EN_AA, autoAckOn ? NRF24_AA_P2_ON : NRF24_AA_P2_OFF, 2, 2);
+      break;
+    case 3:
+      return _mod->SPIsetRegValue(NRF24_REG_EN_AA, autoAckOn ? NRF24_AA_P3_ON : NRF24_AA_P3_OFF, 3, 3);
+      break;
+    case 4:
+      return _mod->SPIsetRegValue(NRF24_REG_EN_AA, autoAckOn ? NRF24_AA_P4_ON : NRF24_AA_P4_OFF, 4, 4);
+      break;
+    case 5:
+      return _mod->SPIsetRegValue(NRF24_REG_EN_AA, autoAckOn ? NRF24_AA_P5_ON : NRF24_AA_P5_OFF, 5, 5);
+      break;
+    default:
+      return (ERR_INVALID_PIPE_NUMBER);
+  }
+}
+
 void nRF24::clearIRQ() {
   // clear status bits
   _mod->SPIsetRegValue(NRF24_REG_STATUS, NRF24_RX_DR | NRF24_TX_DS | NRF24_MAX_RT, 6, 4);

--- a/src/modules/nRF24/nRF24.cpp
+++ b/src/modules/nRF24/nRF24.cpp
@@ -19,7 +19,7 @@ int16_t nRF24::begin(int16_t freq, int16_t dataRate, int8_t power, uint8_t addrW
 
   // check SPI connection
   int16_t val = _mod->SPIgetRegValue(NRF24_REG_SETUP_AW);
-  if(!((val >= 1) && (val <= 3))) {
+  if(!((val >= 0) && (val <= 3))) {
     RADIOLIB_DEBUG_PRINTLN(F("No nRF24 found!"));
     _mod->term();
     return(ERR_CHIP_NOT_FOUND);
@@ -339,6 +339,11 @@ int16_t nRF24::setAddressWidth(uint8_t addrWidth) {
 
   // set address width
   switch(addrWidth) {
+    case 2:
+      // Even if marked as 'Illegal' on the datasheet this will work:
+      // http://travisgoodspeed.blogspot.com/2011/02/promiscuity-is-nrf24l01s-duty.html
+      state = _mod->SPIsetRegValue(NRF24_REG_SETUP_AW, NRF24_ADDRESS_2_BYTES, 1, 0);
+      break;
     case 3:
       state = _mod->SPIsetRegValue(NRF24_REG_SETUP_AW, NRF24_ADDRESS_3_BYTES, 1, 0);
       break;

--- a/src/modules/nRF24/nRF24.h
+++ b/src/modules/nRF24/nRF24.h
@@ -422,20 +422,20 @@ class nRF24: public PhysicalLayer {
     int16_t setCrcFiltering(bool crcOn = true);
 
     /*!
-     \brief Enable or disable auto-acknowlede packets
+     \brief Enable or disable auto-acknowlede packets on all pipes
 
-     \param crcOn Enable (true) or disable (false) auto-acks.
+     \param autoAckOn Enable (true) or disable (false) auto-acks.
 
      \returns \ref status_codes
    */
     int16_t setAutoAck(bool autoAckOn = true);
 
     /*!
-     \brief Enable or disable auto-acknowlede packets
-
-     \param crcOn Enable (true) or disable (false) auto-acks.
+     \brief Enable or disable auto-acknowlede packets on given pipe.
 
      \param pipeNum Number of pipe to which enable / disable auto-acks.
+
+     \param autoAckOn Enable (true) or disable (false) auto-acks.
 
      \returns \ref status_codes
    */

--- a/src/modules/nRF24/nRF24.h
+++ b/src/modules/nRF24/nRF24.h
@@ -69,6 +69,8 @@
 #define NRF24_PRX                                     0b00000001  //  0     0     enable primary Rx
 
 // NRF24_REG_EN_AA
+#define NRF24_AA_ALL_OFF                              0b00000000  //  5     0     auto-ACK on all pipes: disabled
+#define NRF24_AA_ALL_ON                               0b00111111  //  5     0                         enabled (default)
 #define NRF24_AA_P5_OFF                               0b00000000  //  5     5     auto-ACK on pipe 5: disabled
 #define NRF24_AA_P5_ON                                0b00100000  //  5     5                         enabled (default)
 #define NRF24_AA_P4_OFF                               0b00000000  //  4     4     auto-ACK on pipe 4: disabled
@@ -407,6 +409,36 @@ class nRF24: public PhysicalLayer {
       \returns Length of last received packet in bytes.
     */
     size_t getPacketLength(bool update = true);
+
+
+    /*!
+     \brief Enable CRC filtering and generation.
+
+     \param crcOn Set or unset CRC check.
+
+     \returns \ref status_codes
+   */
+    int16_t setCrcFiltering(bool crcOn = true);
+
+    /*!
+     \brief Enable or disable auto-acknowlede packets
+
+     \param crcOn Enable (true) or disable (false) auto-acks.
+
+     \returns \ref status_codes
+   */
+    int16_t setAutoAck(bool autoAckOn = true);
+
+    /*!
+     \brief Enable or disable auto-acknowlede packets
+
+     \param crcOn Enable (true) or disable (false) auto-acks.
+
+     \param pipeNum Number of pipe to which enable / disable auto-acks.
+
+     \returns \ref status_codes
+   */
+    int16_t setAutoAck(uint8_t pipeNum, bool autoAckOn = true);
 
 #ifndef RADIOLIB_GODMODE
   private:

--- a/src/modules/nRF24/nRF24.h
+++ b/src/modules/nRF24/nRF24.h
@@ -99,7 +99,8 @@
 #define NRF24_P0_ON                                   0b00000001  //  0     0                     enabled (default)
 
 // NRF24_REG_SETUP_AW
-#define NRF24_ADDRESS_3_BYTES                         0b00000001  //  1     0     address width: 3 bytes
+#define NRF24_ADDRESS_2_BYTES                         0b00000000  //  1     0     address width: 2 bytes
+#define NRF24_ADDRESS_3_BYTES                         0b00000001  //  1     0                    3 bytes
 #define NRF24_ADDRESS_4_BYTES                         0b00000010  //  1     0                    4 bytes
 #define NRF24_ADDRESS_5_BYTES                         0b00000011  //  1     0                    5 bytes (default)
 


### PR DESCRIPTION
Hi Jan, 
Regarding commit _a82002b_ the "TX/RX Address field width" could be as low as 2 bytes even if marked as illegal on the datasheet. This was found [by Travis Goodspeed](http://travisgoodspeed.blogspot.com/2011/02/promiscuity-is-nrf24l01s-duty.html).
This particular configuration is useful in order to achieve promiscuous mode.