### PR TITLE
[CC1101] The synchronization word is a two-byte value

### DIFF
--- a/src/modules/CC1101/CC1101.cpp
+++ b/src/modules/CC1101/CC1101.cpp
@@ -450,7 +450,7 @@ int16_t CC1101::setOutputPower(int8_t power) {
 }
 
 int16_t CC1101::setSyncWord(uint8_t* syncWord, uint8_t len, uint8_t maxErrBits) {
-  if((maxErrBits > 1) || (len > 2)) {
+  if((maxErrBits > 1) || (len != 2)) {
     return(ERR_INVALID_SYNC_WORD);
   }
 


### PR DESCRIPTION
Hi Jan,
I think there's a small inaccuracy since [CC1101 Datasheet](https://www.ti.com/lit/ds/symlink/cc1101.pdf) at page 38 states: "The synchronization word is a two-byte value"