### PR TITLE
Enabled SX126x CRC check IRQs on receive

### DIFF
--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -444,7 +444,7 @@ int16_t SX126x::startTransmit(uint8_t* data, size_t len, uint8_t addr) {
 
 int16_t SX126x::startReceive(uint32_t timeout) {
   // set DIO mapping
-  int16_t state = setDioIrqParams(SX126X_IRQ_RX_DONE | SX126X_IRQ_TIMEOUT, SX126X_IRQ_RX_DONE);
+  int16_t state = setDioIrqParams(SX126X_IRQ_RX_DONE | SX126X_IRQ_TIMEOUT | SX126X_IRQ_CRC_ERR | SX126X_IRQ_HEADER_ERR, SX126X_IRQ_RX_DONE);
   if(state != ERR_NONE) {
     return(state);
   }


### PR DESCRIPTION
It seems that IRQs don't show up in `getIrqStatus()` if they're not globally enabled (set 1 in the first parameter of `setDioIrqParams`). As a result, CRC errors weren't being detected in `readData` because the IRQs weren't enabled in `startReceive`.

This addresses issue #80. The issue report details how to test it. It was an easy fix, but surprisingly painful to test (not difficult, just need to get everything lined up).

The datasheet is misleading in this respect: It never explains the purpose of the first parameter of `setDioIrqParams`, and gives bad advice in `14.3` step `7`.