### PR TITLE
[CC1101] Output power updated according to chosen frequency

### DIFF
--- a/src/modules/CC1101/CC1101.cpp
+++ b/src/modules/CC1101/CC1101.cpp
@@ -315,7 +315,8 @@ int16_t CC1101::setFrequency(float freq) {
     _freq = freq;
   }
 
-  return(state);
+  // Update the TX power accordingly to new freq. (PA values depend on chosen freq)
+  return setOutputPower(_power);
 }
 
 int16_t CC1101::setBitRate(float br) {
@@ -389,6 +390,9 @@ int16_t CC1101::setFrequencyDeviation(float freqDev) {
 }
 
 int16_t CC1101::setOutputPower(int8_t power) {
+  // Store the value.
+  _power = power;
+
   // round to the known frequency settings
   uint8_t f;
   if(_freq < 374.0) {

--- a/src/modules/CC1101/CC1101.h
+++ b/src/modules/CC1101/CC1101.h
@@ -833,6 +833,7 @@ class CC1101: public PhysicalLayer {
     bool _promiscuous;
 
     uint8_t _syncWordLength;
+    int8_t _power;
 
     int16_t config();
     int16_t directMode();


### PR DESCRIPTION
Hi Jan,
I think output power register should be updated after changing frequency, otherwise the radio may be left in an inconsistent state since different frequencies have different values for the PA_TABLE.

For example if you call `setFrequency(433.0)` the PA_TABLE reg is still set to the default value for the 868Mhz (which is `0x50`) but the default value for the 434Mhz is different (`0x60`).

What do you think ?