### PR TITLE
[SX126x] implicit mode

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -117,6 +117,8 @@ clearGdo2Action	KEYWORD2
 setTCXO	KEYWORD2
 setDio2AsRfSwitch	KEYWORD2
 getTimeOnAir	KEYWORD2
+implicitHeader
+explicitHeader
 setSyncBits	KEYWORD2
 setWhitening	KEYWORD2
 startReceiveDutyCycle	KEYWORD2

--- a/keywords.txt
+++ b/keywords.txt
@@ -117,8 +117,8 @@ clearGdo2Action	KEYWORD2
 setTCXO	KEYWORD2
 setDio2AsRfSwitch	KEYWORD2
 getTimeOnAir	KEYWORD2
-implicitHeader
-explicitHeader
+implicitHeader	KEYWORD2
+explicitHeader	KEYWORD2
 setSyncBits	KEYWORD2
 setWhitening	KEYWORD2
 startReceiveDutyCycle	KEYWORD2

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -1170,8 +1170,8 @@ uint32_t SX126x::getTimeOnAir(size_t len) {
   }
 }
 
-int16_t implicitHeader() {
-    return setHeaderType(SX126X_LORA_HEADER_IMPLICIT);
+int16_t implicitHeader(size_t len) {
+    return setHeaderType(SX126X_LORA_HEADER_IMPLICIT, len);
 }
 
 int16_t explicitHeader() {
@@ -1354,9 +1354,9 @@ int16_t SX126x::setPacketMode(uint8_t mode, uint8_t len) {
   return(state);
 }
 
-int16_t SX126x::setHeaderType(uint8_t headerType) {
+int16_t SX126x::setHeaderType(uint8_t headerType, size_t len) {
   // set requested packet mode
-  int16_t state = setPacketParams(_preambleLength, _crcType, 0xFF, headerType);
+  int16_t state = setPacketParams(_preambleLength, _crcType, len, headerType);
 
   if(state != ERR_NONE) {
     return(state);

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -743,7 +743,7 @@ int16_t SX126x::setPreambleLength(uint16_t preambleLength) {
   uint8_t modem = getPacketType();
   if(modem == SX126X_PACKET_TYPE_LORA) {
     _preambleLength = preambleLength;
-    return(setPacketParams(_preambleLength, _crcType, 0xFF, _headerType));
+    return(setPacketParams(_preambleLength, _crcType, _implicitLen, _headerType));
   } else if(modem == SX126X_PACKET_TYPE_GFSK) {
     _preambleLengthFSK = preambleLength;
     return(setPacketParamsFSK(_preambleLengthFSK, _crcTypeFSK, _syncWordLength, _addrComp, _whitening, _packetType));
@@ -1048,7 +1048,7 @@ int16_t SX126x::setCRC(uint8_t len, uint16_t initial, uint16_t polynomial, bool 
       _crcType = SX126X_LORA_CRC_OFF;
     }
 
-    return(setPacketParams(_preambleLength, _crcType, 0xFF, _headerType));
+    return(setPacketParams(_preambleLength, _crcType, _implicitLen, _headerType));
   }
 
   return(ERR_UNKNOWN);

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -289,15 +289,6 @@ int16_t SX126x::receive(uint8_t* data, size_t len) {
     // calculate timeout (100 LoRa symbols, the default for SX127x series)
     float symbolLength = (float)(uint32_t(1) << _sf) / (float)_bwKhz;
     timeout = (uint32_t)(symbolLength * 100.0 * 1000.0);
-
-      // set implicit mode and expected len if applicable
-      if (_headerType == SX126X_LORA_HEADER_IMPLICIT) {
-          state = setPacketParams(_preambleLength, _crcType, _implicitLen, _headerType);
-          if(state != ERR_NONE) {
-            return(state);
-          }
-      }
-
   } else if(modem == SX126X_PACKET_TYPE_GFSK) {
     // calculate timeout (500 % of expected time-one-air)
     size_t maxLen = len;

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -290,6 +290,14 @@ int16_t SX126x::receive(uint8_t* data, size_t len) {
     float symbolLength = (float)(uint32_t(1) << _sf) / (float)_bwKhz;
     timeout = (uint32_t)(symbolLength * 100.0 * 1000.0);
 
+      // set implicit mode and expected len if applicable
+      if (_headerType == SX126X_LORA_HEADER_IMPLICIT) {
+          state = setPacketParams(_preambleLength, _crcType, _implicitLen, _headerType);
+          if(state != ERR_NONE) {
+            return(state);
+          }
+      }
+
   } else if(modem == SX126X_PACKET_TYPE_GFSK) {
     // calculate timeout (500 % of expected time-one-air)
     size_t maxLen = len;
@@ -599,6 +607,14 @@ int16_t SX126x::startReceiveCommon() {
 
   // clear interrupt flags
   state = clearIrqStatus();
+
+  // set implicit mode and expected len if applicable
+  if (_headerType == SX126X_LORA_HEADER_IMPLICIT && getPacketType() == SX126X_PACKET_TYPE_LORA) {
+      state = setPacketParams(_preambleLength, _crcType, _implicitLen, _headerType);
+      if(state != ERR_NONE) {
+        return(state);
+      }
+  }
 
   return(state);
 }

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -1170,6 +1170,14 @@ uint32_t SX126x::getTimeOnAir(size_t len) {
   }
 }
 
+int16_t implicitHeader() {
+    return setHeaderType(SX126X_LORA_HEADER_IMPLICIT);
+}
+
+int16_t explicitHeader() {
+    return setHeaderType(SX126X_LORA_HEADER_EXPLICIT);
+}
+
 int16_t SX126x::setTCXO(float voltage, uint32_t delay) {
   // set mode to standby
   standby();

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -1178,11 +1178,11 @@ uint32_t SX126x::getTimeOnAir(size_t len) {
   }
 }
 
-void SX126x::implicitHeader(size_t len) {
+int16_t SX126x::implicitHeader(size_t len) {
     return setHeaderType(SX126X_LORA_HEADER_IMPLICIT, len);
 }
 
-void SX126x::explicitHeader() {
+int16_t SX126x::explicitHeader() {
     return setHeaderType(SX126X_LORA_HEADER_EXPLICIT);
 }
 
@@ -1367,6 +1367,7 @@ int16_t SX126x::setHeaderType(uint8_t headerType, size_t len) {
   if(getPacketType() != SX126X_PACKET_TYPE_LORA) {
     return(ERR_WRONG_MODEM);
   }
+
   // set requested packet mode
   int16_t state = setPacketParams(_preambleLength, _crcType, len, headerType);
 
@@ -1377,6 +1378,7 @@ int16_t SX126x::setHeaderType(uint8_t headerType, size_t len) {
   // update cached value
   _headerType = headerType;
   _implicitLen = len;
+
   return(state);
 }
 

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -600,11 +600,11 @@ int16_t SX126x::startReceiveCommon() {
   state = clearIrqStatus();
 
   // set implicit mode and expected len if applicable
-  if (_headerType == SX126X_LORA_HEADER_IMPLICIT && getPacketType() == SX126X_PACKET_TYPE_LORA) {
-      state = setPacketParams(_preambleLength, _crcType, _implicitLen, _headerType);
-      if(state != ERR_NONE) {
-        return(state);
-      }
+  if(_headerType == SX126X_LORA_HEADER_IMPLICIT && getPacketType() == SX126X_PACKET_TYPE_LORA) {
+    state = setPacketParams(_preambleLength, _crcType, _implicitLen, _headerType);
+    if(state != ERR_NONE) {
+      return(state);
+    }
   }
 
   return(state);
@@ -1179,11 +1179,11 @@ uint32_t SX126x::getTimeOnAir(size_t len) {
 }
 
 int16_t SX126x::implicitHeader(size_t len) {
-    return setHeaderType(SX126X_LORA_HEADER_IMPLICIT, len);
+    return(setHeaderType(SX126X_LORA_HEADER_IMPLICIT, len));
 }
 
 int16_t SX126x::explicitHeader() {
-    return setHeaderType(SX126X_LORA_HEADER_EXPLICIT);
+    return(setHeaderType(SX126X_LORA_HEADER_EXPLICIT));
 }
 
 int16_t SX126x::setTCXO(float voltage, uint32_t delay) {
@@ -1370,7 +1370,6 @@ int16_t SX126x::setHeaderType(uint8_t headerType, size_t len) {
 
   // set requested packet mode
   int16_t state = setPacketParams(_preambleLength, _crcType, len, headerType);
-
   if(state != ERR_NONE) {
     return(state);
   }

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -1187,12 +1187,12 @@ uint32_t SX126x::getTimeOnAir(size_t len) {
   }
 }
 
-void implicitHeader(size_t len) {
+void SX126x::implicitHeader(size_t len) {
     _headerType = SX126X_LORA_HEADER_IMPLICIT;
     _implicitLen = len;
 }
 
-void explicitHeader() {
+void SX126x::explicitHeader() {
     _headerType = SX126X_LORA_HEADER_EXPLICIT;
     _implicitLen = 0xFF;
 }

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -21,6 +21,7 @@ int16_t SX126x::begin(float bw, uint8_t sf, uint8_t cr, uint8_t syncWord, float 
   _crcType = SX126X_LORA_CRC_ON;
   _preambleLength = preambleLength;
   _tcxoDelay = 0;
+  _headerType = SX126X_LORA_HEADER_EXPLICIT;
 
   // reset the module and verify startup
   int16_t state = reset();

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -1168,7 +1168,7 @@ uint32_t SX126x::getTimeOnAir(size_t len) {
       sfDivisor = 4*(_sf - 2);
     }
     const int8_t bitsPerCrc = 16;
-    const int8_t N_symbol_header = 20;
+    const int8_t N_symbol_header = _headerType == SX126X_LORA_HEADER_EXPLICIT ? 20 : 0;
 
     // numerator of equation in section 6.1.4 of SX1268 datasheet v1.1 (might not actually be bitcount, but it has len * 8)
     int16_t bitCount = (int16_t) 8 * len + _crcType * bitsPerCrc - 4 * _sf  + sfCoeff2 + N_symbol_header;

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -1179,13 +1179,11 @@ uint32_t SX126x::getTimeOnAir(size_t len) {
 }
 
 void SX126x::implicitHeader(size_t len) {
-    _headerType = SX126X_LORA_HEADER_IMPLICIT;
-    _implicitLen = len;
+    return setHeaderType(SX126X_LORA_HEADER_IMPLICIT, len);
 }
 
 void SX126x::explicitHeader() {
-    _headerType = SX126X_LORA_HEADER_EXPLICIT;
-    _implicitLen = 0xFF;
+    return setHeaderType(SX126X_LORA_HEADER_EXPLICIT);
 }
 
 int16_t SX126x::setTCXO(float voltage, uint32_t delay) {
@@ -1361,6 +1359,24 @@ int16_t SX126x::setPacketMode(uint8_t mode, uint8_t len) {
 
   // update cached value
   _packetType = mode;
+  return(state);
+}
+
+int16_t SX126x::setHeaderType(uint8_t headerType, size_t len) {
+  // check active modem
+  if(getPacketType() != SX126X_PACKET_TYPE_LORA) {
+    return(ERR_WRONG_MODEM);
+  }
+  // set requested packet mode
+  int16_t state = setPacketParams(_preambleLength, _crcType, len, headerType);
+
+  if(state != ERR_NONE) {
+    return(state);
+  }
+
+  // update cached value
+  _headerType = headerType;
+  _implicitLen = len;
   return(state);
 }
 

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -1346,6 +1346,19 @@ int16_t SX126x::setPacketMode(uint8_t mode, uint8_t len) {
   return(state);
 }
 
+int16_t SX126x::setHeaderType(uint8_t headerType) {
+  // set requested packet mode
+  int16_t state = setPacketParams(_preambleLength, _crcType, len);
+
+  if(state != ERR_NONE) {
+    return(state);
+  }
+
+  // update cached value
+  _headerType = headerType;
+  return(state);
+}
+
 int16_t SX126x::setModulationParams(uint8_t sf, uint8_t bw, uint8_t cr, uint8_t ldro) {
   // calculate symbol length and enable low data rate optimization, if needed
   if(ldro == 0xFF) {

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -22,6 +22,7 @@ int16_t SX126x::begin(float bw, uint8_t sf, uint8_t cr, uint8_t syncWord, float 
   _preambleLength = preambleLength;
   _tcxoDelay = 0;
   _headerType = SX126X_LORA_HEADER_EXPLICIT;
+  _implicitLen = 0xFF;
 
   // reset the module and verify startup
   int16_t state = reset();
@@ -1170,12 +1171,14 @@ uint32_t SX126x::getTimeOnAir(size_t len) {
   }
 }
 
-int16_t implicitHeader(size_t len) {
-    return setHeaderType(SX126X_LORA_HEADER_IMPLICIT, len);
+void implicitHeader(size_t len) {
+    _headerType = SX126X_LORA_HEADER_IMPLICIT;
+    _implicitLen = len;
 }
 
-int16_t explicitHeader() {
-    return setHeaderType(SX126X_LORA_HEADER_EXPLICIT);
+void explicitHeader() {
+    _headerType = SX126X_LORA_HEADER_EXPLICIT;
+    _implicitLen = 0xFF;
 }
 
 int16_t SX126x::setTCXO(float voltage, uint32_t delay) {
@@ -1351,19 +1354,6 @@ int16_t SX126x::setPacketMode(uint8_t mode, uint8_t len) {
 
   // update cached value
   _packetType = mode;
-  return(state);
-}
-
-int16_t SX126x::setHeaderType(uint8_t headerType, size_t len) {
-  // set requested packet mode
-  int16_t state = setPacketParams(_preambleLength, _crcType, len, headerType);
-
-  if(state != ERR_NONE) {
-    return(state);
-  }
-
-  // update cached value
-  _headerType = headerType;
   return(state);
 }
 

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -1356,7 +1356,7 @@ int16_t SX126x::setPacketMode(uint8_t mode, uint8_t len) {
 
 int16_t SX126x::setHeaderType(uint8_t headerType) {
   // set requested packet mode
-  int16_t state = setPacketParams(_preambleLength, _crcType, len);
+  int16_t state = setPacketParams(_preambleLength, _crcType, 0xFF, headerType);
 
   if(state != ERR_NONE) {
     return(state);

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -450,7 +450,7 @@ int16_t SX126x::startTransmit(uint8_t* data, size_t len, uint8_t addr) {
   int16_t state = ERR_NONE;
   uint8_t modem = getPacketType();
   if(modem == SX126X_PACKET_TYPE_LORA) {
-    state = setPacketParams(_preambleLength, _crcType, len);
+    state = setPacketParams(_preambleLength, _crcType, len, _headerType);
   } else if(modem == SX126X_PACKET_TYPE_GFSK) {
     state = setPacketParamsFSK(_preambleLengthFSK, _crcTypeFSK, _syncWordLength, _addrComp, _whitening, _packetType, len);
   } else {
@@ -742,7 +742,7 @@ int16_t SX126x::setPreambleLength(uint16_t preambleLength) {
   uint8_t modem = getPacketType();
   if(modem == SX126X_PACKET_TYPE_LORA) {
     _preambleLength = preambleLength;
-    return(setPacketParams(_preambleLength, _crcType));
+    return(setPacketParams(_preambleLength, _crcType, 0xFF, _headerType));
   } else if(modem == SX126X_PACKET_TYPE_GFSK) {
     _preambleLengthFSK = preambleLength;
     return(setPacketParamsFSK(_preambleLengthFSK, _crcTypeFSK, _syncWordLength, _addrComp, _whitening, _packetType));
@@ -1047,7 +1047,7 @@ int16_t SX126x::setCRC(uint8_t len, uint16_t initial, uint16_t polynomial, bool 
       _crcType = SX126X_LORA_CRC_OFF;
     }
 
-    return(setPacketParams(_preambleLength, _crcType));
+    return(setPacketParams(_preambleLength, _crcType, 0xFF, _headerType));
   }
 
   return(ERR_UNKNOWN);

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -795,7 +795,7 @@ class SX126x: public PhysicalLayer {
 
      \returns \ref status_codes
    */
-   int16_t implicitHeader(size_t len);
+   void implicitHeader(size_t len);
 
     /*!
      \brief Set explicit header mode for future reception/transmission.
@@ -804,7 +804,7 @@ class SX126x: public PhysicalLayer {
 
      \returns \ref status_codes
    */
-   int16_t explicitHeader();
+   void explicitHeader();
 #ifndef RADIOLIB_GODMODE
   protected:
 #endif
@@ -838,7 +838,6 @@ class SX126x: public PhysicalLayer {
     int16_t setFrequencyRaw(float freq);
     int16_t setOptimalHiPowerPaConfig(int8_t* inOutPower);
     int16_t setPacketMode(uint8_t mode, uint8_t len);
-    int16_t setHeaderType(uint8_t headerType, size_t len = 0xFF)
 
     // fixes to errata
     int16_t fixSensitivity();
@@ -863,6 +862,8 @@ class SX126x: public PhysicalLayer {
     float _dataRate;
 
     uint32_t _tcxoDelay;
+
+    size_t _implicitLen;
 
     int16_t config(uint8_t modem);
 

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -826,7 +826,7 @@ class SX126x: public PhysicalLayer {
     int16_t setTxParams(uint8_t power, uint8_t rampTime = SX126X_PA_RAMP_200U);
     int16_t setModulationParams(uint8_t sf, uint8_t bw, uint8_t cr, uint8_t ldro = 0xFF);
     int16_t setModulationParamsFSK(uint32_t br, uint8_t pulseShape, uint8_t rxBw, uint32_t freqDev);
-    int16_t setPacketParams(uint16_t preambleLength, uint8_t crcType, uint8_t payloadLength = 0xFF, uint8_t headerType = SX126X_LORA_HEADER_EXPLICIT, uint8_t invertIQ = SX126X_LORA_IQ_STANDARD);
+    int16_t setPacketParams(uint16_t preambleLength, uint8_t crcType, uint8_t payloadLength = 0xFF, uint8_t headerType, uint8_t invertIQ = SX126X_LORA_IQ_STANDARD);
     int16_t setPacketParamsFSK(uint16_t preambleLength, uint8_t crcType, uint8_t syncWordLength, uint8_t addrComp, uint8_t whitening, uint8_t packetType = SX126X_GFSK_PACKET_VARIABLE, uint8_t payloadLength = 0xFF, uint8_t preambleDetectorLength = SX126X_GFSK_PREAMBLE_DETECT_16);
     int16_t setBufferBaseAddress(uint8_t txBaseAddress = 0x00, uint8_t rxBaseAddress = 0x00);
     uint8_t getStatus();

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -834,7 +834,7 @@ class SX126x: public PhysicalLayer {
 #endif
     Module* _mod;
 
-    uint8_t _bw, _sf, _cr, _ldro, _crcType;
+    uint8_t _bw, _sf, _cr, _ldro, _crcType, _headerType;
     uint16_t _preambleLength;
     float _bwKhz;
 

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -838,6 +838,7 @@ class SX126x: public PhysicalLayer {
     int16_t setFrequencyRaw(float freq);
     int16_t setOptimalHiPowerPaConfig(int8_t* inOutPower);
     int16_t setPacketMode(uint8_t mode, uint8_t len);
+    int16_t setHeaderType(uint8_t headerType, size_t len = 0xFF);
 
     // fixes to errata
     int16_t fixSensitivity();

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -795,10 +795,12 @@ class SX126x: public PhysicalLayer {
 
      \returns \ref status_codes
    */
-   int16_t implicitHeader();
+   int16_t implicitHeader(size_t len);
 
     /*!
      \brief Set explicit header mode for future reception/transmission.
+
+     \param len Payload length in bytes. **WILL BE GLOBALLY OVERRIDDEN BY transmit()**
 
      \returns \ref status_codes
    */
@@ -836,7 +838,7 @@ class SX126x: public PhysicalLayer {
     int16_t setFrequencyRaw(float freq);
     int16_t setOptimalHiPowerPaConfig(int8_t* inOutPower);
     int16_t setPacketMode(uint8_t mode, uint8_t len);
-    int16_t setHeaderType(uint8_t headerType)
+    int16_t setHeaderType(uint8_t headerType, size_t len = 0xFF)
 
     // fixes to errata
     int16_t fixSensitivity();

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -800,7 +800,7 @@ class SX126x: public PhysicalLayer {
     /*!
      \brief Set explicit header mode for future reception/transmission.
 
-     \param len Payload length in bytes. **WILL BE GLOBALLY OVERRIDDEN BY transmit()**
+     \param len Payload length in bytes.
 
      \returns \ref status_codes
    */

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -795,7 +795,7 @@ class SX126x: public PhysicalLayer {
 
      \returns \ref status_codes
    */
-   void implicitHeader(size_t len);
+   int16_t implicitHeader(size_t len);
 
     /*!
      \brief Set explicit header mode for future reception/transmission.
@@ -804,7 +804,7 @@ class SX126x: public PhysicalLayer {
 
      \returns \ref status_codes
    */
-   void explicitHeader();
+   int16_t explicitHeader();
 #ifndef RADIOLIB_GODMODE
   protected:
 #endif

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -514,7 +514,7 @@ class SX126x: public PhysicalLayer {
 
       \returns \ref status_codes
     */
-    int16_t startReceive(size_t len, uint32_t timeout = SX126X_RX_TIMEOUT_INF);
+    int16_t startReceive(uint32_t timeout = SX126X_RX_TIMEOUT_INF);
 
     /*!
       \brief Interrupt-driven receive method where the device mostly sleeps and periodically wakes to listen.
@@ -526,7 +526,7 @@ class SX126x: public PhysicalLayer {
 
       \returns \ref status_codes
     */
-    int16_t startReceiveDutyCycle(size_t len, uint32_t rxPeriod, uint32_t sleepPeriod);
+    int16_t startReceiveDutyCycle(uint32_t rxPeriod, uint32_t sleepPeriod);
 
     /*!
       \brief Calls \ref startReceiveDutyCycle with rxPeriod and sleepPeriod set so the unit shouldn't miss any messages.
@@ -539,7 +539,7 @@ class SX126x: public PhysicalLayer {
 
       \returns \ref status_codes
     */
-    int16_t startReceiveDutyCycleAuto(size_t len, uint16_t senderPreambleLength = 0, uint16_t minSymbols = 8);
+    int16_t startReceiveDutyCycleAuto(uint16_t senderPreambleLength = 0, uint16_t minSymbols = 8);
 
     /*!
       \brief Reads data received after calling startReceive method.

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -789,6 +789,20 @@ class SX126x: public PhysicalLayer {
      \returns Expected time-on-air in microseconds.
    */
    uint32_t getTimeOnAir(size_t len);
+
+    /*!
+     \brief Set implicit header mode for future reception/transmission.
+
+     \returns \ref status_codes
+   */
+   int16_t implicitHeader();
+
+    /*!
+     \brief Set explicit header mode for future reception/transmission.
+
+     \returns \ref status_codes
+   */
+   int16_t explicitHeader();
 #ifndef RADIOLIB_GODMODE
   protected:
 #endif
@@ -822,6 +836,7 @@ class SX126x: public PhysicalLayer {
     int16_t setFrequencyRaw(float freq);
     int16_t setOptimalHiPowerPaConfig(int8_t* inOutPower);
     int16_t setPacketMode(uint8_t mode, uint8_t len);
+    int16_t setHeaderType(uint8_t headerType)
 
     // fixes to errata
     int16_t fixSensitivity();

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -826,7 +826,7 @@ class SX126x: public PhysicalLayer {
     int16_t setTxParams(uint8_t power, uint8_t rampTime = SX126X_PA_RAMP_200U);
     int16_t setModulationParams(uint8_t sf, uint8_t bw, uint8_t cr, uint8_t ldro = 0xFF);
     int16_t setModulationParamsFSK(uint32_t br, uint8_t pulseShape, uint8_t rxBw, uint32_t freqDev);
-    int16_t setPacketParams(uint16_t preambleLength, uint8_t crcType, uint8_t payloadLength = 0xFF, uint8_t headerType, uint8_t invertIQ = SX126X_LORA_IQ_STANDARD);
+    int16_t setPacketParams(uint16_t preambleLength, uint8_t crcType, uint8_t payloadLength, uint8_t headerType, uint8_t invertIQ = SX126X_LORA_IQ_STANDARD);
     int16_t setPacketParamsFSK(uint16_t preambleLength, uint8_t crcType, uint8_t syncWordLength, uint8_t addrComp, uint8_t whitening, uint8_t packetType = SX126X_GFSK_PACKET_VARIABLE, uint8_t payloadLength = 0xFF, uint8_t preambleDetectorLength = SX126X_GFSK_PREAMBLE_DETECT_16);
     int16_t setBufferBaseAddress(uint8_t txBaseAddress = 0x00, uint8_t rxBaseAddress = 0x00);
     uint8_t getStatus();

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -514,7 +514,7 @@ class SX126x: public PhysicalLayer {
 
       \returns \ref status_codes
     */
-    int16_t startReceive(uint32_t timeout = SX126X_RX_TIMEOUT_INF);
+    int16_t startReceive(size_t len, uint32_t timeout = SX126X_RX_TIMEOUT_INF);
 
     /*!
       \brief Interrupt-driven receive method where the device mostly sleeps and periodically wakes to listen.
@@ -526,7 +526,7 @@ class SX126x: public PhysicalLayer {
 
       \returns \ref status_codes
     */
-    int16_t startReceiveDutyCycle(uint32_t rxPeriod, uint32_t sleepPeriod);
+    int16_t startReceiveDutyCycle(size_t len, uint32_t rxPeriod, uint32_t sleepPeriod);
 
     /*!
       \brief Calls \ref startReceiveDutyCycle with rxPeriod and sleepPeriod set so the unit shouldn't miss any messages.
@@ -539,7 +539,7 @@ class SX126x: public PhysicalLayer {
 
       \returns \ref status_codes
     */
-    int16_t startReceiveDutyCycleAuto(uint16_t senderPreambleLength = 0, uint16_t minSymbols = 8);
+    int16_t startReceiveDutyCycleAuto(size_t len, uint16_t senderPreambleLength = 0, uint16_t minSymbols = 8);
 
     /*!
       \brief Reads data received after calling startReceive method.


### PR DESCRIPTION
Not complete yet. See https://github.com/jgromes/RadioLib/issues/86 for implementation discussion.

- [x] Declarations/interface
- [x] SetHeaderType
- [x] setImplicitHeader/setExplicitHeader
- [x] check getOnAirTime takes lack of header into account
- [x] make sure all calls to setPacketParams use cached _headerType and _implicitLen (new vars)
- [x] only set these vars in setHeaderMode, do not use setPacketParams. _Maybe remove setHeaderMode as it's not doing much since discussion_
- [x] receive methods should call setPacketParams in implicit mode only
- [x] decide what to do with existing specified len on receive()
- [x] test implementation on hardware