### PR TITLE
Prevent spurious resets on some boards

### DIFF
--- a/src/modules/RF69/RF69.cpp
+++ b/src/modules/RF69/RF69.cpp
@@ -95,7 +95,6 @@ void RF69::reset() {
   Module::digitalWrite(_mod->getRst(), HIGH);
   delayMicroseconds(100);
   Module::digitalWrite(_mod->getRst(), LOW);
-  Module::pinMode(_mod->getRst(), INPUT);
   delay(10);
 }
 

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -155,7 +155,6 @@ int16_t SX126x::reset(bool verify) {
   Module::digitalWrite(_mod->getRst(), LOW);
   delayMicroseconds(150);
   Module::digitalWrite(_mod->getRst(), HIGH);
-  Module::pinMode(_mod->getRst(), INPUT);
 
   // return immediately when verification is disabled
   if(!verify) {

--- a/src/modules/SX127x/SX127x.cpp
+++ b/src/modules/SX127x/SX127x.cpp
@@ -126,7 +126,6 @@ void SX127x::reset() {
   Module::digitalWrite(_mod->getRst(), LOW);
   delayMicroseconds(100);
   Module::digitalWrite(_mod->getRst(), HIGH);
-  Module::pinMode(_mod->getRst(), INPUT);
   delay(5);
 }
 

--- a/src/modules/XBee/XBee.cpp
+++ b/src/modules/XBee/XBee.cpp
@@ -56,7 +56,6 @@ void XBee::reset() {
   digitalWrite(_mod->getRst(), LOW);
   delayMicroseconds(200);
   digitalWrite(_mod->getRst(), HIGH);
-  pinMode(_mod->getRst(), INPUT);
 }
 
 int16_t XBee::transmit(uint8_t* dest, const char* payload, uint8_t radius) {


### PR DESCRIPTION
My receiver was failing to receive after a random amount of time (2 - 60
seconds). I discovered some power supply issues (DC-DC converter
related) that turned out to be another cause of the same problem but
only on some boards. I also noted that reinitialising the radio temporarily fixed the problem.

The reset procedure for most of the boards that RadioLib can drive
changes the pin mode of the reset line to an input after reset,
effectively tri-stating the output. I had seen this but dismissed it
after checking that the SX126x has a pullup on NRST meaning this was not
an issue.

The receiver I have produced uses a level converter to translate the 5v0
signals to 3v3. The level converters are not themselves pulled up or
down, which means when a pin is connected in a high-impedance input
state it will float around possibly randomly.

This can cause spurious resets on my board, and possibly others. I
remembered the reset procedure when I realised I could reproduce the
problem by rubbing the board on my shirt, probably causing some ESD to
trigger a change on the reset line.

This PR simply removes the lines that change the pinmode to input after
reset leaving it as an output which is hard-driven and the safest way. I
assume that the current behaviour was chosen to decrease the chance of a
conflict if used incorrectly.

Note that the NSS line is already safe (always an output).