### PR TITLE
LoRa: Add ability for receiver to check if CRC is present in payload

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -90,6 +90,7 @@ setDataShaping	KEYWORD2
 setOOK	KEYWORD2
 setDataShapingOOK	KEYWORD2
 setCRC	KEYWORD2
+crcOnPayload	KEYWORD2
 variablePacketLengthMode	KEYWORD2
 fixedPacketLengthMode	KEYWORD2
 setCrcFiltering KEYWORD2

--- a/src/modules/SX127x/SX1278.cpp
+++ b/src/modules/SX127x/SX1278.cpp
@@ -439,6 +439,10 @@ int16_t SX1278::setCRC(bool enableCRC) {
   }
 }
 
+uint8_t SX1278::crcOnPayload() {
+  return(_mod->SPIgetRegValue(SX127X_REG_HOP_CHANNEL, 6, 6) >> 6);
+}
+
 int16_t SX1278::setBandwidthRaw(uint8_t newBandwidth) {
   // set mode to standby
   int16_t state = SX127x::standby();

--- a/src/modules/SX127x/SX1278.h
+++ b/src/modules/SX127x/SX1278.h
@@ -259,6 +259,13 @@ class SX1278: public SX127x {
     */
     int16_t setCRC(bool enableCRC);
 
+	  /*!
+      \brief Check if payload includes CRC and thus CRC is enabled in explicit header mode
+
+      \returns 1 if payload includes CRC and CRC is enabled, otherwise 0
+    */
+	  uint8_t crcOnPayload();
+
 #ifndef RADIOLIB_GODMODE
   protected:
 #endif

--- a/src/modules/SX127x/SX1278.h
+++ b/src/modules/SX127x/SX1278.h
@@ -259,12 +259,12 @@ class SX1278: public SX127x {
     */
     int16_t setCRC(bool enableCRC);
 
-	  /*!
+    /*!
       \brief Check if payload includes CRC and thus CRC is enabled in explicit header mode
 
       \returns 1 if payload includes CRC and CRC is enabled, otherwise 0
     */
-	  uint8_t crcOnPayload();
+    uint8_t crcOnPayload();
 
 #ifndef RADIOLIB_GODMODE
   protected:


### PR DESCRIPTION
setCRC() has no effect when used with receiver in LoRa explicit header mode (SX1276/77/78/79 datasheet page 30). This modification adds crcOnPayload()-function, which can be used to detect if CRC is present in payload. With this it is possible to verify that CRC is really used between sender and receiver.

SX1276/77/78/79 datasheet page 112:
RegHopChannel (0x1C), bit 6: CrcOnPayload (read)
CRC Information extracted from the received packet header (Explicit header mode only)
0 = Header indicates CRC off
1 = Header indicates CRC on