### PR TITLE
Carrier sense as sync word qualifier

### DIFF
--- a/src/modules/CC1101/CC1101.cpp
+++ b/src/modules/CC1101/CC1101.cpp
@@ -357,14 +357,14 @@ int16_t CC1101::setRxBandwidth(float rxBw) {
   for(int8_t e = 3; e >= 0; e--) {
     for(int8_t m = 3; m >= 0; m --) {
       float point = (CC1101_CRYSTAL_FREQ * 1000000.0)/(8 * (m + 4) * ((uint32_t)1 << e));
-      if(abs((rxBw * 1000.0) - point) <= 0.001) {
+      if(abs((rxBw * 1000.0) - point) <= 1000) {
         // set Rx channel filter bandwidth
         return(SPIsetRegValue(CC1101_REG_MDMCFG4, (e << 6) | (m << 4), 7, 4));
       }
     }
   }
 
-  return(ERR_UNKNOWN);
+  return(ERR_INVALID_RX_BANDWIDTH);
 }
 
 int16_t CC1101::setFrequencyDeviation(float freqDev) {

--- a/src/modules/CC1101/CC1101.cpp
+++ b/src/modules/CC1101/CC1101.cpp
@@ -792,6 +792,7 @@ int16_t CC1101::setPacketMode(uint8_t mode, uint8_t len) {
   RADIOLIB_ASSERT(state);
 
   // update the cached value
+  _packetLength = len;
   _packetLengthConfig = mode;
   return(state);
 }

--- a/src/modules/CC1101/CC1101.cpp
+++ b/src/modules/CC1101/CC1101.cpp
@@ -566,24 +566,24 @@ int16_t CC1101::setOOK(bool enableOOK) {
     int16_t state = SPIsetRegValue(CC1101_REG_MDMCFG2, CC1101_MOD_FORMAT_ASK_OOK, 6, 4);
     RADIOLIB_ASSERT(state);
 
-    // update current modulation
-    _modulation = CC1101_MOD_FORMAT_ASK_OOK;
-
     // PA_TABLE[0] is (by default) the power value used when transmitting a "0L".
     // Set PA_TABLE[1] to be used when transmitting a "1L".
     state = SPIsetRegValue(CC1101_REG_FREND0, 1, 2, 0);
     RADIOLIB_ASSERT(state);
 
+
+    // update current modulation
+    _modulation = CC1101_MOD_FORMAT_ASK_OOK;
   } else {
     int16_t state = SPIsetRegValue(CC1101_REG_MDMCFG2, CC1101_MOD_FORMAT_2_FSK, 6, 4);
     RADIOLIB_ASSERT(state);
 
-    // update current modulation
-    _modulation = CC1101_MOD_FORMAT_2_FSK;
-
     // Reset FREND0 to default value.
     state = SPIsetRegValue(CC1101_REG_FREND0, 0, 2, 0);
     RADIOLIB_ASSERT(state);
+
+    // update current modulation
+    _modulation = CC1101_MOD_FORMAT_2_FSK;
   }
 
   // Update PA_TABLE values according to the new _modulation.

--- a/src/modules/CC1101/CC1101.h
+++ b/src/modules/CC1101/CC1101.h
@@ -709,9 +709,11 @@ class CC1101: public PhysicalLayer {
 
       \param maxErrBits Maximum allowed number of bit errors in received sync word. Defaults to 0.
 
+      \param requireCarrierSense Require carrier sense above threshold in addition to sync word.
+
       \returns \ref status_codes
     */
-    int16_t setSyncWord(uint8_t syncH, uint8_t syncL, uint8_t maxErrBits = 0);
+    int16_t setSyncWord(uint8_t syncH, uint8_t syncL, uint8_t maxErrBits = 0, bool requireCarrierSense = false);
 
     /*!
       \brief Sets 1 or 2 bytes of sync word.
@@ -722,9 +724,11 @@ class CC1101: public PhysicalLayer {
 
       \param maxErrBits Maximum allowed number of bit errors in received sync word. Defaults to 0.
 
+      \param requireCarrierSense Require carrier sense above threshold in addition to sync word.
+
       \returns \ref status_codes
     */
-    int16_t setSyncWord(uint8_t* syncWord, uint8_t len, uint8_t maxErrBits = 0);
+    int16_t setSyncWord(uint8_t* syncWord, uint8_t len, uint8_t maxErrBits = 0, bool requireCarrierSense = false);
 
     /*!
       \brief Sets preamble length.
@@ -808,16 +812,20 @@ class CC1101: public PhysicalLayer {
 
       \param numBits Sync word length in bits.
 
+      \param requireCarrierSense Require carrier sense above threshold in addition to sync word.
+
       \returns \ref status_codes
     */
-    int16_t enableSyncWordFiltering(uint8_t maxErrBits = 0);
+    int16_t enableSyncWordFiltering(uint8_t maxErrBits = 0, bool requireCarrierSense = false);
 
      /*!
       \brief Disable preamble and sync word filtering and generation.
 
+      \param requireCarrierSense Require carrier sense above threshold.
+
       \returns \ref status_codes
     */
-    int16_t disableSyncWordFiltering();
+    int16_t disableSyncWordFiltering(bool requireCarrierSense = false);
 
      /*!
       \brief Enable CRC filtering and generation.


### PR DESCRIPTION
Hi @jgromes 
I'm sending you some tested changes:

-  Had to increase tolerance in `setRxBandwidth()` since some bandwidth values (coming from datasheet) were not accepted. It should be ok but, please, check it out.
   **Example**:   `[(26*1000000) / (8*( 4 + 0 ) * 2 ^ 2 )]  -  203 * 1000 = 125`
     _man = 0, exp = 2  corresponds to 203 Khz (datasheet page 35)._
     The above diff is 125 so that value won't be accepted with 0.1 tolerance.
- Some minor fixes. (imho)
- Added "carrier sense" as sync word qualifier; defaults to false to achieve back compatibility.

Thanks, 
Let me know.