### PR TITLE
[CC1101] Receive and Transmit up to 255 bytes

### DIFF
--- a/src/modules/CC1101/CC1101.h
+++ b/src/modules/CC1101/CC1101.h
@@ -599,9 +599,9 @@ class CC1101: public PhysicalLayer {
 
       \param func ISR to call.
 
-      \param dir Signal change direction. Defaults to FALLING.
+      \param dir Signal change direction. Defaults to RISING.
     */
-    void setGdo0Action(void (*func)(void), uint8_t dir = FALLING);
+    void setGdo0Action(void (*func)(void), uint8_t dir = RISING);
 
     /*!
       \brief Clears interrupt service routine to call when GDO0 activates.

--- a/src/modules/CC1101/CC1101.h
+++ b/src/modules/CC1101/CC1101.h
@@ -885,8 +885,6 @@ class CC1101: public PhysicalLayer {
     uint8_t _syncWordLength;
     int8_t _power;
 
-    uint8_t min(uint8_t a, uint8_t b);
-
     int16_t config();
     int16_t directMode();
     void getExpMant(float target, uint16_t mantOffset, uint8_t divExp, uint8_t expMax, uint8_t& exp, uint8_t& mant);

--- a/src/modules/CC1101/CC1101.h
+++ b/src/modules/CC1101/CC1101.h
@@ -8,9 +8,10 @@
 
 // CC1101 physical layer properties
 #define CC1101_FREQUENCY_STEP_SIZE                    396.7285156
-#define CC1101_MAX_PACKET_LENGTH                      63
+#define CC1101_MAX_PACKET_LENGTH                      255
 #define CC1101_CRYSTAL_FREQ                           26.0
 #define CC1101_DIV_EXPONENT                           16
+#define CC1101_FIFO_SIZE                              64
 
 // CC1101 SPI commands
 #define CC1101_CMD_READ                               0b10000000
@@ -168,7 +169,7 @@
 #define CC1101_RX_ATTEN_6_DB                          0b00010000  //  5     4                     6 dB
 #define CC1101_RX_ATTEN_12_DB                         0b00100000  //  5     4                     12 dB
 #define CC1101_RX_ATTEN_18_DB                         0b00110000  //  5     4                     18 dB
-#define CC1101_FIFO_THR                               0b00000111  //  5     4     Rx FIFO threshold [bytes] = CC1101_FIFO_THR * 4; Tx FIFO threshold [bytes] = 65 - (CC1101_FIFO_THR * 4)
+#define CC1101_FIFO_THR_TX_61_RX_4                    0b00000000  //  3     0     TX fifo threshold: 61, RX fifo threshold: 4
 
 // CC1101_REG_SYNC1
 #define CC1101_SYNC_WORD_MSB                          0xD3        //  7     0     sync word MSB
@@ -883,6 +884,8 @@ class CC1101: public PhysicalLayer {
 
     uint8_t _syncWordLength;
     int8_t _power;
+
+    uint8_t min(uint8_t a, uint8_t b);
 
     int16_t config();
     int16_t directMode();


### PR DESCRIPTION
Hi @jgromes 
As I anticipated in the other PR, I'm using this code to read and receive packets beyond the size of the FIFO.

Basically it keeps feeding the FIFO on TX and waits for the radio to push new data on RX.

Moreover there's a small fix: `CC1101_REG_IOCFG0` was previously set to `CC1101_GDOX_SYNC_WORD_SENT_OR_RECEIVED` but I noticed that, during RX, GDO0 will not be asserted if sync word detection is disabled (I tested it and, well, it makes sense.). 


Let me know.