### PR TITLE
[SX127x] Set OOK parameter before setting the bitrate to avoid reading undefined variable

### DIFF
--- a/src/modules/SX127x/SX127x.cpp
+++ b/src/modules/SX127x/SX127x.cpp
@@ -74,6 +74,10 @@ int16_t SX127x::beginFSK(uint8_t chipVersion, float br, float freqDev, float rxB
     RADIOLIB_ASSERT(state);
   }
 
+  // enable/disable OOK
+  state = setOOK(enableOOK);
+  RADIOLIB_ASSERT(state);
+
   // set bit rate
   state = SX127x::setBitRate(br);
   RADIOLIB_ASSERT(state);
@@ -101,10 +105,6 @@ int16_t SX127x::beginFSK(uint8_t chipVersion, float br, float freqDev, float rxB
 
   // disable address filtering
   state = disableAddressFiltering();
-  RADIOLIB_ASSERT(state);
-
-  // enable/disable OOK
-  state = setOOK(enableOOK);
   RADIOLIB_ASSERT(state);
 
   // set default RSSI measurement config


### PR DESCRIPTION
On SX127x when calling beginFSK, the [setOOK](https://github.com/jgromes/RadioLib/blob/master/src/modules/SX127x/SX127x.cpp#L107) method is called after [setBitRate](https://github.com/jgromes/RadioLib/blob/master/src/modules/SX127x/SX127x.cpp#L78) but inside setBitRate the _ook variable is used (before it is set): https://github.com/jgromes/RadioLib/blob/master/src/modules/SX127x/SX127x.cpp#L660

This results in ERR_INVALID_BIT_RATE deppending on what that section of memory has at the time it is called.

Calling setOOK before setBitRate solve the problem and I think it does not cause any other issue.