### PR TITLE
nRF24 small improvements.

### DIFF
--- a/src/modules/nRF24/nRF24.cpp
+++ b/src/modules/nRF24/nRF24.cpp
@@ -423,6 +423,10 @@ int16_t nRF24::getStatus(uint8_t mask) {
   return(_mod->SPIgetRegValue(NRF24_REG_STATUS) & mask);
 }
 
+bool nRF24::isCarrierDetected() {
+  return(_mod->SPIgetRegValue(NRF24_REG_RPD, 0,0)) == 1;
+}
+
 int16_t nRF24::setFrequencyDeviation(float freqDev) {
   // nRF24 is unable to set frequency deviation
   // this method is implemented only for PhysicalLayer compatibility

--- a/src/modules/nRF24/nRF24.h
+++ b/src/modules/nRF24/nRF24.h
@@ -393,6 +393,13 @@ class nRF24: public PhysicalLayer {
     int16_t getStatus(uint8_t mask = 0xFF);
 
     /*!
+      \brief Checks if carrier was detected during last RX
+
+      \returns Whatever the carrier was above threshold.
+    */
+    bool isCarrierDetected();
+
+    /*!
       \brief Dummy configuration method, to ensure PhysicalLayer compatibility.
 
       \param freqDev Dummy frequency deviation parameter, no configuration will be changed.

--- a/src/modules/nRF24/nRF24.h
+++ b/src/modules/nRF24/nRF24.h
@@ -445,7 +445,7 @@ class nRF24: public PhysicalLayer {
 
      \returns \ref status_codes
    */
-    int16_t setAutoAck(uint8_t pipeNum, bool autoAckOn = true);
+    int16_t setAutoAck(uint8_t pipeNum, bool autoAckOn);
 
     /*!
       \brief Dummy data shaping configuration method, to ensure PhysicalLayer compatibility.

--- a/src/modules/nRF24/nRF24.h
+++ b/src/modules/nRF24/nRF24.h
@@ -127,7 +127,7 @@
 // NRF24_REG_STATUS
 #define NRF24_RX_DR                                   0b01000000  //  6     6     Rx data ready
 #define NRF24_TX_DS                                   0b00100000  //  5     5     Tx data sent
-#define NRF24_MAX_RT                                  0b00010000  //  4     4     maximum number of rentransmits reached (must be cleared to continue)
+#define NRF24_MAX_RT                                  0b00010000  //  4     4     maximum number of retransmits reached (must be cleared to continue)
 #define NRF24_RX_FIFO_EMPTY                           0b00001110  //  3     1     Rx FIFO is empty
 #define NRF24_RX_P_NO                                 0b00000000  //  3     1     number of data pipe that received data
 #define NRF24_TX_FIFO_FULL                            0b00000001  //  0     0     Tx FIFO is full


### PR DESCRIPTION
Hi Jan, 

I'm using your nRF24 driver to scan over frequencies, I made some small changes:

- `isCarrierDetected()`, to detect whatever the carrier is detected.
- I'm attaching notes on modified lines.

Please, let me know.