### PR TITLE
Set the min/max ranges per the Semtech SX1278/SX1276 datasheet

### DIFF
--- a/src/modules/RFM9x/RFM95.cpp
+++ b/src/modules/RFM9x/RFM95.cpp
@@ -35,7 +35,7 @@ int16_t RFM95::begin(float freq, float bw, uint8_t sf, uint8_t cr, uint8_t syncW
 }
 
 int16_t RFM95::setFrequency(float freq) {
-  RADIOLIB_CHECK_RANGE(freq, 868.0, 915.0, ERR_INVALID_FREQUENCY);
+  RADIOLIB_CHECK_RANGE(freq, 862.0, 1020.0, ERR_INVALID_FREQUENCY);
 
   // set frequency
   return(SX127x::setFrequencyRaw(freq));

--- a/src/modules/RFM9x/RFM96.cpp
+++ b/src/modules/RFM9x/RFM96.cpp
@@ -35,7 +35,7 @@ int16_t RFM96::begin(float freq, float bw, uint8_t sf, uint8_t cr, uint8_t syncW
 }
 
 int16_t RFM96::setFrequency(float freq) {
-  RADIOLIB_CHECK_RANGE(freq, 433.0, 470.0, ERR_INVALID_FREQUENCY);
+  RADIOLIB_CHECK_RANGE(freq, 410.0, 525.0, ERR_INVALID_FREQUENCY);
 
   // set frequency
   return(SX127x::setFrequencyRaw(freq));


### PR DESCRIPTION
Hi.  I love ya'll's lib ;-).  I just switched our [www.meshtastic.org](www.meshtastic.org) project over from our fairly diverged originally RadioHead drivers to your nice framework.

I'm sending in a few PRs you might want.  This one is because I noticed that the high frequency limit for the RFM95 was too tight for legal US frequency bands.  So I changed the limits based on the Sematech datasheet values for both the RFM95 and RFM96.