### PR TITLE
when probing for sx127xs don't wait so long between attempts.

### DIFF
--- a/src/modules/SX127x/SX127x.cpp
+++ b/src/modules/SX127x/SX127x.cpp
@@ -998,7 +998,7 @@ bool SX127x::findChip(uint8_t ver) {
         RADIOLIB_DEBUG_PRINT(F(", expected 0x00"));
         RADIOLIB_DEBUG_PRINTLN(ver, HEX);
       #endif
-      delay(1000);
+      delay(10);
       i++;
     }
   }


### PR DESCRIPTION
Hi,

Is there a reason the delay between probe attempts was so long?  I can't find anything in the datasheet that would suggest this requirement.  So I've changed it to 10ms per probe, so that if the device is missing we only stall the boot for about 100ms.