### PR TITLE
Don't teardown interfaces (SPI) that are possibly shared 

### DIFF
--- a/src/modules/SX127x/SX127x.cpp
+++ b/src/modules/SX127x/SX127x.cpp
@@ -14,7 +14,7 @@ int16_t SX127x::begin(uint8_t chipVersion, uint8_t syncWord, uint8_t currentLimi
   // try to find the SX127x chip
   if(!SX127x::findChip(chipVersion)) {
     RADIOLIB_DEBUG_PRINTLN(F("No SX127x found!"));
-    _mod->term();
+    // _mod->term(); don't teardown SPI interfaces that might be shared with other devices
     return(ERR_CHIP_NOT_FOUND);
   } else {
     RADIOLIB_DEBUG_PRINTLN(F("Found SX127x!"));


### PR DESCRIPTION
In my application I have multiple devices on a single SPI bus (which are not radios), but Module.term() tears down the SPI controller.  Also, it tears down hardware serial.

Is there a reason for not just leaving the SPI controller alone when we fail to find our chip?