### PR TITLE
make Radiolib work on NRF52 arduino.  Two changes:

### DIFF
--- a/src/BuildOpt.h
+++ b/src/BuildOpt.h
@@ -52,7 +52,7 @@
   #define RADIOLIB_INTERRUPT_STATUS                   RADIOLIB_PIN_STATUS
   #define RADIOLIB_NC                                 (0xFF)
   #define RADIOLIB_SOFTWARE_SERIAL_UNSUPPORTED
-  #define RADIOLIB_HARDWARE_SERIAL_PORT               Serial1
+  #define RADIOLIB_HARDWARE_SERIAL_PORT               &Serial1
   #define RADIOLIB_TONE_UNSUPPORTED
 
 #elif defined(ARDUINO_ARCH_STM32)
@@ -64,7 +64,7 @@
   #define RADIOLIB_INTERRUPT_STATUS                   RADIOLIB_PIN_STATUS
   #define RADIOLIB_NC                                 (0xFFFFFFFF)
   #define RADIOLIB_SOFTWARE_SERIAL_UNSUPPORTED
-  #define RADIOLIB_HARDWARE_SERIAL_PORT               Serial1
+  #define RADIOLIB_HARDWARE_SERIAL_PORT               &Serial1
 
 #elif defined(SAMD_SERIES)
   // Arduino SAMD boards - Zero, MKR, etc.
@@ -75,7 +75,7 @@
   #define RADIOLIB_INTERRUPT_STATUS                   RADIOLIB_PIN_STATUS
   #define RADIOLIB_NC                                 (0xFFFFFFFF)
   #define RADIOLIB_SOFTWARE_SERIAL_UNSUPPORTED
-  #define RADIOLIB_HARDWARE_SERIAL_PORT               Serial1
+  #define RADIOLIB_HARDWARE_SERIAL_PORT               &Serial1
 
 #elif defined(__SAM3X8E__)
   // Arduino Due
@@ -86,7 +86,7 @@
   #define RADIOLIB_INTERRUPT_STATUS                   RADIOLIB_PIN_STATUS
   #define RADIOLIB_NC                                 (0xFFFFFFFF)
   #define RADIOLIB_SOFTWARE_SERIAL_UNSUPPORTED
-  #define RADIOLIB_HARDWARE_SERIAL_PORT               Serial1
+  #define RADIOLIB_HARDWARE_SERIAL_PORT               &Serial1
   #define RADIOLIB_TONE_UNSUPPORTED
 
 #elif (defined(NRF52832_XXAA) || defined(NRF52840_XXAA)) && !defined(ARDUINO_ARDUINO_NANO33BLE)
@@ -97,6 +97,7 @@
   #define RADIOLIB_PIN_STATUS                         uint32_t
   #define RADIOLIB_INTERRUPT_STATUS                   RADIOLIB_PIN_STATUS
   #define RADIOLIB_NC                                 (0xFFFFFFFF)
+  #define RADIOLIB_SOFTWARE_SERIAL_UNSUPPORTED
 
 #elif defined(ARDUINO_ARC32_TOOLS)
   // Intel Curie
@@ -125,7 +126,7 @@
   #define RADIOLIB_INTERRUPT_STATUS                   RADIOLIB_PIN_STATUS
   #define RADIOLIB_NC                                 (0xFF)
   #define RADIOLIB_SOFTWARE_SERIAL_UNSUPPORTED
-  #define RADIOLIB_HARDWARE_SERIAL_PORT               Serial1
+  #define RADIOLIB_HARDWARE_SERIAL_PORT               &Serial1
   #define RADIOLIB_TONE_UNSUPPORTED
 
 #elif defined(ARDUINO_ARDUINO_NANO33BLE)
@@ -137,7 +138,7 @@
   #define RADIOLIB_INTERRUPT_STATUS                   RADIOLIB_PIN_STATUS
   #define RADIOLIB_NC                                 (0xFF)
   #define RADIOLIB_SOFTWARE_SERIAL_UNSUPPORTED
-  #define RADIOLIB_HARDWARE_SERIAL_PORT               Serial1
+  #define RADIOLIB_HARDWARE_SERIAL_PORT               &Serial1
 
   // Nano 33 BLE uses mbed libraries, which already contain ESP8266 driver
   #define _RADIOLIB_ESP8266_H
@@ -151,7 +152,7 @@
   #define RADIOLIB_INTERRUPT_STATUS                   ExtIntTriggerMode
   #define RADIOLIB_NC                                 (0xFF)
   #define RADIOLIB_SOFTWARE_SERIAL_UNSUPPORTED
-  #define RADIOLIB_HARDWARE_SERIAL_PORT               Serial1
+  #define RADIOLIB_HARDWARE_SERIAL_PORT               &Serial1
   #define RADIOLIB_TONE_UNSUPPORTED
 
 #else

--- a/src/Module.h
+++ b/src/Module.h
@@ -5,9 +5,16 @@
 
 #include <SPI.h>
 //#include <Wire.h>
+
+#ifndef RADIOLIB_HARDWARE_SERIAL_PORT
+// If a hardware serial port is not specified, assume the platform doesn't have one
+#define RADIOLIB_HARDWARE_SERIAL_PORT NULL
+#endif
+
 #ifndef RADIOLIB_SOFTWARE_SERIAL_UNSUPPORTED
 #include <SoftwareSerial.h>
 #endif
+
 
 /*!
   \class Module
@@ -30,7 +37,7 @@ class Module {
       \param rst Arduino pin to be used as hardware reset for the module. Defaults to NC (unused).
     */
 #ifdef RADIOLIB_SOFTWARE_SERIAL_UNSUPPORTED
-    Module(RADIOLIB_PIN_TYPE tx, RADIOLIB_PIN_TYPE rx, HardwareSerial* serial = &RADIOLIB_HARDWARE_SERIAL_PORT, RADIOLIB_PIN_TYPE rst = RADIOLIB_NC);
+    Module(RADIOLIB_PIN_TYPE tx, RADIOLIB_PIN_TYPE rx, HardwareSerial* serial = RADIOLIB_HARDWARE_SERIAL_PORT, RADIOLIB_PIN_TYPE rst = RADIOLIB_NC);
 #else
     Module(RADIOLIB_PIN_TYPE tx, RADIOLIB_PIN_TYPE rx, HardwareSerial* serial = nullptr, RADIOLIB_PIN_TYPE rst = RADIOLIB_NC);
 #endif
@@ -111,7 +118,7 @@ class Module {
       \param serial HardwareSerial to be used on ESP32 and SAMD. Defaults to 1
     */
 #ifdef RADIOLIB_SOFTWARE_SERIAL_UNSUPPORTED
-    Module(RADIOLIB_PIN_TYPE cs, RADIOLIB_PIN_TYPE irq, RADIOLIB_PIN_TYPE rst, RADIOLIB_PIN_TYPE rx, RADIOLIB_PIN_TYPE tx, SPIClass& spi = SPI, SPISettings spiSettings = SPISettings(2000000, MSBFIRST, SPI_MODE0), HardwareSerial* serial = &RADIOLIB_HARDWARE_SERIAL_PORT);
+    Module(RADIOLIB_PIN_TYPE cs, RADIOLIB_PIN_TYPE irq, RADIOLIB_PIN_TYPE rst, RADIOLIB_PIN_TYPE rx, RADIOLIB_PIN_TYPE tx, SPIClass& spi = SPI, SPISettings spiSettings = SPISettings(2000000, MSBFIRST, SPI_MODE0), HardwareSerial* serial = RADIOLIB_HARDWARE_SERIAL_PORT);
 #else
     Module(RADIOLIB_PIN_TYPE cs, RADIOLIB_PIN_TYPE irq, RADIOLIB_PIN_TYPE rst, RADIOLIB_PIN_TYPE rx, RADIOLIB_PIN_TYPE tx, SPIClass& spi = SPI, SPISettings spiSettings = SPISettings(2000000, MSBFIRST, SPI_MODE0), HardwareSerial* serial = nullptr);
 #endif


### PR DESCRIPTION
Hi,

I was getting build errors on my Adafruit Arduino NRF52 based project because SoftwareSerial is not defined on that platform (and no SoftwareSerial.h).  So I marked it as RADIOLIB_SOFTWARE_SERIAL_UNSUPPORTED.  Also, their default build doesn't have a hardware serial port either.  So I changed RADIOLIB_HARDWARE_SERIAL_PORT so that platforms could leave it as NULL in the constructor call to Module.

With this change my project now builds and runs on ESP32 and NRF52.

---
* Adafruit NRF52 arduino doesn't have a software serial port.

* Make RADIOLIB_HARDWARE_SERIAL_PORT optional and if not set assume NULL.
Note: this changes the type to a ptr from an object.

