### PR TITLE
[SX127x] add getTempRaw method

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -126,6 +126,7 @@ setRSSIConfig	KEYWORD2
 setEncoding	KEYWORD2
 getIRQFlags	KEYWORD2
 getModemStatus	KEYWORD2
+getTempRaw	KEYWORD2
 
 # RF69-specific
 setAESKey	KEYWORD2

--- a/src/modules/SX127x/SX127x.h
+++ b/src/modules/SX127x/SX127x.h
@@ -459,8 +459,8 @@
 #define SX127X_TEMP_THRESHOLD_10_DEG_C                0b00000010  //  2     1                                   10 deg. C (default)
 #define SX127X_TEMP_THRESHOLD_15_DEG_C                0b00000100  //  2     1                                   15 deg. C
 #define SX127X_TEMP_THRESHOLD_20_DEG_C                0b00000110  //  2     1                                   20 deg. C
-#define SX127X_TEMP_MONITOR_OFF                       0b00000000  //  0     0     temperature monitoring disabled (default)
-#define SX127X_TEMP_MONITOR_ON                        0b00000001  //  0     0     temperature monitoring enabled
+#define SX127X_TEMP_MONITOR_ON                        0b00000000  //  0     0     temperature monitoring enabled (default)
+#define SX127X_TEMP_MONITOR_OFF                       0b00000001  //  0     0     temperature monitoring disabled
 
 // SX127X_REG_LOW_BAT
 #define SX127X_LOW_BAT_OFF                            0b00000000  //  3     3     low battery detector disabled
@@ -912,6 +912,13 @@ class SX127x: public PhysicalLayer {
       \returns Modem status.
     */
     uint8_t getModemStatus();
+
+    /*!
+      \brief Reads uncalibrated temperature value.
+
+      \returns Uncalibrated temperature sensor reading.
+    */
+    int8_t getTempRaw();
 
     #ifdef RADIOLIB_DEBUG
       void regDump();


### PR DESCRIPTION
this is pretty much just a RadioLib-ed version of the example code from the datasheet page 126++.

since this is quite the ritual dance with a bunch of register read/writes, it seemed better to include
it RL side instead of going with thin accessor functions like modemStatus.

SX127X_TEMP_MONITOR_ON/OFF logic seems to have been inverted, see datasheet page 89.
since these defines were unused within RL afaict i didnt make that part a separate commit.
this might bite anyone who does use the defines through godmode.

partially for that reason the code is more verbose then it really needs to be when dealing
with the bit-operations, to avoid having "assumptions about the defines coded in".

i considered adding more to the description in the .h, but was not sure how to properly phrase it.
possibly worth adding would be:
- this changing the opmode (so dont call it while actively rx/tx)
- it restoring the modem to original opmode
- blocking for 200us

200us is more than the example code uses, but depending on where in the datasheet you look, they use
anything from 140-160us, and 200us is still "very short" and "works well here".
this could probably be made configurable or a parameter.

adding an "async mode" would also be possible, but would require a way to "stash" the old OpMode
and doesnt seem worth it considering 200us is ... still very short.
