### PR TITLE
New platform support for SparkFun LoRa Thing Plus - expLoRaBLE

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ SX127x, RFM9x, SX126x, RF69, SX1231, CC1101, nRF24L01, RFM2x, Si443x and SX128x
   * [__Curie__](https://github.com/arduino/ArduinoCore-arc32) - Arduino 101
 
 * __SparkFun__
-  * [__Apollo3__](https://github.com/sparkfun/Arduino_Apollo3) - Sparkfun Artemis Redboard
+  * [__Apollo3__](https://github.com/sparkfun/Arduino_Apollo3) - Sparkfun Artemis Redboard, SparkFun LoRa Thing Plus - expLoRaBLE
 
 * __ST Microelectronics__
   * [__STM32__ (official core)](https://github.com/stm32duino/Arduino_Core_STM32) - STM32 Nucleo, Discovery, Maple, BluePill, BlackPill etc.

--- a/src/BuildOpt.h
+++ b/src/BuildOpt.h
@@ -312,6 +312,43 @@
     #define RADIOLIB_PROGMEM                            PROGMEM
     #define RADIOLIB_PROGMEM_READ_BYTE(addr)            pgm_read_byte(addr)
 
+  #elif defined(ARDUINO_LoRa_THING_PLUS_expLoRaBLE)
+    // SparkFun LoRa Thing Plus - expLoRaBLE
+    #define RADIOLIB_PLATFORM                           "SparkFun LoRa Thing Plus expLoRaBLE"
+    #define RADIOLIB_PIN_TYPE                           pin_size_t
+    #define RADIOLIB_PIN_MODE                           Arduino_PinMode
+    #define RADIOLIB_PIN_STATUS                         PinStatus
+    #define RADIOLIB_INTERRUPT_STATUS                   RADIOLIB_PIN_STATUS
+    #define RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(p)        digitalPinToInterrupt(p)
+    #define RADIOLIB_NC                                 (0xFF)
+    #define RADIOLIB_DEFAULT_SPI                        SPI1
+    #define RADIOLIB_PROGMEM                            PROGMEM
+    #define RADIOLIB_PROGMEM_READ_BYTE(addr)            pgm_read_byte(addr)    
+    #define RADIOLIB_SOFTWARE_SERIAL_UNSUPPORTED
+    #define RADIOLIB_HARDWARE_SERIAL_PORT               Serial1    
+    #define RADIOLIB_EXCLUDE_CC1101
+    #define RADIOLIB_EXCLUDE_ESP8266
+    #define RADIOLIB_EXCLUDE_HC05
+    #define RADIOLIB_EXCLUDE_JDY08
+    #define RADIOLIB_EXCLUDE_NRF24
+    #define RADIOLIB_EXCLUDE_RF69
+    #define RADIOLIB_EXCLUDE_SX1231     // dependent on RADIOLIB_EXCLUDE_RF69
+    #define RADIOLIB_EXCLUDE_SI443X
+    #define RADIOLIB_EXCLUDE_RFM2X      // dependent on RADIOLIB_EXCLUDE_SI443X
+    #define RADIOLIB_EXCLUDE_SX127X
+    #define RADIOLIB_EXCLUDE_RFM9X      // dependent on RADIOLIB_EXCLUDE_SX127X
+    //#define RADIOLIB_EXCLUDE_SX126X
+    #define RADIOLIB_EXCLUDE_SX128X
+    #define RADIOLIB_EXCLUDE_XBEE
+    #define RADIOLIB_EXCLUDE_AFSK
+    #define RADIOLIB_EXCLUDE_AX25
+    #define RADIOLIB_EXCLUDE_HELLSCHREIBER
+    #define RADIOLIB_EXCLUDE_HTTP
+    #define RADIOLIB_EXCLUDE_MORSE
+    #define RADIOLIB_EXCLUDE_MQTT
+    #define RADIOLIB_EXCLUDE_RTTY
+    #define RADIOLIB_EXCLUDE_SSTV    
+
   #else
     // other platforms not covered by the above list - this may or may not work
     #define RADIOLIB_PLATFORM                           "Unknown"

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -1717,7 +1717,7 @@ int16_t SX126x::SPItransfer(uint8_t* cmd, uint8_t cmdLen, bool write, uint8_t* d
     // some faster platforms require a short delay here
     // not sure why, but it seems that long enough SPI transaction
     // (e.g. setPacketParams for GFSK) will fail without it
-    #if defined(ARDUINO_ARCH_STM32) || defined(SAMD_SERIES)
+    #if defined(ARDUINO_ARCH_STM32) || defined(SAMD_SERIES) || defined(ARDUINO_ARCH_APOLLO3)
       Module::delay(1);
     #endif
   #endif


### PR DESCRIPTION
Dear Jan Gromes,
Thank you so much for your work on this RadioLib Arduino Library. It has been wonderful developing with a new project using the apollo3 and sx1262! We are about to release our new product, and we will most definitely be directing users to your library in our hookup guide. In an effort to make using your library even easier with our new hardware, we have made the following changes. 

Please let us know what you think and thanks for considering our pull request!
Pete Lewis
SparkFun Electronics




Added platform support for new SparkFun Hardware, the SparkFun LoRa Thing Plus - expLoRaBLE. This module uses the apollo3 and sx1262.

-Note, also adjusted the SX126x.cpp file. I added a check for apollo3 archtecture to ensure the SPITransfer works more consistently using the 1 ms delay.

