### PR TITLE
Added GetRSSIInst command for SX126x

### DIFF
--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -1130,11 +1130,11 @@ uint32_t SX126x::getTimeOnAir(size_t len) {
   }
 }
 
-uint8_t SX126x::getRSSIInst() {
+float SX126x::getRSSIInst() {
   uint8_t data[3] = {0, 0, 0};  // RssiInst, Status, RFU
   SPIreadCommand(SX126X_CMD_GET_RSSI_INST, data, 3);
 
-  return data[0];
+  return (float)data[0] / (-2.0);
 }
 
 int16_t SX126x::implicitHeader(size_t len) {

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -1130,6 +1130,13 @@ uint32_t SX126x::getTimeOnAir(size_t len) {
   }
 }
 
+uint8_t SX126x::getRSSIInst() {
+  uint8_t data[3] = {0, 0, 0};  // RssiInst, Status, RFU
+  SPIreadCommand(SX126X_CMD_GET_RSSI_INST, data, 3);
+
+  return data[0];
+}
+
 int16_t SX126x::implicitHeader(size_t len) {
   return(setHeaderType(SX126X_LORA_HEADER_IMPLICIT, len));
 }

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -807,9 +807,9 @@ class SX126x: public PhysicalLayer {
    uint32_t getTimeOnAir(size_t len);
 
    /*!
-     \brief Get instantaneous RSSI value in FSK mode. Can be used for LBT implementation, checking for interference before transmitting.
+     \brief Get instantaneous RSSI value during recption of the packet. Should switch to FSK receive mode for LBT implementation.
 
-     \returns Instantaneous RSSI value in (-2)*dBm
+     \returns Instantaneous RSSI value in (-2)*dBm.
    */
    uint8_t getRSSIInst();
 

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -807,6 +807,13 @@ class SX126x: public PhysicalLayer {
    uint32_t getTimeOnAir(size_t len);
 
    /*!
+     \brief Get instantaneous RSSI value in FSK mode. Can be used for LBT implementation, checking for interference before transmitting.
+
+     \returns Instantaneous RSSI value in (-2)*dBm
+   */
+   uint8_t getRSSIInst();
+
+   /*!
      \brief Set implicit header mode for future reception/transmission.
 
      \returns \ref status_codes

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -809,9 +809,9 @@ class SX126x: public PhysicalLayer {
    /*!
      \brief Get instantaneous RSSI value during recption of the packet. Should switch to FSK receive mode for LBT implementation.
 
-     \returns Instantaneous RSSI value in (-2)*dBm.
+     \returns Instantaneous RSSI value in dBm, in steps of 0.5dBm
    */
-   uint8_t getRSSIInst();
+   float getRSSIInst();
 
    /*!
      \brief Set implicit header mode for future reception/transmission.


### PR DESCRIPTION
Hi,

While trying to implement the LBT(Listen-Before-Talk) feature on SX1262 chips, I've added the GetRSSIInst command (Opcode=0x15) for SX126x chips.
Since this command only works during the reception, in order to implement LBT for LoRa transmission the user will have to manually switch to FSK, set to receive mode, run the GetRSSIInst command, and switch back to LoRa.
I've tested it with STM32F103 MCU, but I expect other platforms to have no problem.