### PR TITLE
Feature/implement afc control

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -104,10 +104,14 @@ setPreambleLength	KEYWORD2
 setGain	KEYWORD2
 getFrequencyError	KEYWORD2
 getRSSI	KEYWORD2
+getAFCError	KEYWORD2
 getSNR	KEYWORD2
 getDataRate	KEYWORD2
 setBitRate	KEYWORD2
 setRxBandwidth	KEYWORD2
+setAFCBandwidth	KEYWORD2
+setAFC		KEYWORD2
+setAFCAGCTrigger	KEYWORD2
 setFrequencyDeviation	KEYWORD2
 setNodeAddress	KEYWORD2
 setBroadcastAddress	KEYWORD2

--- a/src/modules/SX127x/SX127x.cpp
+++ b/src/modules/SX127x/SX127x.cpp
@@ -669,6 +669,22 @@ float SX127x::getFrequencyError(bool autoCorrect) {
   return(ERR_UNKNOWN);
 }
 
+float SX127x::getAFCError()
+{
+  // check active modem
+  int16_t modem = getActiveModem();
+  if(modem != SX127X_FSK_OOK) {
+    return 0;
+  }
+
+  // get raw frequency error
+  int16_t raw = (uint16_t)_mod->SPIgetRegValue(SX127X_REG_AFC_MSB) << 8;
+  raw |= _mod->SPIgetRegValue(SX127X_REG_AFC_LSB);
+
+  uint32_t base = 1;
+  return raw * (32000000.0 / (float)(base << 19));
+}
+
 float SX127x::getSNR() {
   // check active modem
   if(getActiveModem() != SX127X_LORA) {

--- a/src/modules/SX127x/SX127x.cpp
+++ b/src/modules/SX127x/SX127x.cpp
@@ -84,8 +84,8 @@ int16_t SX127x::beginFSK(uint8_t chipVersion, float br, float freqDev, float rxB
   state = SX127x::setBitRate(br);
   RADIOLIB_ASSERT(state);
 
-  // set receiver bandwidth
-  state = SX127x::setRxBandwidth(rxBw);
+  // set frequency deviation
+  state = SX127x::setFrequencyDeviation(freqDev);
   RADIOLIB_ASSERT(state);
 
   //set AFC bandwidth
@@ -1219,7 +1219,7 @@ bool SX127x::findChip(uint8_t ver) {
 }
 
 int16_t SX127x::setMode(uint8_t mode) {
-  return(_mod->SPIsetRegValue(SX127X_REG_OP_MODE, mode, 2, 0, 5));
+  return(_mod->SPIsetRegValue(SX127X_REG_OP_MODE, mode, 2, 0, 2));
 }
 
 int16_t SX127x::getActiveModem() {

--- a/src/modules/SX127x/SX127x.cpp
+++ b/src/modules/SX127x/SX127x.cpp
@@ -678,8 +678,8 @@ float SX127x::getAFCError()
   }
 
   // get raw frequency error
-  int16_t raw = (uint16_t)_mod->SPIgetRegValue(SX127X_REG_AFC_MSB) << 8;
-  raw |= _mod->SPIgetRegValue(SX127X_REG_AFC_LSB);
+  int16_t raw = (uint16_t)_mod->SPIreadRegister(SX127X_REG_AFC_MSB) << 8;
+  raw |= _mod->SPIreadRegister(SX127X_REG_AFC_LSB);
 
   uint32_t base = 1;
   return raw * (32000000.0 / (float)(base << 19));
@@ -758,7 +758,7 @@ int16_t SX127x::setFrequencyDeviation(float freqDev) {
   return(state);
 }
 
-uint8_t SX127x::calculateBWManExp(float bandwidth) const
+uint8_t SX127x::calculateBWManExp(float bandwidth)
 {
   for(uint8_t e = 7; e >= 1; e--) {
     for(int8_t m = 2; m >= 0; m--) {

--- a/src/modules/SX127x/SX127x.cpp
+++ b/src/modules/SX127x/SX127x.cpp
@@ -1219,7 +1219,7 @@ bool SX127x::findChip(uint8_t ver) {
 }
 
 int16_t SX127x::setMode(uint8_t mode) {
-  return(_mod->SPIsetRegValue(SX127X_REG_OP_MODE, mode, 2, 0, 2));
+  return(_mod->SPIsetRegValue(SX127X_REG_OP_MODE, mode, 2, 0, 5));
 }
 
 int16_t SX127x::getActiveModem() {

--- a/src/modules/SX127x/SX127x.h
+++ b/src/modules/SX127x/SX127x.h
@@ -824,6 +824,24 @@ class SX127x: public PhysicalLayer {
     int16_t setAFCBandwidth(float afcBw);
 
     /*!
+      \brief Enables or disables FSK automatic frequency correction(AFC)
+
+      \param isEnabled AFC enabled or disabled
+
+      \return \ref status_codes
+    */
+    int16_t setAFC(bool isEnabled);
+
+    /*!
+      \brief Controls trigger of AFC and AGC
+
+      \param trigger one from SX127X_RX_TRIGGER_NONE, SX127X_RX_TRIGGER_RSSI_INTERRUPT, SX127X_RX_TRIGGER_PREAMBLE_DETECT, SX127X_RX_TRIGGER_BOTH
+
+      \return \ref status_codes
+    */
+    int16_t setAFCAGCTrigger(uint8_t trigger);
+
+    /*!
       \brief Sets FSK sync word. Allowed sync words are up to 8 bytes long and can not contain null bytes. Only available in FSK mode.
 
       \param syncWord Sync word array.

--- a/src/modules/SX127x/SX127x.h
+++ b/src/modules/SX127x/SX127x.h
@@ -774,6 +774,13 @@ class SX127x: public PhysicalLayer {
     float getFrequencyError(bool autoCorrect = false);
 
     /*!
+      \brief Gets current AFC error.
+
+      \returns Frequency offset from RF in Hz if AFC is enabled and triggered, zero otherwise.
+    */
+    float getAFCError();
+
+    /*!
       \brief Gets signal-to-noise ratio of the latest received packet.
 
       \returns Last packet signal-to-noise ratio (SNR).

--- a/src/modules/SX127x/SX127x.h
+++ b/src/modules/SX127x/SX127x.h
@@ -815,6 +815,15 @@ class SX127x: public PhysicalLayer {
     int16_t setRxBandwidth(float rxBw);
 
     /*!
+      \brief Sets FSK automatic frequency correction bandwidth. Allowed values range from 2.6 to 250 kHz. Only available in FSK mode.
+
+      \param rxBw Receiver AFC bandwidth to be set (in kHz).
+
+      \returns \ref status_codes
+    */
+    int16_t setAFCBandwidth(float afcBw);
+
+    /*!
       \brief Sets FSK sync word. Allowed sync words are up to 8 bytes long and can not contain null bytes. Only available in FSK mode.
 
       \param syncWord Sync word array.
@@ -993,7 +1002,7 @@ class SX127x: public PhysicalLayer {
     int16_t invertIQ(bool invertIQ);
 
 #if !defined(RADIOLIB_GODMODE) && !defined(RADIOLIB_LOW_LEVEL)
-  protected:
+protected:
 #endif
     Module* _mod;
 
@@ -1006,7 +1015,6 @@ class SX127x: public PhysicalLayer {
     uint8_t _sf = 0;
     uint8_t _cr = 0;
     float _br = 0;
-    float _rxBw = 0;
     bool _ook = false;
     bool _crcEnabled = false;
     size_t _packetLength = 0;
@@ -1030,6 +1038,14 @@ class SX127x: public PhysicalLayer {
     int16_t setActiveModem(uint8_t modem);
     void clearIRQFlags();
     void clearFIFO(size_t count); // used mostly to clear remaining bytes in FIFO after a packet read
+    /**
+     * @brief Calculate exponent and mantissa values for receiver bandwidth and AFC
+     *
+     * \param bandwidth bandwidth to be set (in kHz).
+     *
+     * \returns bandwidth in manitsa and exponent format
+     */
+    uint8_t calculateBWManExp(float bandwidth) const;
 };
 
 #endif

--- a/src/modules/SX127x/SX127x.h
+++ b/src/modules/SX127x/SX127x.h
@@ -1070,7 +1070,7 @@ class SX127x: public PhysicalLayer {
      *
      * \returns bandwidth in manitsa and exponent format
      */
-    uint8_t calculateBWManExp(float bandwidth) const;
+    static uint8_t calculateBWManExp(float bandwidth);
 };
 
 #endif

--- a/src/modules/SX127x/SX127x.h
+++ b/src/modules/SX127x/SX127x.h
@@ -1020,7 +1020,7 @@ class SX127x: public PhysicalLayer {
     int16_t invertIQ(bool invertIQ);
 
 #if !defined(RADIOLIB_GODMODE) && !defined(RADIOLIB_LOW_LEVEL)
-protected:
+  protected:
 #endif
     Module* _mod;
 


### PR DESCRIPTION
With this patch, a AFC works pretty well and could be fully user-controlled. There is however a **glitch** calling ```SX127x::receiveDirect()``` ends always with an error -16. Setting SX127X_RX(0b00000101) *doesn't* work.

It has to be set to ```0b00000101``` in order to start RX, but it's not stored even after a maximal timeout! When setting just ```0b00000100``` (RSRx) the receiver is (obviously) not started but the SPI Write succeeds.  

I would suggest returning always true from ```int16_t SX127x::setMode(uint8_t mode)``` but it's an API change and not sure of possible implications.