### PR TITLE
Add assign a class method as an interrupt handler

### DIFF
--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -374,6 +374,10 @@ void Module::attachInterrupt(RADIOLIB_PIN_TYPE interruptNum, void (*userFunc)(vo
   ::attachInterrupt(interruptNum, userFunc, mode);
 }
 
+void Module::attachInterrupt(RADIOLIB_PIN_TYPE interruptNum, std::function<void(void)> userFunc, RADIOLIB_INTERRUPT_STATUS mode) {
+  ::attachInterrupt(interruptNum, userFunc, mode);
+}
+
 void Module::detachInterrupt(RADIOLIB_PIN_TYPE interruptNum) {
   ::detachInterrupt(interruptNum);
 }

--- a/src/Module.h
+++ b/src/Module.h
@@ -2,6 +2,9 @@
 #define _RADIOLIB_MODULE_H
 
 #include "TypeDef.h"
+#include <functional>
+#include <FunctionalInterrupt.h>
+
 
 #include <SPI.h>
 #ifndef RADIOLIB_SOFTWARE_SERIAL_UNSUPPORTED
@@ -432,6 +435,7 @@ class Module {
     */
     static void attachInterrupt(RADIOLIB_PIN_TYPE interruptNum, void (*userFunc)(void), RADIOLIB_INTERRUPT_STATUS mode);
 
+    static void attachInterrupt(RADIOLIB_PIN_TYPE interruptNum, std::function<void(void)> userFunc, RADIOLIB_INTERRUPT_STATUS mode);
     /*!
       \brief Arduino core detachInterrupt override.
 

--- a/src/modules/SX127x/SX127x.cpp
+++ b/src/modules/SX127x/SX127x.cpp
@@ -414,6 +414,10 @@ void SX127x::setDio0Action(void (*func)(void)) {
   Module::attachInterrupt(RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(_mod->getIrq()), func, RISING);
 }
 
+void SX127x::setDio0Action(std::function<void(void)> func) {
+  Module::attachInterrupt(RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(_mod->getIrq()), func, RISING);
+}
+
 void SX127x::clearDio0Action() {
   Module::detachInterrupt(RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(_mod->getIrq()));
 }

--- a/src/modules/SX127x/SX127x.h
+++ b/src/modules/SX127x/SX127x.h
@@ -1,6 +1,7 @@
 #if !defined(_RADIOLIB_SX127X_H)
 #define _RADIOLIB_SX127X_H
 
+#include <functional>
 #include "../../TypeDef.h"
 
 #if !defined(RADIOLIB_EXCLUDE_SX127X)
@@ -681,6 +682,9 @@ class SX127x: public PhysicalLayer {
       \param func Pointer to interrupt service routine.
     */
     void setDio0Action(void (*func)(void));
+
+
+    void setDio0Action(std::function<void(void)> func);
 
     /*!
       \brief Clears interrupt service routine to call when DIO0 activates.


### PR DESCRIPTION
The intention is to be able to execute code inside of a class with access to the instance data when a packet is received.