### PR TITLE
Fix issue #357.

### DIFF
--- a/src/modules/CC1101/CC1101.cpp
+++ b/src/modules/CC1101/CC1101.cpp
@@ -97,13 +97,13 @@ int16_t CC1101::begin(float freq, float br, float freqDev, float rxBw, int8_t po
 
 void CC1101::reattachGdo0Interrupt()
 {
-    if (gdo0action != nullptr)
-        Module::attachInterrupt(RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(_mod->getIrq()), gdo0action, gdo0dir);
+  if (gdo0action != nullptr)
+    Module::attachInterrupt(RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(_mod->getIrq()), gdo0action, gdo0dir);
 }
 
 static void handleTxInterrupt(void)
 {
-    return;
+  return;
 }
 
 
@@ -111,7 +111,7 @@ int16_t CC1101::transmit(uint8_t* data, size_t len, uint8_t addr) {
   // calculate timeout (5ms + 500 % of expected time-on-air)
   uint32_t timeout = 5000000 + (uint32_t)((((float)(len * 8)) / (_br * 1000.0)) * 5000000.0);
 
-    Module::attachInterrupt(RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(_mod->getIrq()), handleTxInterrupt, gdo0dir);
+  Module::attachInterrupt(RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(_mod->getIrq()), handleTxInterrupt, gdo0dir);
 
     // start transmission
   int16_t state = startTransmit(data, len, addr);
@@ -136,14 +136,14 @@ int16_t CC1101::transmit(uint8_t* data, size_t len, uint8_t addr) {
     Module::yield();
 
     if(Module::micros() - start > timeout) {
-        reattachGdo0Interrupt();
+      reattachGdo0Interrupt();
       standby();
       SPIsendCommand(CC1101_CMD_FLUSH_TX);
       return(ERR_TX_TIMEOUT);
     }
   }
 
-    reattachGdo0Interrupt();
+  reattachGdo0Interrupt();
   // set mode to standby
   standby();
 
@@ -229,13 +229,13 @@ int16_t CC1101::packetMode() {
 }
 
 void CC1101::setGdo0Action(void (*func)(void), RADIOLIB_INTERRUPT_STATUS dir) {
-    gdo0action = func;
-    gdo0dir = dir;
+  gdo0action = func;
+  gdo0dir = dir;
   Module::attachInterrupt(RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(_mod->getIrq()), gdo0action, gdo0dir);
 }
 
 void CC1101::clearGdo0Action() {
-    gdo0action = nullptr;
+  gdo0action = nullptr;
   Module::detachInterrupt(RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(_mod->getIrq()));
 }
 

--- a/src/modules/CC1101/CC1101.h
+++ b/src/modules/CC1101/CC1101.h
@@ -947,10 +947,14 @@ class CC1101: public PhysicalLayer {
     uint8_t _syncWordLength = 2;
     int8_t _power = 0;
 
+    void (*gdo0action)(void)  = nullptr;
+    RADIOLIB_INTERRUPT_STATUS gdo0dir;
+
     int16_t config();
     int16_t directMode();
     static void getExpMant(float target, uint16_t mantOffset, uint8_t divExp, uint8_t expMax, uint8_t& exp, uint8_t& mant);
     int16_t setPacketMode(uint8_t mode, uint8_t len);
+    void reattachGdo0Interrupt();
 };
 
 #endif


### PR DESCRIPTION
Fix issue #357 as described in the issue report.
The fix simply change the interrupt handler as long as the transmit is completed, then restoring the original handler before returning.
