### PR TITLE
SX127X FSK Mode: transmit up to 256 bytes

### DIFF
--- a/examples/SX127x/SX127x_FSK_FIFO_Refill/SX127x_FSK_FIFO_Refill.ino
+++ b/examples/SX127x/SX127x_FSK_FIFO_Refill/SX127x_FSK_FIFO_Refill.ino
@@ -1,0 +1,83 @@
+/*
+   RadioLib SX127x FSK FIFO on-the-fly Refilling Example
+
+   This example shows how to use refill the FIFO buffer in SX127x chips, to allow for transmitting
+   FSK/OOK packets longer than 256 bytes.
+
+   For default module settings, see the wiki page
+   https://github.com/jgromes/RadioLib/wiki/Default-configuration#sx127xrfm9x---fsk-modem
+
+   For full API reference, see the GitHub Pages
+   https://jgromes.github.io/RadioLib/
+*/
+
+// include the library
+#include <RadioLib.h>
+
+// SX1276 has the following connections:
+// NSS pin:   8
+// DIO0 pin:  51
+// RESET pin: 22
+// DIO1 pin:  52
+SX1276 radio = new Module(8, 51, 22, 52);
+
+// or using RadioShield
+// https://github.com/jgromes/RadioShield
+//SX1278 fsk = RadioShield.ModuleA;
+
+uint8_t syncWord[] = { 0x91, 0xD3, 0x91, 0xD3 };
+
+char* msg = "This is just some message that extends well beyond the 64 bytes limit of the FIFO";
+size_t msg_length;
+size_t msg_counter;
+
+// this interrupt is called whenever the FIFO buffer falls below a certain threshold
+void fifoRefill() {
+  msg_counter += radio.fifoAppend(
+    (uint8_t*)msg + msg_counter,    // start of message, offset by # of bytes already sent
+    msg_length - msg_counter        // # of bytes left to send
+  );
+}
+
+void setup() {
+  Serial.begin(9600);
+
+  // RF switch for my board
+  pinMode(47, OUTPUT);
+
+  // initialize SX1278 FSK modem with default settings
+  Serial.print(F("[SX1276] Initializing ... "));
+  int state = radio.beginFSK();
+  if (state == ERR_NONE) {
+    Serial.println(F("success!"));
+  } else {
+    Serial.print(F("failed, code "));
+    Serial.println(state);
+    while (true);
+  }
+
+  // Set config options
+  radio.setDataShaping(RADIOLIB_SHAPING_NONE);
+  radio.setSyncWord(syncWord, sizeof(syncWord));
+  radio.setEncoding(RADIOLIB_ENCODING_WHITENING);
+  radio.setCRC(true);
+
+  // Set up FIFO operations
+  radio.setFifoThreshold(16);
+  radio.setFifoThresholdAction(fifoRefill);
+}
+
+void loop() {
+
+  radio.variablePacketLengthMode();
+
+  // set RF switch to TX mode
+  digitalWrite(47, LOW);
+
+  // start transmission of message
+  msg_length = strlen(msg);
+  radio.startTransmit((uint8_t*)msg, msg_length, msg_counter);
+  while (msg_counter != msg_length);
+
+  Serial.println("[SX1276] Done transmitting");
+}

--- a/src/modules/SX127x/SX127x.cpp
+++ b/src/modules/SX127x/SX127x.cpp
@@ -472,15 +472,6 @@ int16_t SX127x::startTransmit(uint8_t* data, size_t len, uint8_t addr) {
     state |= _mod->SPIsetRegValue(SX127X_REG_FIFO_TX_BASE_ADDR, SX127X_FIFO_TX_BASE_ADDR_MAX);
     state |= _mod->SPIsetRegValue(SX127X_REG_FIFO_ADDR_PTR, SX127X_FIFO_TX_BASE_ADDR_MAX);
 
-    // write packet to FIFO
-    _mod->SPIwriteRegisterBurst(SX127X_REG_FIFO, data, len);
-
-    // set RF switch (if present)
-    _mod->setRfSwitchState(LOW, HIGH);
-
-    // start transmission
-    state |= setMode(SX127X_TX);
-
   } else if(modem == SX127X_FSK_OOK) {
     // check packet length
     if(len >= SX127X_MAX_PACKET_LENGTH_FSK) {
@@ -503,29 +494,16 @@ int16_t SX127x::startTransmit(uint8_t* data, size_t len, uint8_t addr) {
     if((filter == SX127X_ADDRESS_FILTERING_NODE) || (filter == SX127X_ADDRESS_FILTERING_NODE_BROADCAST)) {
       _mod->SPIwriteRegister(SX127X_REG_FIFO, addr);
     }
-    
-    // Pre-load the FIFO with message before entering TX mode
-    uint8_t* ind = data;
-    _mod->SPIwriteRegisterBurst(SX127X_REG_FIFO, ind, min(len, 64));
-    ind += min(len, 64);
-
-    // set RF switch (if present) and start transmitting
-    _mod->setRfSwitchState(LOW, HIGH);
-    state |= setMode(SX127X_TX);
-
-    // Re-fill the FIFO on-the-fly as bytes are transmitted
-    while (ind < data + len) {
-      uint16_t flags = getIRQFlags();
-      bool fifo_full = flags >> 15;
-
-      // If FIFO not full, write another byte
-      if (!fifo_full) {
-        _mod->SPIwriteRegister(SX127X_REG_FIFO, *ind);
-        ind++;
-      }
-    }
   }
 
+  // write packet to FIFO
+  _mod->SPIwriteRegisterBurst(SX127X_REG_FIFO, data, len);
+
+  // set RF switch (if present)
+  _mod->setRfSwitchState(LOW, HIGH);
+
+  // start transmission
+  state |= setMode(SX127X_TX);
   RADIOLIB_ASSERT(state);
 
   return(ERR_NONE);

--- a/src/modules/SX127x/SX127x.h
+++ b/src/modules/SX127x/SX127x.h
@@ -12,7 +12,7 @@
 // SX127x physical layer properties
 #define SX127X_FREQUENCY_STEP_SIZE                    61.03515625
 #define SX127X_MAX_PACKET_LENGTH                      255
-#define SX127X_MAX_PACKET_LENGTH_FSK                  255
+#define SX127X_MAX_PACKET_LENGTH_FSK                  64
 #define SX127X_CRYSTAL_FREQ                           32.0
 #define SX127X_DIV_EXPONENT                           19
 
@@ -601,7 +601,7 @@ class SX127x: public PhysicalLayer {
     int16_t beginFSK(uint8_t chipVersion, float br, float freqDev, float rxBw, uint16_t preambleLength, bool enableOOK);
 
     /*!
-      \brief Binary transmit method. Will transmit arbitrary binary data up to 255 bytes long.
+      \brief Binary transmit method. Will transmit arbitrary binary data up to 255 bytes long using %LoRa or up to 63 bytes using FSK modem.
       For overloads to transmit Arduino String or C-string, see PhysicalLayer::transmit.
 
       \param data Binary data that will be transmitted.

--- a/src/modules/SX127x/SX127x.h
+++ b/src/modules/SX127x/SX127x.h
@@ -12,7 +12,7 @@
 // SX127x physical layer properties
 #define SX127X_FREQUENCY_STEP_SIZE                    61.03515625
 #define SX127X_MAX_PACKET_LENGTH                      255
-#define SX127X_MAX_PACKET_LENGTH_FSK                  64
+#define SX127X_MAX_PACKET_LENGTH_FSK                  255
 #define SX127X_CRYSTAL_FREQ                           32.0
 #define SX127X_DIV_EXPONENT                           19
 
@@ -601,7 +601,7 @@ class SX127x: public PhysicalLayer {
     int16_t beginFSK(uint8_t chipVersion, float br, float freqDev, float rxBw, uint16_t preambleLength, bool enableOOK);
 
     /*!
-      \brief Binary transmit method. Will transmit arbitrary binary data up to 255 bytes long using %LoRa or up to 63 bytes using FSK modem.
+      \brief Binary transmit method. Will transmit arbitrary binary data up to 255 bytes long.
       For overloads to transmit Arduino String or C-string, see PhysicalLayer::transmit.
 
       \param data Binary data that will be transmitted.

--- a/src/modules/SX127x/SX127x.h
+++ b/src/modules/SX127x/SX127x.h
@@ -714,14 +714,16 @@ class SX127x: public PhysicalLayer {
     int16_t startTransmit(uint8_t* data, size_t len, uint8_t addr = 0) override;
 
     /*!
-      \brief Interrupt-driven binary transmit method. Will start transmitting arbitrary binary data up to 255 bytes long using %LoRa or up to 255 bytes using FSK modem.
+      \brief Interrupt-driven binary transmit method. Will start transmitting
+          arbitrary binary data up to 255 bytes long using %LoRa or FSK modem.
       \param data Binary data that will be transmitted.
       \param len Length of binary data to transmit (in bytes).
-      \param[out] counter Reference to a variable to track the number of sent bytes in
+      \param counter Reference to a counter variable to track the number of
+          bytes read from `data` into the FIFO
       \param addr Node address to transmit the packet to. Only used in FSK mode.
       \returns \ref status_codes
     */
-    int16_t startTransmit(uint8_t* data, size_t len, size_t&& counter, uint8_t addr = 0) override;
+    int16_t startTransmit(uint8_t* data, size_t len, size_t& counter, uint8_t addr = 0) override;
 
     /*!
       \brief Interrupt-driven receive method. DIO0 will be activated when full valid packet is received.
@@ -964,7 +966,19 @@ class SX127x: public PhysicalLayer {
     */
     int16_t setFifoThreshold(uint8_t cap = 16);
     void setFifoThresholdAction(void (*func)(void)) override;
-    int fifoAppend(uint8_t* buff, size_t remaining) override;
+
+    /**
+     * \brief Append additional data into the FIFO buffer
+     * \param buff Pointer to the start of the message buffer
+     * \param len The length of the message buffer
+     * \param counter A reference to a persistent counter variable
+     * \return int 
+     * 
+     * `buff` and `len` should be the same values used when calling
+     * startTransmit(), and `counter` should be a reference to a variable which
+     * persists for the duration of the transmission.
+     */
+    int fifoAppend(uint8_t* buff, size_t len, size_t& counter) override;
     int fifoGet(uint8_t* buff, size_t remaining) override;
 
     /*!

--- a/src/protocols/PhysicalLayer/PhysicalLayer.h
+++ b/src/protocols/PhysicalLayer/PhysicalLayer.h
@@ -143,10 +143,11 @@ class PhysicalLayer {
       \brief Interrupt-driven binary transmit method.
       \param data Binary data that will be transmitted.
       \param len Length of binary data to transmit (in bytes).
-      \param[out] counter Reference to a variable to track the number of bytes sent in.
+      \param counter Reference to a counter variable to track the number of
+          bytes read from `data` into the FIFO
       \param addr Node address to transmit the packet to. Only used in FSK mode.
     */
-    virtual int16_t startTransmit(uint8_t* data, size_t len, size_t&& counter, uint8_t add = 0) = 0;
+    virtual int16_t startTransmit(uint8_t* data, size_t len, size_t& counter, uint8_t addr = 0) = 0;
 
     /*!
       \brief Set the ISR routine to execute when the FIFO falls below the threshold.
@@ -157,16 +158,19 @@ class PhysicalLayer {
     */
     virtual void setFifoThresholdAction(void (*func)(void)) = 0;
 
-    /*!
-      \brief Append more data into the FIFO Buffer
-
-      This is used for stream-based transmissions.
-
-      \param buff A pointer to the start of the data to append
-      \param remaining A pointer to a counter variable
-      \return Number of bytes consumed from `buff`, or error code.
-    */
-    virtual int16_t fifoAppend(uint8_t* buff, size_t remaining) = 0;
+    /**
+     * \brief Append more data into the FIFO buffer
+     * \param buff Pointer to the start of the message buffer
+     * \param len The length of the message buffer
+     * \param counter A reference to a persistent counter variable
+     * \return int 
+     * 
+     * `buff` and `len` should be the same values used when calling
+     * startTransmit(), and `counter` should be a reference to a variable which
+     * persists for the duration of the transmission (i.e. not local to the
+     * interrupt).
+     */
+    virtual int16_t fifoAppend(uint8_t* buff, size_t msg_len, size_t& counter) = 0;
 
     /*!
       \brief Read data from the FIFO buffer.

--- a/src/protocols/PhysicalLayer/PhysicalLayer.h
+++ b/src/protocols/PhysicalLayer/PhysicalLayer.h
@@ -140,6 +140,43 @@ class PhysicalLayer {
     virtual int16_t startTransmit(uint8_t* data, size_t len, uint8_t addr = 0) = 0;
 
     /*!
+      \brief Interrupt-driven binary transmit method.
+      \param data Binary data that will be transmitted.
+      \param len Length of binary data to transmit (in bytes).
+      \param[out] counter Reference to a variable to track the number of bytes sent in.
+      \param addr Node address to transmit the packet to. Only used in FSK mode.
+    */
+    virtual int16_t startTransmit(uint8_t* data, size_t len, size_t&& counter, uint8_t add = 0) = 0;
+
+    /*!
+      \brief Set the ISR routine to execute when the FIFO falls below the threshold.
+
+      This interrupt will only be called when transmitting a message larger than the FIFO capacity.
+
+      \param func Pointer to an Interrupt Service Routine. `NULL` will clear action.
+    */
+    virtual void setFifoThresholdAction(void (*func)(void)) = 0;
+
+    /*!
+      \brief Append more data into the FIFO Buffer
+
+      This is used for stream-based transmissions.
+
+      \param buff A pointer to the start of the data to append
+      \param remaining A pointer to a counter variable
+      \return Number of bytes consumed from `buff`, or error code.
+    */
+    virtual int16_t fifoAppend(uint8_t* buff, size_t remaining) = 0;
+
+    /*!
+      \brief Read data from the FIFO buffer.
+      \param buff the buffer to read data into
+      \param available the maximum number of bytes available in `buff`
+      \return Number of bytes read in from FIFO, or error code.
+    */
+    virtual int16_t fifoGet(uint8_t* buff, size_t available) = 0;
+
+    /*!
       \brief Reads data that was received after calling startReceive method.
 
       \param str Address of Arduino String to save the received data.


### PR DESCRIPTION
The datasheet describes an "on-the-fly" method of refilling the FIFO buffer when transmitting in FSK mode, which allows for FSK packets up to 256 bytes long. I made small tweaks to the `SX127X::transmit` method to handle this case.

I am not familiar `yield()`, but this implementation will capture control and just sit in a loop until all of a message has been pushed into the FIFO, which I suspect might not be fantastic.