### PR TITLE
Add setOokPeakThresholdStep method

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -136,6 +136,7 @@ invertIQ    KEYWORD2
 setOokThresholdType	KEYWORD2
 setOokPeakThresholdDecrement	KEYWORD2
 setOokFixedOrFloorThreshold	KEYWORD2
+setOokPeakThresholdStep KEYWORD2
 setDirectSyncWord	KEYWORD2
 setDirectAction	KEYWORD2
 readBit	KEYWORD2

--- a/src/modules/SX127x/SX127x.cpp
+++ b/src/modules/SX127x/SX127x.cpp
@@ -948,6 +948,14 @@ int16_t SX127x::setOokPeakThresholdDecrement(uint8_t value) {
   return(_mod->SPIsetRegValue(RADIOLIB_SX127X_REG_OOK_AVG, value, 7, 5, 5));
 }
 
+int16_t SX127x::setOokPeakThresholdStep(uint8_t value) {
+  // check active modem
+  if(getActiveModem() != RADIOLIB_SX127X_FSK_OOK) {
+    return(RADIOLIB_ERR_WRONG_MODEM);
+  }
+  return(_mod->SPIsetRegValue(RADIOLIB_SX127X_REG_OOK_PEAK, value, 2, 0, 5));
+}
+
 int16_t SX127x::enableBitSync() {
   return(_mod->SPIsetRegValue(RADIOLIB_SX127X_REG_OOK_PEAK, RADIOLIB_SX127X_BIT_SYNC_ON, 5, 5, 5));
 }

--- a/src/modules/SX127x/SX127x.h
+++ b/src/modules/SX127x/SX127x.h
@@ -930,6 +930,15 @@ class SX127x: public PhysicalLayer {
     */
     int16_t setOokFixedOrFloorThreshold(uint8_t value);
 
+      /*!
+      \brief Size of each decrement of the RSSI threshold in the OOK demodulator.
+
+      \param value Step size: RADIOLIB_SX127X_OOK_PEAK_THRESH_STEP_0_5_DB (default), RADIOLIB_SX127X_OOK_PEAK_THRESH_STEP_1_0_DB, RADIOLIB_SX127X_OOK_PEAK_THRESH_STEP_1_5_DB, RADIOLIB_SX127X_OOK_PEAK_THRESH_STEP_2_0_DB, RADIOLIB_SX127X_OOK_PEAK_THRESH_STEP_3_0_DB, RADIOLIB_SX127X_OOK_PEAK_THRESH_STEP_4_0_DB, RADIOLIB_SX127X_OOK_PEAK_THRESH_STEP_5_0_DB, RADIOLIB_SX127X_OOK_PEAK_THRESH_STEP_6_0_DB  
+
+      \returns \ref status_codes
+    */
+    int16_t setOokPeakThresholdStep(uint8_t value);  
+  
     /*!
     \brief Enable Bit synchronizer.
 


### PR DESCRIPTION
Needed to optimize the OOK Demodulator for Fast Fading Signals.  