### PR TITLE
Fix: Si4432 interrupt examples

### DIFF
--- a/examples/Si443x/Si443x_Receive_Interrupt/Si443x_Receive_Interrupt.ino
+++ b/examples/Si443x/Si443x_Receive_Interrupt/Si443x_Receive_Interrupt.ino
@@ -76,6 +76,9 @@ volatile bool enableInterrupt = true;
 // is received by the module
 // IMPORTANT: this function MUST be 'void' type
 //            and MUST NOT have any arguments!
+#ifdef ESP8266
+  ICACHE_RAM_ATTR
+#endif
 void setFlag(void) {
   // check if the interrupt is enabled
   if(!enableInterrupt) {

--- a/examples/Si443x/Si443x_Transmit_Interrupt/Si443x_Transmit_Interrupt.ino
+++ b/examples/Si443x/Si443x_Transmit_Interrupt/Si443x_Transmit_Interrupt.ino
@@ -75,6 +75,9 @@ volatile bool enableInterrupt = true;
 // is transmitted by the module
 // IMPORTANT: this function MUST be 'void' type
 //            and MUST NOT have any arguments!
+#ifdef ESP8266
+  ICACHE_RAM_ATTR
+#endif
 void setFlag(void) {
   // check if the interrupt is enabled
   if(!enableInterrupt) {


### PR DESCRIPTION
Added ICACHE_RAM_ATTR macro to Si4432 interrupt examples when compiling for ESP8266.

Fixes #434