### PR TITLE
Correct typos in explicit/implicitHeader functions. 

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -146,6 +146,9 @@ setFHSSHoppingPeriod	KEYWORD2
 getFHSSHoppingPeriod	KEYWORD2
 getFHSSChannel	KEYWORD2
 clearFHSSInt	KEYWORD2
+randomByte	KEYWORD2
+getPacketLength
+
 
 # RF69-specific
 setAESKey	KEYWORD2

--- a/keywords.txt
+++ b/keywords.txt
@@ -147,7 +147,7 @@ getFHSSHoppingPeriod	KEYWORD2
 getFHSSChannel	KEYWORD2
 clearFHSSInt	KEYWORD2
 randomByte	KEYWORD2
-getPacketLength
+getPacketLength	KEYWORD2
 
 
 # RF69-specific

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -827,7 +827,9 @@ class SX126x: public PhysicalLayer {
    float getRSSIInst();
 
    /*!
-     \brief Set implicit header mode for future reception/transmission.
+     \brief Set implicit header mode for future reception/transmission. Required for spreading factor 6.
+
+     \param len Payload length in bytes.
 
      \returns \ref status_codes
    */
@@ -835,8 +837,6 @@ class SX126x: public PhysicalLayer {
 
    /*!
      \brief Set explicit header mode for future reception/transmission.
-
-     \param len Payload length in bytes.
 
      \returns \ref status_codes
    */

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -827,7 +827,7 @@ class SX126x: public PhysicalLayer {
    float getRSSIInst();
 
    /*!
-     \brief Set implicit header mode for future reception/transmission. Required for spreading factor 6.
+     \brief Set implicit header mode for future reception/transmission.
 
      \param len Payload length in bytes.
 

--- a/src/modules/SX127x/SX1272.h
+++ b/src/modules/SX127x/SX1272.h
@@ -278,7 +278,9 @@ class SX1272: public SX127x {
     int16_t autoLDRO();
 
     /*!
-      \brief Set implicit header mode for future reception/transmission.
+     \brief Set implicit header mode for future reception/transmission. Required for spreading factor 6.
+
+      \param len Payload length in bytes.
 
       \returns \ref status_codes
     */
@@ -286,8 +288,6 @@ class SX1272: public SX127x {
 
     /*!
       \brief Set explicit header mode for future reception/transmission.
-
-      \param len Payload length in bytes.
 
       \returns \ref status_codes
     */

--- a/src/modules/SX127x/SX1278.h
+++ b/src/modules/SX127x/SX1278.h
@@ -287,7 +287,9 @@ class SX1278: public SX127x {
     int16_t autoLDRO();
 
     /*!
-      \brief Set implicit header mode for future reception/transmission.
+     \brief Set implicit header mode for future reception/transmission. Required for spreading factor 6.
+
+      \param len Payload length in bytes.
 
       \returns \ref status_codes
     */
@@ -295,8 +297,6 @@ class SX1278: public SX127x {
 
     /*!
       \brief Set explicit header mode for future reception/transmission.
-
-      \param len Payload length in bytes.
 
       \returns \ref status_codes
     */


### PR DESCRIPTION
The docs for [explicit](https://jgromes.github.io/RadioLib/class_s_x1272.html#ae3c9704cb58232f696b5f90f69c115f7)/implicitHeader were very confusing until I realized it's a typo. PR fixes the typo.

I added a few missing keywords that I thought were important enough to be included. There are a lot of functions missing from keywords.txt. I didn't add them all because I'm not sure what your criteria was for inclusion. 