### PR TITLE
Fix >= to allow 255 bytes on SX1276

### DIFF
--- a/src/modules/SX127x/SX127x.cpp
+++ b/src/modules/SX127x/SX127x.cpp
@@ -448,7 +448,7 @@ int16_t SX127x::startTransmit(uint8_t* data, size_t len, uint8_t addr) {
   int16_t modem = getActiveModem();
   if(modem == RADIOLIB_SX127X_LORA) {
     // check packet length
-    if(len >= RADIOLIB_SX127X_MAX_PACKET_LENGTH) {
+    if(len > RADIOLIB_SX127X_MAX_PACKET_LENGTH) {
       return(RADIOLIB_ERR_PACKET_TOO_LONG);
     }
 


### PR DESCRIPTION
Just because PRs are gravy.