### PR TITLE
Introduce asynchronous reception and transmission for CC1101

### DIFF
--- a/src/modules/CC1101/CC1101.h
+++ b/src/modules/CC1101/CC1101.h
@@ -592,6 +592,22 @@ class CC1101: public PhysicalLayer {
     int16_t receiveDirect() override;
 
     /*!
+      \brief Starts asynchronous direct mode transmission.
+
+      \param frf Raw RF frequency value. Defaults to 0, required for quick frequency shifts in RTTY.
+
+      \returns \ref status_codes
+    */
+    int16_t transmitDirectAsync(uint32_t frf = 0);
+
+    /*!
+      \brief Starts asynchronous direct mode reception.
+
+      \returns \ref status_codes
+    */
+    int16_t receiveDirectAsync();
+
+    /*!
       \brief Stops direct mode. It is required to call this method to switch from direct transmissions to packet-based transmissions.
     */
     int16_t packetMode();
@@ -953,6 +969,7 @@ class CC1101: public PhysicalLayer {
 
     int16_t config();
     int16_t directMode();
+    int16_t asyncDirectMode();
     static void getExpMant(float target, uint16_t mantOffset, uint8_t divExp, uint8_t expMax, uint8_t& exp, uint8_t& mant);
     int16_t setPacketMode(uint8_t mode, uint16_t len);
 };

--- a/src/modules/CC1101/CC1101.h
+++ b/src/modules/CC1101/CC1101.h
@@ -968,8 +968,9 @@ class CC1101: public PhysicalLayer {
     int8_t _power = 0;
 
     int16_t config();
-    int16_t directMode();
-    int16_t asyncDirectMode();
+    int16_t transmitDirect(bool sync, uint32_t frf);
+    int16_t receiveDirect(bool sync);
+    int16_t directMode(bool sync);
     static void getExpMant(float target, uint16_t mantOffset, uint8_t divExp, uint8_t expMax, uint8_t& exp, uint8_t& mant);
     int16_t setPacketMode(uint8_t mode, uint16_t len);
 };


### PR DESCRIPTION
This allows using the asynchronous mode from the CC110, should a project need it for "raw" transmissions. This is most useful in projects that do timing and packet analysis by themselves, such as RFLink32 for instance.