### PR TITLE
[CC1101] Data shaping and encoding params in right order

### DIFF
--- a/src/modules/CC1101/CC1101.cpp
+++ b/src/modules/CC1101/CC1101.cpp
@@ -81,11 +81,11 @@ int16_t CC1101::begin(float freq, float br, float freqDev, float rxBw, int8_t po
   RADIOLIB_ASSERT(state);
 
   // set default data shaping
-  state = setDataShaping(RADIOLIB_ENCODING_NRZ);
+  state = setDataShaping(RADIOLIB_SHAPING_NONE);
   RADIOLIB_ASSERT(state);
 
   // set default encoding
-  state = setEncoding(RADIOLIB_SHAPING_NONE);
+  state = setEncoding(RADIOLIB_ENCODING_NRZ);
   RADIOLIB_ASSERT(state);
 
   // set default sync word


### PR DESCRIPTION
For some reason, the `RADIOLIB_SHAPING_NONE` was being passed to `setEncoding` and `RADIOLIB_ENCODING_NRZ` was being passed to `setDataShaping`. Flipped these to be passed to the correct functions.

Note: These are both defined as `0x00` so this should have no impact on functionality, just makes initialization less confusing.