### PR TITLE
[RF69] Set RX bandwidth correctly for OOK mode

### DIFF
--- a/src/modules/RF69/RF69.cpp
+++ b/src/modules/RF69/RF69.cpp
@@ -464,7 +464,7 @@ int16_t RF69::setRxBandwidth(float rxBw) {
   // calculate exponent and mantissa values for receiver bandwidth
   for(int8_t e = 7; e >= 0; e--) {
     for(int8_t m = 2; m >= 0; m--) {
-      float point = (RADIOLIB_RF69_CRYSTAL_FREQ * 1000000.0)/(((4 * m) + 16) * ((uint32_t)1 << (e + 2)));
+      float point = (RADIOLIB_RF69_CRYSTAL_FREQ * 1000000.0)/(((4 * m) + 16) * ((uint32_t)1 << (e + (_ook ? 3 : 2))));
       if(fabs(rxBw - (point / 1000.0)) <= 0.1) {
         // set Rx bandwidth
         state = _mod->SPIsetRegValue(RADIOLIB_RF69_REG_RX_BW, (m << 3) | e, 4, 0);

--- a/src/modules/RF69/RF69.cpp
+++ b/src/modules/RF69/RF69.cpp
@@ -9,7 +9,7 @@ Module* RF69::getMod() {
   return(_mod);
 }
 
-int16_t RF69::begin(float freq, float br, float freqDev, float rxBw, int8_t power, uint8_t preambleLen) {
+int16_t RF69::begin(float freq, float br, float freqDev, float rxBw, int8_t power, uint8_t preambleLen, bool enableOOK) {
   // set module properties
   _mod->init();
   _mod->pinMode(_mod->getIrq(), INPUT);
@@ -52,6 +52,10 @@ int16_t RF69::begin(float freq, float br, float freqDev, float rxBw, int8_t powe
 
   // configure settings not accessible by API
   int16_t state = config();
+  RADIOLIB_ASSERT(state);
+
+  // enable/disable OOK
+  state = setOOK(enableOOK);
   RADIOLIB_ASSERT(state);
 
   // configure publicly accessible settings

--- a/src/modules/RF69/RF69.cpp
+++ b/src/modules/RF69/RF69.cpp
@@ -9,7 +9,7 @@ Module* RF69::getMod() {
   return(_mod);
 }
 
-int16_t RF69::begin(float freq, float br, float freqDev, float rxBw, int8_t power, uint8_t preambleLen, bool enableOOK) {
+int16_t RF69::begin(float freq, float br, float freqDev, float rxBw, int8_t power, uint8_t preambleLen) {
   // set module properties
   _mod->init();
   _mod->pinMode(_mod->getIrq(), INPUT);
@@ -52,10 +52,6 @@ int16_t RF69::begin(float freq, float br, float freqDev, float rxBw, int8_t powe
 
   // configure settings not accessible by API
   int16_t state = config();
-  RADIOLIB_ASSERT(state);
-
-  // enable/disable OOK
-  state = setOOK(enableOOK);
   RADIOLIB_ASSERT(state);
 
   // configure publicly accessible settings
@@ -394,9 +390,13 @@ int16_t RF69::setOOK(bool enableOOK) {
   } else {
     state = _mod->SPIsetRegValue(RADIOLIB_RF69_REG_DATA_MODUL, RADIOLIB_RF69_FSK, 4, 3, 5);
   }
+
   if(state == RADIOLIB_ERR_NONE) {
     _ook = enableOOK;
   }
+
+  // call setRxBandwidth again, since register values differ based on OOK mode being enabled
+  state |= setRxBandwidth(_rxBw);
 
   return(state);
 }

--- a/src/modules/RF69/RF69.h
+++ b/src/modules/RF69/RF69.h
@@ -473,7 +473,7 @@ class RF69: public PhysicalLayer {
 
       \returns \ref status_codes
     */
-    int16_t begin(float freq = 434.0, float br = 4.8, float freqDev = 5.0, float rxBw = 125.0, int8_t power = 10, uint8_t preambleLen = 16);
+    int16_t begin(float freq = 434.0, float br = 4.8, float freqDev = 5.0, float rxBw = 125.0, int8_t power = 10, uint8_t preambleLen = 16, bool enableOOK = false);
 
     /*!
       \brief Reset method. Will reset the chip to the default state using RST pin.

--- a/src/modules/RF69/RF69.h
+++ b/src/modules/RF69/RF69.h
@@ -473,7 +473,7 @@ class RF69: public PhysicalLayer {
 
       \returns \ref status_codes
     */
-    int16_t begin(float freq = 434.0, float br = 4.8, float freqDev = 5.0, float rxBw = 125.0, int8_t power = 10, uint8_t preambleLen = 16, bool enableOOK = false);
+    int16_t begin(float freq = 434.0, float br = 4.8, float freqDev = 5.0, float rxBw = 125.0, int8_t power = 10, uint8_t preambleLen = 16);
 
     /*!
       \brief Reset method. Will reset the chip to the default state using RST pin.
@@ -744,6 +744,7 @@ class RF69: public PhysicalLayer {
 
     /*!
       \brief Enables/disables OOK modulation instead of FSK.
+       Note: This function calls setRxBandwidth again, since register values differ based on OOK mode being enabled/disabled
 
       \param enableOOK Enable (true) or disable (false) OOK.
 


### PR DESCRIPTION
The formula for calculating RX bandwidth on the RF69 differs depending on if you are in FSK mode or OOK mode (see datasheet section 3.4.6). 

This PR fixes RX bandwidth selection by using the correct exponent value when in OOK mode.

This bug was present prior to #498 being merged, but #498 makes it much easier to fix.