### PR TITLE
[RF69] Persist bit synchronization settings

### DIFF
--- a/src/modules/RF69/RF69.cpp
+++ b/src/modules/RF69/RF69.cpp
@@ -223,7 +223,11 @@ int16_t RF69::directMode() {
   RADIOLIB_ASSERT(state);
 
   // set continuous mode
-  return(_mod->SPIsetRegValue(RADIOLIB_RF69_REG_DATA_MODUL, RADIOLIB_RF69_CONTINUOUS_MODE_WITH_SYNC, 6, 5));
+  if(_bitSync) {
+    return(_mod->SPIsetRegValue(RADIOLIB_RF69_REG_DATA_MODUL, RADIOLIB_RF69_CONTINUOUS_MODE_WITH_SYNC, 6, 5));
+  } else {
+    return(_mod->SPIsetRegValue(RADIOLIB_RF69_REG_DATA_MODUL, RADIOLIB_RF69_CONTINUOUS_MODE, 6, 5));
+  }
 }
 
 int16_t RF69::packetMode() {
@@ -666,11 +670,21 @@ int16_t RF69::disableSyncWordFiltering() {
 }
 
 int16_t RF69::enableContinuousModeBitSync() {
-  return(_mod->SPIsetRegValue(RADIOLIB_RF69_REG_DATA_MODUL, RADIOLIB_RF69_CONTINUOUS_MODE_WITH_SYNC, 6, 5));
+  int16_t state = _mod->SPIsetRegValue(RADIOLIB_RF69_REG_DATA_MODUL, RADIOLIB_RF69_CONTINUOUS_MODE_WITH_SYNC, 6, 5);
+  if(state == RADIOLIB_ERR_NONE) {
+    _bitSync = true;
+  }
+
+  return(state);
 }
 
 int16_t RF69::disableContinuousModeBitSync() {
-  return(_mod->SPIsetRegValue(RADIOLIB_RF69_REG_DATA_MODUL, RADIOLIB_RF69_CONTINUOUS_MODE, 6, 5));
+  int16_t state = _mod->SPIsetRegValue(RADIOLIB_RF69_REG_DATA_MODUL, RADIOLIB_RF69_CONTINUOUS_MODE, 6, 5);
+  if(state == RADIOLIB_ERR_NONE) {
+    _bitSync = false;
+  }
+
+  return(state);
 }
 
 int16_t RF69::setCrcFiltering(bool crcOn) {

--- a/src/modules/RF69/RF69.h
+++ b/src/modules/RF69/RF69.h
@@ -942,6 +942,8 @@ class RF69: public PhysicalLayer {
 
     uint8_t _syncWordLength = 2;
 
+    bool _bitSync = true;
+
     int16_t config();
     int16_t directMode();
     int16_t setPacketMode(uint8_t mode, uint8_t len);


### PR DESCRIPTION
This PR persists `disableContinuousModeBitSync` or `enableContinuousModeBitSync` preferences so that any subsequent calls to `receiveDirect` respect the previously set bit sync preference. 

This is particularly important when building a protocol that uses continuous mode without bit sync, since we are interacting with the radio using `PhysicalLayer` methods and cannot always call `disableContinuousModeBitSync` after calling `receiveDirect`.

This PR defaults to bit sync "enabled" when calling `receiveDirect` to maintain the current behavior.