### PR TITLE
Allow SPIbeginTransaction and SPIendTransaction to be overridden by subclasses

### DIFF
--- a/src/Module.h
+++ b/src/Module.h
@@ -190,7 +190,7 @@ class Module {
 
       \param numBytes Number of bytes to transfer.
     */
-    virtual void SPItransfer(uint8_t cmd, uint8_t reg, uint8_t* dataOut, uint8_t* dataIn, uint8_t numBytes);
+    void SPItransfer(uint8_t cmd, uint8_t reg, uint8_t* dataOut, uint8_t* dataIn, uint8_t numBytes);
 
     // pin number access methods
 
@@ -361,9 +361,9 @@ class Module {
     // helper functions to set up SPI overrides on Arduino
     #if defined(RADIOLIB_BUILD_ARDUINO)
     void SPIbegin();
-    void SPIbeginTransaction();
+    virtual void SPIbeginTransaction();
     uint8_t SPItransfer(uint8_t b);
-    void SPIendTransaction();
+    virtual void SPIendTransaction();
     void SPIend();
     #endif
 

--- a/src/Module.h
+++ b/src/Module.h
@@ -190,7 +190,7 @@ class Module {
 
       \param numBytes Number of bytes to transfer.
     */
-    void SPItransfer(uint8_t cmd, uint8_t reg, uint8_t* dataOut, uint8_t* dataIn, uint8_t numBytes);
+    virtual void SPItransfer(uint8_t cmd, uint8_t reg, uint8_t* dataOut, uint8_t* dataIn, uint8_t numBytes);
 
     // pin number access methods
 


### PR DESCRIPTION
This allows API clients to provide 'smarter' versions of Module that can do things like add thread safety so that multiple devices (and service threads) can share the same SPI bus. i.e. a subclass would lock some sort of mutex.

This is used in the Radiolib Fork for Meshtastic to share an SPI bus with SD Card and TFT Display but we want to move back to upstream and not maintain our own fork.