### PR TITLE
Tweaks for async direct mode usage with rtl_433_ESP

### DIFF
--- a/src/modules/CC1101/CC1101.cpp
+++ b/src/modules/CC1101/CC1101.cpp
@@ -711,12 +711,25 @@ int16_t CC1101::setOOK(bool enableOOK) {
   return(setOutputPower(_power));
 }
 
-float CC1101::getRSSI() const {
+float CC1101::getRSSI() { 
   float rssi;
-  if(_rawRSSI >= 128) {
-    rssi = (((float)_rawRSSI - 256.0)/2.0) - 74.0;
+
+  if (_directMode) {
+    if(_rawRSSI >= 128) {
+      rssi = (((float)_rawRSSI - 256.0)/2.0) - 74.0;
+    } else {
+      rssi = (((float)_rawRSSI)/2.0) - 74.0;
+    }
   } else {
-    rssi = (((float)_rawRSSI)/2.0) - 74.0;
+    uint8_t rawRssi = SPIreadRegister(RADIOLIB_CC1101_REG_RSSI);
+    if (rawRssi >= 128)
+    {
+      rssi = ((rawRssi - 256) / 2) - 74;
+    }
+    else
+    {
+      rssi = (rawRssi / 2) - 74;
+    }
   }
   return(rssi);
 }
@@ -907,6 +920,7 @@ int16_t CC1101::directMode(bool sync) {
   SPIsendCommand(RADIOLIB_CC1101_CMD_IDLE);
 
   int16_t state = 0;
+  _directMode = sync;
   if (sync) {
     // set GDO0 and GDO2 mapping
   	state |= SPIsetRegValue(RADIOLIB_CC1101_REG_IOCFG0, RADIOLIB_CC1101_GDOX_SERIAL_CLOCK , 5, 0);

--- a/src/modules/CC1101/CC1101.h
+++ b/src/modules/CC1101/CC1101.h
@@ -791,9 +791,11 @@ class CC1101: public PhysicalLayer {
     /*!
       \brief Gets RSSI (Recorded Signal Strength Indicator) of the last received packet.
 
-      \returns Last packet RSSI in dBm.
+      or in asynchronous direct mode the current RSSI level
+
+      \returns RSSI in dBm.
     */
-    float getRSSI() const;
+    float getRSSI();
 
     /*!
       \brief Gets LQI (Link Quality Indicator) of the last received packet.
@@ -963,6 +965,7 @@ class CC1101: public PhysicalLayer {
 
     bool _promiscuous = false;
     bool _crcOn = true;
+    bool _directMode = true;
 
     uint8_t _syncWordLength = 2;
     int8_t _power = 0;

--- a/src/modules/SX127x/SX1278.cpp
+++ b/src/modules/SX127x/SX1278.cpp
@@ -297,7 +297,7 @@ int16_t SX1278::setGain(uint8_t gain) {
       // gain set to 0, enable AGC loop
       state |= _mod->SPIsetRegValue(RADIOLIB_SX127X_REG_RX_CONFIG, RADIOLIB_SX127X_AGC_AUTO_ON, 3, 3);
     } else {
-      state |= _mod->SPIsetRegValue(RADIOLIB_SX127X_REG_RX_CONFIG, RADIOLIB_SX127X_AGC_AUTO_ON, 3, 3);
+      state |= _mod->SPIsetRegValue(RADIOLIB_SX127X_REG_RX_CONFIG, RADIOLIB_SX1278_AGC_AUTO_OFF, 3, 3);
       state |= _mod->SPIsetRegValue(RADIOLIB_SX127X_REG_LNA, (gain << 5) | RADIOLIB_SX127X_LNA_BOOST_ON);
     }
 

--- a/src/modules/SX127x/SX127x.cpp
+++ b/src/modules/SX127x/SX127x.cpp
@@ -746,7 +746,7 @@ int16_t SX127x::setBitRate(float br) {
 
   // check allowed bit rate
   if(_ook) {
-    RADIOLIB_CHECK_RANGE(br, 1.2, 32.768, RADIOLIB_ERR_INVALID_BIT_RATE);
+    RADIOLIB_CHECK_RANGE(br, 1.2, 32.768002, RADIOLIB_ERR_INVALID_BIT_RATE);      // Found that 32.768 is 32.768002
   } else {
     RADIOLIB_CHECK_RANGE(br, 1.2, 300.0, RADIOLIB_ERR_INVALID_BIT_RATE);
   }


### PR DESCRIPTION
As we were discussing in #337 these are the fixes I implemented to use OOK mode in direct mode with rtl_433_ESP.  At the present time I have RadioLib working with both CC1101 and SX127X Transceivers receiving OOK encoded messages in direct mode from a number of 433Mhz devices.

Changes / Fixes

1. SX127x.cpp - Fix for setBitRate when setting 32.768, found that the float was 32.768002

2. SX1278.cpp - Fix for setGain, found that AGC was not being set when in FSK_OOK mode

3. CC1101.cpp/CC1101.h - Fix for getRSSI, so that in the functionality is similar to getRSSI for SX127X, and returns the current RSSI level in Direct Mode.

Once this pull request is implemented, I will update rtl_433_ESP to use this transceiver library then work on having this into implemented OpenMQTTGateway as well.

FYI @1technophile @DigiH