### PR TITLE
remedy Module when RADIOLIB_BUILD_ARDUINO is not defined

### DIFF
--- a/src/BuildOpt.h
+++ b/src/BuildOpt.h
@@ -886,6 +886,7 @@
   #define RADIOLIB_PLATFORM                           "Generic"
 
   // platform properties may be defined here, or somewhere else in the build system
+  #include "noarduino.h"
 
 #endif
 
@@ -1019,11 +1020,11 @@
 #define RADIOLIB_REST(arg, ...) __VA_ARGS__
 #define RADIOLIB_EXP(...) __VA_ARGS__
 
-#define RADIOLIB_GENERATE_CALLBACK_RET_FUNC(RET, FUNC, ...) public: typedef RET (*FUNC##_cb_t)(__VA_ARGS__); void setCb_##FUNC(FUNC##_cb_t cb) { cb_##FUNC = cb; }; private: FUNC##_cb_t cb_##FUNC;
+#define RADIOLIB_GENERATE_CALLBACK_RET_FUNC(RET, FUNC, ...) public: typedef RET (*FUNC##_cb_t)(__VA_ARGS__); void setCb_##FUNC(FUNC##_cb_t cb) { cb_##FUNC = cb; }; private: FUNC##_cb_t cb_##FUNC = nullptr;
 #define RADIOLIB_GENERATE_CALLBACK_RET(RET, ...) RADIOLIB_GENERATE_CALLBACK_RET_FUNC(RET, __VA_ARGS__)
 #define RADIOLIB_GENERATE_CALLBACK(CB) RADIOLIB_GENERATE_CALLBACK_RET(RADIOLIB_EXP(RADIOLIB_FIRST CB), RADIOLIB_EXP(RADIOLIB_REST CB))
 
-#define RADIOLIB_GENERATE_CALLBACK_SPI_RET_FUNC(RET, FUNC, ...) public: typedef RET (Module::*FUNC##_cb_t)(__VA_ARGS__); void setCb_##FUNC(FUNC##_cb_t cb) { cb_##FUNC = cb; }; private: FUNC##_cb_t cb_##FUNC;
+#define RADIOLIB_GENERATE_CALLBACK_SPI_RET_FUNC(RET, FUNC, ...) public: typedef RET (Module::*FUNC##_cb_t)(__VA_ARGS__); void setCb_##FUNC(FUNC##_cb_t cb) { cb_##FUNC = cb; }; private: FUNC##_cb_t cb_##FUNC = nullptr;
 #define RADIOLIB_GENERATE_CALLBACK_SPI_RET(RET, ...) RADIOLIB_GENERATE_CALLBACK_SPI_RET_FUNC(RET, __VA_ARGS__)
 #define RADIOLIB_GENERATE_CALLBACK_SPI(CB) RADIOLIB_GENERATE_CALLBACK_SPI_RET(RADIOLIB_EXP(RADIOLIB_FIRST CB), RADIOLIB_EXP(RADIOLIB_REST CB))
 

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -105,13 +105,16 @@ Module& Module::operator=(const Module& mod) {
 void Module::init() {
   this->pinMode(_cs, OUTPUT);
   this->digitalWrite(_cs, HIGH);
+#if defined(RADIOLIB_BUILD_ARDUINO)
   if(_initInterface) {
     (this->*cb_SPIbegin)();
   }
+#endif
 }
 
 void Module::term() {
   // stop hardware interfaces (if they were initialized by the library)
+#if defined(RADIOLIB_BUILD_ARDUINO)
   if(!_initInterface) {
     return;
   }
@@ -119,6 +122,7 @@ void Module::term() {
   if(_spi != nullptr) {
     this->SPIend();
   }
+#endif
 }
 
 int16_t Module::SPIgetRegValue(uint8_t reg, uint8_t msb, uint8_t lsb) {
@@ -381,57 +385,75 @@ uint32_t Module::pulseIn(RADIOLIB_PIN_TYPE pin, RADIOLIB_PIN_STATUS state, uint3
 }
 
 void Module::begin() {
+#if defined(RADIOLIB_BUILD_ARDUINO)
   if(cb_SPIbegin == nullptr) {
     return;
   }
   (this->*cb_SPIbegin)();
+#endif
 }
 
 void Module::beginTransaction() {
+#if defined(RADIOLIB_BUILD_ARDUINO)
   if(cb_SPIbeginTransaction == nullptr) {
     return;
   }
   (this->*cb_SPIbeginTransaction)();
+#endif
 }
 
 uint8_t Module::transfer(uint8_t b) {
+#if defined(RADIOLIB_BUILD_ARDUINO)
   if(cb_SPItransfer == nullptr) {
     return(0xFF);
   }
   return((this->*cb_SPItransfer)(b));
+#endif
 }
 
 void Module::endTransaction() {
+#if defined(RADIOLIB_BUILD_ARDUINO)
   if(cb_SPIendTransaction == nullptr) {
     return;
   }
   (this->*cb_SPIendTransaction)();
+#endif
 }
 
 void Module::end() {
+#if defined(RADIOLIB_BUILD_ARDUINO)
   if(cb_SPIend == nullptr) {
     return;
   }
   (this->*cb_SPIend)();
+#endif
 }
 
 #if defined(RADIOLIB_BUILD_ARDUINO)
 void Module::SPIbegin() {
   _spi->begin();
 }
+#endif
 
 void Module::SPIbeginTransaction() {
+#if defined(RADIOLIB_BUILD_ARDUINO)
   _spi->beginTransaction(_spiSettings);
+#endif
 }
 
 uint8_t Module::SPItransfer(uint8_t b) {
+#if defined(RADIOLIB_BUILD_ARDUINO)
   return(_spi->transfer(b));
+#endif
 }
 
 void Module::SPIendTransaction() {
+#if defined(RADIOLIB_BUILD_ARDUINO)
   _spi->endTransaction();
+#endif
 }
 
+#if defined(RADIOLIB_BUILD_ARDUINO)
 void Module::SPIend() {
   _spi->end();
 }

--- a/src/Module.h
+++ b/src/Module.h
@@ -366,11 +366,11 @@ class Module {
     // helper functions to set up SPI overrides on Arduino
     #if defined(RADIOLIB_BUILD_ARDUINO)
     void SPIbegin();
-    virtual void SPIbeginTransaction();
-    uint8_t SPItransfer(uint8_t b);
-    virtual void SPIendTransaction();
     void SPIend();
     #endif
+    virtual void SPIbeginTransaction();
+    virtual uint8_t SPItransfer(uint8_t b);
+    virtual void SPIendTransaction();
 
     /*!
       \brief Function to reflect bits within a byte.


### PR DESCRIPTION
In its present form, it seems RadioLib cannot be compiled when RADIOLIB_BUILD_ARDUINO is not defined.

This is because the source code in the non-RADIOLIB_BUILD_ARDUINO variant of Module.cpp makes repeated use of functionality unique to when RADIOLIB_BUILD_ARDUINO is defined.

So, this is a proposed PR to remedy these issues when RADIOLIB_BUILD_ARDUINO is not defined.

One change in ./src/BuildOpt.h is to modify the RADIOLIB_GENERATE_CALLBACK_RET_FUNC and RADIOLIB_GENERATE_CALLBACK_SPI_RET_FUNC macros so that the default value is nullptr.  These values are only written by the RADIOLIB_BUILD_ARDUINO constructor, and the Module source code *presumes* that a nullptr check will work.  However, that check will only work if these values are initialized to nullptr to begin with.

In the present ./src/Module.cpp, the non-RADIOLIB_BUILD_ARDUINO variant makes use of "_initInterface", a value that only exists when RADIOLIB_BUILD_ARDUINO is defined.  It then presumes a callback value to be valid.  This PR places such code within an #ifdef  RADIOLIB_BUILD_ARDUINO.

In the present ./src/Module.cpp,  the non-RADIOLIB_BUILD_ARDUINO variant makes use of SPIbeginTransaction(), SPItransfer(uint8_t), and SPIendTransaction(), which are presently only defined when RADIOLIB_BUILD_ARDUINO defined.  The proposed solution is to make all three of these available regardless of RADIOLIB_BUILD_ARDUINO and defined as virtual functions to allow the user to overload these for the non-Arduino SPI implementation.

The final change is to allow RadioLib to be more easily integrated into projects.  In its present form, RadioLib requires modification of ./src/BuildOpt.h when RADIOLIB_BUILD_ARDUINO is not defined; the comments even direct users to do this.  However, this is not terribly practical when RadioLib is a git submodule of another project.  Moreover, every time the source code changes, the same modification must be re-applied.  So, to remedy, an #include "noarduino.h" was added to so that the user simply has to put such a file somewhere in the include path.  (They are, alas, still on the hook to update this noarduino.h file whenever yet another #define is added to ./src/BuildOpt.h, but the important difference is that the RadioLib submodule can remain untouched.)