### PR TITLE
fix: wrong cast

### DIFF
--- a/src/BuildOpt.h
+++ b/src/BuildOpt.h
@@ -222,7 +222,7 @@
     #define RADIOLIB_PIN_MODE                           uint32_t
     #define RADIOLIB_PIN_STATUS                         uint32_t
     #define RADIOLIB_INTERRUPT_STATUS                   RADIOLIB_PIN_STATUS
-    #define RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(p)        digitalPinToInterrupt((PinName)p)
+    #define RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(p)        digitalPinToInterrupt(p)
     #define RADIOLIB_NC                                 (0xFFFFFFFF)
     #define RADIOLIB_DEFAULT_SPI                        SPI
     #define RADIOLIB_DEFAULT_SPI_SETTINGS               SPISettings(2000000, MSBFIRST, SPI_MODE0)


### PR DESCRIPTION
Hi @jgromes 

This PR fixes a warning when building with `ARDUINO_ARCH_STM32`:

```
In file included from STMicroelectronics\hardware\stm32\2.3.0\cores\arduino/Arduino.h:56,
                 from libraries\radiolib\src\BuildOpt.h:6,
                 from libraries\radiolib\src\typedef.h:4,
                 from libraries\RadioLib\src\modules\CC1101\CC1101.h:4,
                 from libraries\RadioLib\src\modules\CC1101\CC1101.cpp:1:
libraries\RadioLib\src\modules\CC1101\CC1101.cpp: In member function 'void CC1101::setGdo0Action(void (*)(), uint32_t)':
STMicroelectronics\hardware\stm32\2.3.0\cores\arduino/pins_arduino.h:126:59: warning: enumerated and non-enumerated type in conditional expression [-Wextra]
  126 | #define digitalPinToInterrupt(p)    (digitalPinIsValid(p) ? p : NOT_AN_INTERRUPT)
      |                                                           ^
libraries\RadioLib\src\BuildOpt.h:230:57: note: in expansion of macro 'digitalPinToInterrupt'
  230 |     #define RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(p)        digitalPinToInterrupt((PinName)p)
      |                                                         ^~~~~~~~~~~~~~~~~~~~~
libraries\RadioLib\src\modules\CC1101\CC1101.cpp:227:25: note: in expansion of macro 'RADIOLIB_DIGITAL_PIN_TO_INTERRUPT'
  227 |   _mod->attachInterrupt(RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(_mod->getIrq()), func, dir);
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
libraries\RadioLib\src\modules\CC1101\CC1101.cpp: In member function 'void CC1101::clearGdo0Action()':
STMicroelectronics\hardware\stm32\2.3.0\cores\arduino/pins_arduino.h:126:59: warning: enumerated and non-enumerated type in conditional expression [-Wextra]
  126 | #define digitalPinToInterrupt(p)    (digitalPinIsValid(p) ? p : NOT_AN_INTERRUPT)
      |                                                           ^
libraries\RadioLib\src\BuildOpt.h:230:57: note: in expansion of macro 'digitalPinToInterrupt'
  230 |     #define RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(p)        digitalPinToInterrupt((PinName)p)
      |                                                         ^~~~~~~~~~~~~~~~~~~~~
libraries\RadioLib\src\modules\CC1101\CC1101.cpp:231:25: note: in expansion of macro 'RADIOLIB_DIGITAL_PIN_TO_INTERRUPT'
  231 |   _mod->detachInterrupt(RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(_mod->getIrq()));
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
libraries\RadioLib\src\modules\CC1101\CC1101.cpp: In member function 'void CC1101::setGdo2Action(void (*)(), uint32_t)':
STMicroelectronics\hardware\stm32\2.3.0\cores\arduino/pins_arduino.h:126:59: warning: enumerated and non-enumerated type in conditional expression [-Wextra]
  126 | #define digitalPinToInterrupt(p)    (digitalPinIsValid(p) ? p : NOT_AN_INTERRUPT)
      |                                                           ^
libraries\RadioLib\src\BuildOpt.h:230:57: note: in expansion of macro 'digitalPinToInterrupt'
  230 |     #define RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(p)        digitalPinToInterrupt((PinName)p)
      |                                                         ^~~~~~~~~~~~~~~~~~~~~
libraries\RadioLib\src\modules\CC1101\CC1101.cpp:239:25: note: in expansion of macro 'RADIOLIB_DIGITAL_PIN_TO_INTERRUPT'
  239 |   _mod->attachInterrupt(RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(_mod->getGpio()), func, dir);
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
libraries\RadioLib\src\modules\CC1101\CC1101.cpp: In member function 'void CC1101::clearGdo2Action()':
STMicroelectronics\hardware\stm32\2.3.0\cores\arduino/pins_arduino.h:126:59: warning: enumerated and non-enumerated type in conditional expression [-Wextra]
  126 | #define digitalPinToInterrupt(p)    (digitalPinIsValid(p) ? p : NOT_AN_INTERRUPT)
      |                                                           ^
libraries\RadioLib\src\BuildOpt.h:230:57: note: in expansion of macro 'digitalPinToInterrupt'
  230 |     #define RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(p)        digitalPinToInterrupt((PinName)p)
      |                                                         ^~~~~~~~~~~~~~~~~~~~~
libraries\RadioLib\src\modules\CC1101\CC1101.cpp:246:25: note: in expansion of macro 'RADIOLIB_DIGITAL_PIN_TO_INTERRUPT'
  246 |   _mod->detachInterrupt(RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(_mod->getGpio()));
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

/cc @matthijskooijman
