### PR TITLE
No bound checks on frequency deviation if ~OOK

### DIFF
--- a/src/modules/CC1101/CC1101.cpp
+++ b/src/modules/CC1101/CC1101.cpp
@@ -506,7 +506,8 @@ int16_t CC1101::setFrequencyDeviation(float freqDev) {
     newFreqDev = 1.587;
   }
 
-  if (_modulation != RADIOLIB_CC1101_MOD_FORMAT_ASK_OOK) {
+  // check range unless 0 (special value)
+  if (freqDev != 0) {
     RADIOLIB_CHECK_RANGE(newFreqDev, 1.587, 380.8, RADIOLIB_ERR_INVALID_FREQUENCY_DEVIATION);
   }
 

--- a/src/modules/CC1101/CC1101.cpp
+++ b/src/modules/CC1101/CC1101.cpp
@@ -506,7 +506,9 @@ int16_t CC1101::setFrequencyDeviation(float freqDev) {
     newFreqDev = 1.587;
   }
 
-  RADIOLIB_CHECK_RANGE(newFreqDev, 1.587, 380.8, RADIOLIB_ERR_INVALID_FREQUENCY_DEVIATION);
+  if (_modulation != RADIOLIB_CC1101_MOD_FORMAT_ASK_OOK) {
+    RADIOLIB_CHECK_RANGE(newFreqDev, 1.587, 380.8, RADIOLIB_ERR_INVALID_FREQUENCY_DEVIATION);
+  }
 
   // set mode to standby
   SPIsendCommand(RADIOLIB_CC1101_CMD_IDLE);


### PR DESCRIPTION
Sometimes it's acceptable to set frequency deviation to 0, even in FSK. For example, I use it to "fool" the radio into acting as a spectrum, by changing the carrier frequency while in FSK and then taking samples of the RSSI.

So, unless the radio is in OOK, which makes sense to do frequency deviation range checks, I'd suggest to not validate this range.