### PR TITLE
CC1101 FEC and 32-bit sync word emulation

### DIFF
--- a/src/TypeDef.h
+++ b/src/TypeDef.h
@@ -328,6 +328,11 @@
 */
 #define RADIOLIB_ERR_INVALID_NUM_BROAD_ADDRS                   (-601)
 
+/*!
+  \brief FEC cannot be enabled for variable packet length mode
+*/
+#define RADIOLIB_ERR_FEC_UNAVAILABLE                           (-602)
+
 // SX126x-specific status codes
 
 /*!

--- a/src/modules/CC1101/CC1101.h
+++ b/src/modules/CC1101/CC1101.h
@@ -765,9 +765,11 @@ class CC1101: public PhysicalLayer {
 
       \param requireCarrierSense Require carrier sense above threshold in addition to sync word.
 
+      \param repeatSyncWord Enable repeated transmission in TX to emulate 32-bit sync word and force 32-bit word detection in RX.
+
       \returns \ref status_codes
     */
-    int16_t setSyncWord(uint8_t syncH, uint8_t syncL, uint8_t maxErrBits = 0, bool requireCarrierSense = false);
+    int16_t setSyncWord(uint8_t syncH, uint8_t syncL, uint8_t maxErrBits = 0, bool requireCarrierSense = false, bool repeatSyncWord = false);
 
     /*!
       \brief Sets 1 or 2 bytes of sync word.
@@ -780,9 +782,11 @@ class CC1101: public PhysicalLayer {
 
       \param requireCarrierSense Require carrier sense above threshold in addition to sync word.
 
+      \param repeatSyncWord Enable repeated transmission in TX to emulate 32-bit sync word and force 32-bit word detection in RX.
+
       \returns \ref status_codes
     */
-    int16_t setSyncWord(uint8_t* syncWord, uint8_t len, uint8_t maxErrBits = 0, bool requireCarrierSense = false);
+    int16_t setSyncWord(uint8_t* syncWord, uint8_t len, uint8_t maxErrBits = 0, bool requireCarrierSense = false, bool repeatSyncWord = false);
 
     /*!
       \brief Sets preamble length.
@@ -864,15 +868,24 @@ class CC1101: public PhysicalLayer {
     int16_t variablePacketLengthMode(uint8_t maxLen = RADIOLIB_CC1101_MAX_PACKET_LENGTH);
 
      /*!
+      \brief Enable or disable forward error correction for fixed length packets.
+
+      \returns \ref status_codes
+    */
+    int16_t setForwardErrorCorrection(bool enable = true);
+
+     /*!
       \brief Enable sync word filtering and generation.
 
       \param numBits Sync word length in bits.
 
       \param requireCarrierSense Require carrier sense above threshold in addition to sync word.
 
+      \param repeatSyncWord Enable repeated transmission in TX to emulate 32-bit sync word and force 32-bit word detection in RX.
+
       \returns \ref status_codes
     */
-    int16_t enableSyncWordFiltering(uint8_t maxErrBits = 0, bool requireCarrierSense = false);
+    int16_t enableSyncWordFiltering(uint8_t maxErrBits = 0, bool requireCarrierSense = false, bool repeatSyncWord);
 
      /*!
       \brief Disable preamble and sync word filtering and generation.

--- a/src/modules/CC1101/CC1101.h
+++ b/src/modules/CC1101/CC1101.h
@@ -872,7 +872,7 @@ class CC1101: public PhysicalLayer {
 
       \returns \ref status_codes
     */
-    int16_t setForwardErrorCorrection(bool enable = true);
+    int16_t setForwardErrorCorrection(bool enable = false);
 
      /*!
       \brief Enable sync word filtering and generation.
@@ -885,7 +885,7 @@ class CC1101: public PhysicalLayer {
 
       \returns \ref status_codes
     */
-    int16_t enableSyncWordFiltering(uint8_t maxErrBits = 0, bool requireCarrierSense = false, bool repeatSyncWord);
+    int16_t enableSyncWordFiltering(uint8_t maxErrBits = 0, bool requireCarrierSense = false, bool repeatSyncWord = true);
 
      /*!
       \brief Disable preamble and sync word filtering and generation.


### PR DESCRIPTION
This commit adds some missing bits about CC1101 module. These features have been tested on hardware, but more testing definitely won't hurt. Also, with FEC enabled, one should keep in mind that the data is becoming 1/2 rate, and in my opinion, better be left disabled by default.

FEC is described in section 18.1 of the datasheet.
32-bit sync word emulation is described in section 17.1. Also, datasheet recommends sync word doubling as a more robust filtering method.