### PR TITLE
[SX127x] Fix FSK Stream mode TX and RX

### DIFF
--- a/examples/Stream/Stream_Transmit/Stream_Transmit.ino
+++ b/examples/Stream/Stream_Transmit/Stream_Transmit.ino
@@ -86,6 +86,8 @@ volatile bool transmittedFlag = false;
 // disable interrupt when it's not needed
 volatile bool enableInterrupt = true;
 
+bool isFifoEmpty = false;
+
 // how many bytes are there in total
 volatile int totalLength = longPacket.length();
 
@@ -104,13 +106,19 @@ void fifoAdd(void) {
   if(!enableInterrupt) {
     return;
   }
-
-  // add more bytes to the transmit buffer
-  uint8_t* txBuffPtr = (uint8_t*)longPacket.c_str();
-  transmittedFlag = radio.fifoAdd(txBuffPtr, totalLength, &remLength);
+  isFifoEmpty = true;
 }
 
 void loop() {
+  if (isFifoEmpty) {
+    enableInterrupt = false;
+    // add more bytes to the transmit buffer
+    uint8_t* txBuffPtr = (uint8_t*)longPacket.c_str();
+    transmittedFlag = radio.fifoAdd(txBuffPtr, totalLength, &remLength);
+    enableInterrupt = true;
+    isFifoEmpty = false;
+  }
+
   // check if the previous transmission finished
   if(transmittedFlag) {
     // disable the interrupt service routine while


### PR DESCRIPTION
Hello!

As i described in [Issue #602 ](https://github.com/jgromes/RadioLib/issues/602) and [Issue #647 ](https://github.com/jgromes/RadioLib/issues/647) there are some problems with streams in FSK on SX127x modules. So i submitted a PR with fixes for problems i described in my issues.

List of changes:

1. Remove clearIrqFlags() method call in fifoAdd() and fifoGet() in  SX127x.cpp, because it causes the package to split into several parts (as i saw on RX side)
2. Remove adding of "magic" byte, because it is not necessary
3. Updated Stream_Transmit.ino example, because it caused wdt reset

