### PR TITLE
[SX126x] Add method to support SX126x Rx Boosted Gain mode

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -194,6 +194,7 @@ setRegulatorDCDC	KEYWORD2
 getCurrentLimit	KEYWORD2
 getIrqStatus	KEYWORD2
 getLastError	KEYWORD2
+setRxBoostedGainMode	KEYWORD2
 
 # nRF24
 setIrqAction	KEYWORD2

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -870,6 +870,26 @@ int16_t SX126x::setRxBandwidth(float rxBw) {
   return(setModulationParamsFSK(_br, _pulseShape, _rxBw, _freqDev));
 }
 
+int16_t SX126x::setRxBoostedGainMode(bool rxbgm) {
+  // read the current register value
+  uint8_t rxGain = 0;
+  int16_t state = readRegister(RADIOLIB_SX126X_REG_RX_GAIN, &rxGain, 1);
+  RADIOLIB_ASSERT(state);
+
+  // gain mode register value (SX1261/2 datasheet v2.1 section 9.6)
+  if(rxbgm) {
+    rxGain = 0x96; // Rx Boosted Gain
+  } else {
+    rxGain = 0x94; // Rx Power Saving Gain
+  }
+
+  // update RX gain setting register
+  state = writeRegister(RADIOLIB_SX126X_REG_RX_GAIN, &rxGain, 1);
+  RADIOLIB_ASSERT(state);
+
+  return(state);
+}
+
 int16_t SX126x::setDataShaping(uint8_t sh) {
   // check active modem
   if(getPacketType() != RADIOLIB_SX126X_PACKET_TYPE_GFSK) {

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -709,6 +709,15 @@ class SX126x: public PhysicalLayer {
     int16_t setRxBandwidth(float rxBw);
 
     /*!
+      \brief Enables or disables Rx Boosted Gain mode as described in SX126x datasheet section 9.6 (SX1261/2 v2.1, SX1268 v1.1)
+
+      \param rxbgm True for Rx Boosted Gain, false for Rx Power Saving Gain
+
+      \returns \ref status_codes
+    */
+    int16_t setRxBoostedGainMode(bool rxbgm);
+
+    /*!
       \brief Sets time-bandwidth product of Gaussian filter applied for shaping.
       Allowed values are RADIOLIB_SHAPING_0_3, RADIOLIB_SHAPING_0_5, RADIOLIB_SHAPING_0_7 or RADIOLIB_SHAPING_1_0.
       Set to RADIOLIB_SHAPING_NONE to disable data shaping.


### PR DESCRIPTION
This adds a method allowing SX126x radios to be toggled between Rx Boosted Gain and Rx Power Saving Gain (the default setting) as described in section 9.6 of the SX126x datasheets. It also optionally allows the gain mode setting to be persisted across sleep/warm start.

I wasn't sure if perhaps it would be preferable to break the 'retain' argument (whether to persist the selected Rx gain setting) out into its own setter. I stopped short of doing that here, partly because the datasheet does not say anything specific about how to revert to _not_ persisting (though the implication seems to be that if the gain retention registers are set to any values other than those specified, the gain setting will not be retained). But, happy to refactor if needed.