### PR TITLE
sx126x-rx-gain-persist: add ability to persist Rx gain setting when calling SX126x::setRxBoostedGainMode

### DIFF
--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -870,7 +870,7 @@ int16_t SX126x::setRxBandwidth(float rxBw) {
   return(setModulationParamsFSK(_br, _pulseShape, _rxBw, _freqDev));
 }
 
-int16_t SX126x::setRxBoostedGainMode(bool rxbgm) {
+int16_t SX126x::setRxBoostedGainMode(bool rxbgm, bool persist) {
   // read the current register value
   uint8_t rxGain = 0;
   int16_t state = readRegister(RADIOLIB_SX126X_REG_RX_GAIN, &rxGain, 1);
@@ -886,6 +886,23 @@ int16_t SX126x::setRxBoostedGainMode(bool rxbgm) {
   // update RX gain setting register
   state = writeRegister(RADIOLIB_SX126X_REG_RX_GAIN, &rxGain, 1);
   RADIOLIB_ASSERT(state);
+
+  // add Rx Gain register to retention memory if requested
+  if(persist) {
+    // values and registers below are specified in SX126x datasheet v2.1 section 9.6, just below table 9-3
+    uint8_t value0 = 0x01;
+    uint8_t value1 = 0x08;
+    uint8_t value2 = 0xAC;
+
+    state = writeRegister(RADIOLIB_SX126X_REG_RX_GAIN_RETENTION_0, &value0, 1);
+    RADIOLIB_ASSERT(state);
+
+    state = writeRegister(RADIOLIB_SX126X_REG_RX_GAIN_RETENTION_1, &value1, 1);
+    RADIOLIB_ASSERT(state);
+
+    state = writeRegister(RADIOLIB_SX126X_REG_RX_GAIN_RETENTION_2, &value2, 1);
+    RADIOLIB_ASSERT(state);
+  }
 
   return(state);
 }

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -713,9 +713,11 @@ class SX126x: public PhysicalLayer {
 
       \param rxbgm True for Rx Boosted Gain, false for Rx Power Saving Gain
 
+      \param persist True to persist Rx gain setting when waking up from warm-start mode (e.g. when using Rx duty cycle mode)
+
       \returns \ref status_codes
     */
-    int16_t setRxBoostedGainMode(bool rxbgm);
+    int16_t setRxBoostedGainMode(bool rxbgm, bool persist = true);
 
     /*!
       \brief Sets time-bandwidth product of Gaussian filter applied for shaping.


### PR DESCRIPTION
This restores the 'persist' functionality when setting Rx boosted gain mode on SX126x devices. I had previously thought this wasn't working, but then realized I had misunderstood how it is intended to work. Just verified that setting these three registers as described in the datasheet _does_ indeed persist the gain setting when using Rx duty cycle mode, where otherwise it immediately reverts to its default power-saving gain setting upon the first switch to Tx and back to Rx.