### PR TITLE
[SX126x/SX128x] Add user-configurable IRQ flags and mask to receive methods

### DIFF
--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -221,6 +221,7 @@
 #define RADIOLIB_SX126X_IRQ_RADIOLIB_PREAMBLE_DETECTED       0b0000000000000100  //  2     2     preamble detected
 #define RADIOLIB_SX126X_IRQ_RX_DONE                          0b0000000000000010  //  1     1     packet received
 #define RADIOLIB_SX126X_IRQ_TX_DONE                          0b0000000000000001  //  0     0     packet transmission completed
+#define RADIOLIB_SX126X_IRQ_RX_DEFAULT                       0b0000001001100010  //  14    0     default for Rx (RX_DONE, TIMEOUT, CRC_ERR and HEADER_ERR)
 #define RADIOLIB_SX126X_IRQ_ALL                              0b0100001111111111  //  14    0     all interrupts
 #define RADIOLIB_SX126X_IRQ_NONE                             0b0000000000000000  //  14     0    no interrupts
 
@@ -608,9 +609,13 @@ class SX126x: public PhysicalLayer {
       \param timeout Raw timeout value, expressed as multiples of 15.625 us. Defaults to RADIOLIB_SX126X_RX_TIMEOUT_INF for infinite timeout (Rx continuous mode), set to RADIOLIB_SX126X_RX_TIMEOUT_NONE for no timeout (Rx single mode).
       If timeout other than infinite is set, signal will be generated on DIO1.
 
+      \param irqFlags Sets the IRQ flags, defaults to RADIOLIB_SX126X_IRQ_RX_DEFAULT.
+
+      \param irqMask Sets the mask of IRQ flags that will trigger DIO1, defaults to RADIOLIB_SX126X_IRQ_RX_DONE.
+
       \returns \ref status_codes
     */
-    int16_t startReceive(uint32_t timeout = RADIOLIB_SX126X_RX_TIMEOUT_INF);
+    int16_t startReceive(uint32_t timeout = RADIOLIB_SX126X_RX_TIMEOUT_INF, uint16_t irqFlags = RADIOLIB_SX126X_IRQ_RX_DEFAULT, uint16_t irqMask = RADIOLIB_SX126X_IRQ_RX_DONE);
 
     /*!
       \brief Interrupt-driven receive method where the device mostly sleeps and periodically wakes to listen.
@@ -620,9 +625,13 @@ class SX126x: public PhysicalLayer {
 
       \param sleepPeriod The duration the receiver will not be in Rx mode, in microseconds.
 
+      \param irqFlags Sets the IRQ flags, defaults to RADIOLIB_SX126X_IRQ_RX_DEFAULT.
+
+      \param irqMask Sets the mask of IRQ flags that will trigger DIO1, defaults to RADIOLIB_SX126X_IRQ_RX_DONE.
+
       \returns \ref status_codes
     */
-    int16_t startReceiveDutyCycle(uint32_t rxPeriod, uint32_t sleepPeriod);
+    int16_t startReceiveDutyCycle(uint32_t rxPeriod, uint32_t sleepPeriod, uint16_t irqFlags = RADIOLIB_SX126X_IRQ_RX_DEFAULT, uint16_t irqMask = RADIOLIB_SX126X_IRQ_RX_DONE);
 
     /*!
       \brief Calls \ref startReceiveDutyCycle with rxPeriod and sleepPeriod set so the unit shouldn't miss any messages.
@@ -633,9 +642,13 @@ class SX126x: public PhysicalLayer {
       \param minSymbols Parameters will be chosen to ensure that the unit will catch at least this many symbols of any preamble of the specified length. Defaults to 8.
       According to Semtech, receiver requires 8 symbols to reliably latch a preamble. This makes this method redundant when transmitter preamble length is less than 17 (2*minSymbols + 1).
 
+      \param irqFlags Sets the IRQ flags, defaults to RADIOLIB_SX126X_IRQ_RX_DEFAULT.
+
+      \param irqMask Sets the mask of IRQ flags that will trigger DIO1, defaults to RADIOLIB_SX126X_IRQ_RX_DONE.
+
       \returns \ref status_codes
     */
-    int16_t startReceiveDutyCycleAuto(uint16_t senderPreambleLength = 0, uint16_t minSymbols = 8);
+    int16_t startReceiveDutyCycleAuto(uint16_t senderPreambleLength = 0, uint16_t minSymbols = 8, uint16_t irqFlags = RADIOLIB_SX126X_IRQ_RX_DEFAULT, uint16_t irqMask = RADIOLIB_SX126X_IRQ_RX_DONE);
 
     /*!
       \brief Reads the current IRQ status.
@@ -1062,7 +1075,7 @@ class SX126x: public PhysicalLayer {
     uint16_t getDeviceErrors();
     int16_t clearDeviceErrors();
 
-    int16_t startReceiveCommon(uint32_t timeout = RADIOLIB_SX126X_RX_TIMEOUT_INF);
+    int16_t startReceiveCommon(uint32_t timeout = RADIOLIB_SX126X_RX_TIMEOUT_INF, uint16_t irqFlags = RADIOLIB_SX126X_IRQ_RX_DEFAULT, uint16_t irqMask = RADIOLIB_SX126X_IRQ_RX_DONE);
     int16_t setFrequencyRaw(float freq);
     int16_t setPacketMode(uint8_t mode, uint8_t len);
     int16_t setHeaderType(uint8_t headerType, size_t len = 0xFF);

--- a/src/modules/SX128x/SX128x.cpp
+++ b/src/modules/SX128x/SX128x.cpp
@@ -546,20 +546,18 @@ int16_t SX128x::finishTransmit() {
   return(standby());
 }
 
-int16_t SX128x::startReceive(uint16_t timeout) {
+int16_t SX128x::startReceive(uint16_t timeout, uint16_t irqFlags, uint16_t irqMask) {
   // check active modem
   if(getPacketType() == RADIOLIB_SX128X_PACKET_TYPE_RANGING) {
     return(RADIOLIB_ERR_WRONG_MODEM);
   }
 
   // set DIO mapping
-  uint16_t mask = RADIOLIB_SX128X_IRQ_RX_DONE;
-
   if(timeout != RADIOLIB_SX128X_RX_TIMEOUT_INF) {
-    mask |= RADIOLIB_SX128X_IRQ_RX_TX_TIMEOUT;
+    irqMask |= RADIOLIB_SX128X_IRQ_RX_TX_TIMEOUT;
   }
 
-  int16_t state = setDioIrqParams(RADIOLIB_SX128X_IRQ_RX_DONE | RADIOLIB_SX128X_IRQ_RX_TX_TIMEOUT | RADIOLIB_SX128X_IRQ_CRC_ERROR | RADIOLIB_SX128X_IRQ_HEADER_ERROR, mask);
+  int16_t state = setDioIrqParams(irqFlags, irqMask);
   RADIOLIB_ASSERT(state);
 
   // set buffer pointers

--- a/src/modules/SX128x/SX128x.h
+++ b/src/modules/SX128x/SX128x.h
@@ -327,6 +327,7 @@
 #define RADIOLIB_SX128X_IRQ_SYNC_WORD_VALID                    0x0004      //  2     2                       sync word valid
 #define RADIOLIB_SX128X_IRQ_RX_DONE                            0x0002      //  1     1                       Rx done
 #define RADIOLIB_SX128X_IRQ_TX_DONE                            0x0001      //  0     0                       Tx done
+#define RADIOLIB_SX128X_IRQ_RX_DEFAULT                         0x4062      //  15    0                       default for Rx (RX_DONE, RX_TX_TIMEOUT, CRC_ERROR and HEADER_ERROR)
 #define RADIOLIB_SX128X_IRQ_NONE                               0x0000      //  15    0                       none
 #define RADIOLIB_SX128X_IRQ_ALL                                0xFFFF      //  15    0                       all
 
@@ -566,9 +567,13 @@ class SX128x: public PhysicalLayer {
       \param timeout Raw timeout value, expressed as multiples of 15.625 us. Defaults to RADIOLIB_SX128X_RX_TIMEOUT_INF for infinite timeout (Rx continuous mode), set to RADIOLIB_SX128X_RX_TIMEOUT_NONE for no timeout (Rx single mode).
       If timeout other than infinite is set, signal will be generated on DIO1.
 
+      \param irqFlags Sets the IRQ flags, defaults to RADIOLIB_SX128X_IRQ_RX_DEFAULT.
+
+      \param irqMask Sets the mask of IRQ flags that will trigger DIO1, defaults to RADIOLIB_SX128X_IRQ_RX_DONE.
+
       \returns \ref status_codes
     */
-    int16_t startReceive(uint16_t timeout = RADIOLIB_SX128X_RX_TIMEOUT_INF);
+    int16_t startReceive(uint16_t timeout = RADIOLIB_SX128X_RX_TIMEOUT_INF, uint16_t irqFlags = RADIOLIB_SX128X_IRQ_RX_DEFAULT, uint16_t irqMask = RADIOLIB_SX128X_IRQ_RX_DONE);
 
     /*!
       \brief Reads the current IRQ status.


### PR DESCRIPTION
As discussed in #682, this adds two parameters to the interrupt receive methods of SX126x and SX128x modules. In this way, a user can set the IRQ flags and mask (the IRQs that will trigger DIO1) as they wish. 

For convenience and readability, I added the `RADIOLIB_SX126X_IRQ_RX_DEFAULT` definition, which is the combination of RX_DONE, TIMEOUT, CRC_ERROR and HEADER_ERROR. The `irqFlags` default to this, while `irqMask` defaults to RX_DONE, like it was up until now.

I tested with Meshtastic firmware 2.0.22 using the SX1261 module (although it _should_ be an SX1262 as discussed in #683) that without giving these parameters, it behaves as before. When adding the HEADER_VALID flag, it can successfully detect using `getIrqStatus()` that it is actively receiving, for both `startReceive()` and `startReceiveDutyCycleAuto()`. Since I do not have an SX128x module, I didn’t test this hardware.