### PR TITLE
Fix args to begin() in SX12xx settings examples

### DIFF
--- a/examples/SX126x/SX126x_Settings/SX126x_Settings.ino
+++ b/examples/SX126x/SX126x_Settings/SX126x_Settings.ino
@@ -74,7 +74,7 @@ void setup() {
   // sync word:                   0x34 (public network/LoRaWAN)
   // output power:                2 dBm
   // preamble length:             20 symbols
-  state = radio2.begin(915.0, 500.0, 6, 5, 0x34, 20);
+  state = radio2.begin(915.0, 500.0, 6, 5, 0x34, 2, 20);
   if (state == RADIOLIB_ERR_NONE) {
     Serial.println(F("success!"));
   } else {

--- a/examples/SX128x/SX128x_Settings/SX128x_Settings.ino
+++ b/examples/SX128x/SX128x_Settings/SX128x_Settings.ino
@@ -65,9 +65,10 @@ void setup() {
   // bandwidth:                   1625.0 kHz
   // spreading factor:            7
   // coding rate:                 5
+  // sync word:                   0x12 (private network)
   // output power:                2 dBm
   // preamble length:             20 symbols
-  state = radio2.begin(2450.0, 1625.0, 7, 5, 2, 20);
+  state = radio2.begin(2450.0, 1625.0, 7, 5, 0x12, 2, 20);
   if (state == RADIOLIB_ERR_NONE) {
     Serial.println(F("success!"));
   } else {


### PR DESCRIPTION
The call to `radio.begin()` in the SX126x and SX128x Settings example code were missing arguments. Since all the arguments have default assigned values, the compiler wasn't complaining, but the values were being applied to incorrect parameters based on the comments.

For example, previously the comment for the SX126x Settings example said that `radio2` was being configured with output power of 2 dBm and preamble length of 20 symbols. Actually it was being configured with an output power of 20 dBm and preamble was left default (8).

I fixed the calls to `begin()` in the SX126x and SX128x Settings examples. The SX127x Settings example was already fine. I did not check the non-Semtech transceiver examples.

**Open question:** For the SX128x Settings Example, the "sync word" was left out and there was no comment stating an expected value. I used the default value of 0x12 (private network) there, but I'm not certain if that matches your intent. The SX126x Settings example uses 0x34 (lorawan public network) and SX127x uses 0x14 (no meaning I'm aware of).

Also, thanks for this awesome library! 💜