### PR TITLE
[SX1278] New getInstRSSI to get current RSSI

### DIFF
--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -1221,7 +1221,7 @@ float SX126x::getDataRate() const {
   return(_dataRate);
 }
 
-float SX126x::getRSSI() {
+float SX126x::getRSSI(bool packet) {
 
   if (packet) { 
   // get last packet RSSI from packet status

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -1222,10 +1222,20 @@ float SX126x::getDataRate() const {
 }
 
 float SX126x::getRSSI() {
+
+  if (packet) { 
   // get last packet RSSI from packet status
-  uint32_t packetStatus = getPacketStatus();
-  uint8_t rssiPkt = packetStatus & 0xFF;
-  return(-1.0 * rssiPkt/2.0);
+    uint32_t packetStatus = getPacketStatus();
+    uint8_t rssiPkt = packetStatus & 0xFF;
+    return(-1.0 * rssiPkt/2.0);
+  } else {
+  // get instantaneous RSSI value
+    uint8_t data[3] = {0, 0, 0};  // RssiInst, Status, RFU
+    _mod->SPIreadStream(RADIOLIB_SX126X_CMD_GET_RSSI_INST, data, 3);
+
+    return (float)data[0] / (-2.0);
+  }
+
 }
 
 float SX126x::getSNR() {

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -1222,20 +1222,17 @@ float SX126x::getDataRate() const {
 }
 
 float SX126x::getRSSI(bool packet) {
-
-  if (packet) { 
-  // get last packet RSSI from packet status
+  if(packet) { 
+    // get last packet RSSI from packet status
     uint32_t packetStatus = getPacketStatus();
     uint8_t rssiPkt = packetStatus & 0xFF;
     return(-1.0 * rssiPkt/2.0);
   } else {
-  // get instantaneous RSSI value
+    // get instantaneous RSSI value
     uint8_t data[3] = {0, 0, 0};  // RssiInst, Status, RFU
     _mod->SPIreadStream(RADIOLIB_SX126X_CMD_GET_RSSI_INST, data, 3);
-
-    return (float)data[0] / (-2.0);
+    return((float)data[0] / (-2.0));
   }
-
 }
 
 float SX126x::getSNR() {
@@ -1335,13 +1332,6 @@ uint32_t SX126x::getTimeOnAir(size_t len) {
   } else {
     return((len * 8 * _br) / (RADIOLIB_SX126X_CRYSTAL_FREQ * 32));
   }
-}
-
-float SX126x::getRSSIInst() {
-  uint8_t data[3] = {0, 0, 0};  // RssiInst, Status, RFU
-  _mod->SPIreadStream(RADIOLIB_SX126X_CMD_GET_RSSI_INST, data, 3);
-
-  return (float)data[0] / (-2.0);
 }
 
 int16_t SX126x::implicitHeader(size_t len) {

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -915,11 +915,11 @@ class SX126x: public PhysicalLayer {
     float getDataRate() const;
 
     /*!
-      \brief Gets RSSI (Recorded Signal Strength Indicator) of the last received packet.
+      \brief GetsRSSI (Recorded Signal Strength Indicator).
 
-      \param packet Set to false to gets current RSSI measurement in LoRa mode.
+      \param packet Whether to read last packet RSSI, or the current value.
 
-      \returns RSSI of the last received packet in dBm.
+      \returns RSSI value in dBm.
     */
     float getRSSI(bool packet = true);
 
@@ -974,13 +974,6 @@ class SX126x: public PhysicalLayer {
       \returns Expected time-on-air in microseconds.
     */
     uint32_t getTimeOnAir(size_t len);
-
-    /*!
-      \brief Get instantaneous RSSI value during recption of the packet. Should switch to FSK receive mode for LBT implementation.
-
-      \returns Instantaneous RSSI value in dBm, in steps of 0.5dBm
-    */
-    float getRSSIInst();
 
     /*!
       \brief Set implicit header mode for future reception/transmission.

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -917,9 +917,11 @@ class SX126x: public PhysicalLayer {
     /*!
       \brief Gets RSSI (Recorded Signal Strength Indicator) of the last received packet.
 
+      \param packet Set to false to gets current RSSI measurement in LoRa mode.
+
       \returns RSSI of the last received packet in dBm.
     */
-    float getRSSI();
+    float getRSSI(bool packet = true);
 
     /*!
       \brief Gets SNR (Signal to Noise Ratio) of the last received packet. Only available for LoRa modem.

--- a/src/modules/SX127x/SX1272.cpp
+++ b/src/modules/SX127x/SX1272.cpp
@@ -352,37 +352,8 @@ int16_t SX1272::setDataShapingOOK(uint8_t sh) {
   return(state);
 }
 
-float SX1272::getRSSI(bool skipReceive) {
-  if(getActiveModem() == RADIOLIB_SX127X_LORA) {
-    // RSSI calculation uses different constant for low-frequency and high-frequency ports
-    float lastPacketRSSI = -139 + _mod->SPIgetRegValue(RADIOLIB_SX127X_REG_PKT_RSSI_VALUE);
-
-    // spread-spectrum modulation signal can be received below noise floor
-    // check last packet SNR and if it's less than 0, add it to reported RSSI to get the correct value
-    float lastPacketSNR = SX127x::getSNR();
-    if(lastPacketSNR < 0.0) {
-      lastPacketRSSI += lastPacketSNR;
-    }
-
-    return(lastPacketRSSI);
-
-  } else {
-    // enable listen mode
-    if(!skipReceive) {
-      startReceive();
-    }
-
-    // read the value for FSK
-    float rssi = (float)_mod->SPIgetRegValue(RADIOLIB_SX127X_REG_RSSI_VALUE_FSK) / -2.0;
-
-    // set mode back to standby
-    if(!skipReceive) {
-      standby();
-    }
-
-    // return the value
-    return(rssi);
-  }
+float SX1272::getRSSI(bool packet, bool skipReceive) {
+  return(SX127x::getRSSI(packet, skipReceive, -139));
 }
 
 int16_t SX1272::setCRC(bool enable, bool mode) {

--- a/src/modules/SX127x/SX1272.h
+++ b/src/modules/SX127x/SX1272.h
@@ -240,13 +240,15 @@ class SX1272: public SX127x {
     int16_t setDataShapingOOK(uint8_t sh);
 
     /*!
-      \brief Gets recorded signal strength indicator of the latest received packet for LoRa modem, or current RSSI level for FSK modem.
+      \brief Gets recorded signal strength indicator.
 
-      \param skipReceive Set to true to skip putting radio in receive mode for the RSSI measurement in FKS/OOK mode.
+      \param packet Whether to read last packet RSSI, or the current value. LoRa mode only, ignored for FSK.
 
-      \returns Last packet RSSI for LoRa modem, or current RSSI level for FSK modem.
+      \param skipReceive Set to true to skip putting radio in receive mode for the RSSI measurement in FSK/OOK mode.
+
+      \returns RSSI value in dBm.
     */
-    float getRSSI(bool skipReceive = false);
+    float getRSSI(bool packet = true, bool skipReceive = false);
 
     /*!
       \brief Enables/disables CRC check of received packets.

--- a/src/modules/SX127x/SX1278.cpp
+++ b/src/modules/SX127x/SX1278.cpp
@@ -421,6 +421,39 @@ float SX1278::getRSSI(bool skipReceive) {
   }
 }
 
+float SX1278::getInstRSSI(bool skipReceive) {
+  if(getActiveModem() == RADIOLIB_SX127X_LORA) {
+    // for LoRa, get current RSSI
+    float currentRSSI;
+
+    // RSSI calculation uses different constant for low-frequency and high-frequency ports
+    if(_freq < 868.0) {
+      currentRSSI = -164 + _mod->SPIgetRegValue(RADIOLIB_SX127X_REG_RSSI_VALUE);
+    } else {
+      currentRSSI = -157 + _mod->SPIgetRegValue(RADIOLIB_SX127X_REG_RSSI_VALUE);
+    }
+
+    return(currentRSSI);
+
+  } else {
+    // enable listen mode
+    if(!skipReceive) {
+      startReceive();
+    }
+
+    // read the value for FSK
+    float rssi = (float)_mod->SPIgetRegValue(RADIOLIB_SX127X_REG_RSSI_VALUE_FSK) / -2.0;
+
+    // set mode back to standby
+    if(!skipReceive) {
+      standby();
+    }
+
+    // return the value
+    return(rssi);
+  }
+}
+
 int16_t SX1278::setCRC(bool enable, bool mode) {
   if(getActiveModem() == RADIOLIB_SX127X_LORA) {
     // set LoRa CRC

--- a/src/modules/SX127x/SX1278.cpp
+++ b/src/modules/SX127x/SX1278.cpp
@@ -382,58 +382,11 @@ int16_t SX1278::setDataShapingOOK(uint8_t sh) {
 }
 
 float SX1278::getRSSI(bool packet, bool skipReceive) {
-  if(getActiveModem() == RADIOLIB_SX127X_LORA) {
-
-    if (packet) {
-    // for LoRa, get RSSI of the last packet
-      float lastPacketRSSI;
-    // RSSI calculation uses different constant for low-frequency and high-frequency ports
-      if(_freq < 868.0) {
-        lastPacketRSSI = -164 + _mod->SPIgetRegValue(RADIOLIB_SX127X_REG_PKT_RSSI_VALUE);
-      } else {
-        lastPacketRSSI = -157 + _mod->SPIgetRegValue(RADIOLIB_SX127X_REG_PKT_RSSI_VALUE);
-      }
-
-    // spread-spectrum modulation signal can be received below noise floor
-    // check last packet SNR and if it's less than 0, add it to reported RSSI to get the correct value
-      float lastPacketSNR = SX127x::getSNR();
-      if(lastPacketSNR < 0.0) {
-        lastPacketRSSI += lastPacketSNR;
-      }
-      return(lastPacketRSSI);
-
-    } else {
-
-    // for LoRa, get current RSSI
-      float currentRSSI;
-
-    // RSSI calculation uses different constant for low-frequency and high-frequency ports
-      if(_freq < 868.0) {
-        currentRSSI = -164 + _mod->SPIgetRegValue(RADIOLIB_SX127X_REG_RSSI_VALUE);
-      } else {
-        currentRSSI = -157 + _mod->SPIgetRegValue(RADIOLIB_SX127X_REG_RSSI_VALUE);
-      }
-      return(currentRSSI);
-    }
-
-  
-  } else {
-    // enable listen mode
-    if(!skipReceive) {
-      startReceive();
-    }
-
-    // read the value for FSK
-    float rssi = (float)_mod->SPIgetRegValue(RADIOLIB_SX127X_REG_RSSI_VALUE_FSK) / -2.0;
-
-    // set mode back to standby
-    if(!skipReceive) {
-      standby();
-    }
-
-    // return the value
-    return(rssi);
+  int16_t offset = -157;
+  if(_freq < 868.0) {
+    offset = -164;
   }
+  return(SX127x::getRSSI(packet, skipReceive, offset));
 }
 
 int16_t SX1278::setCRC(bool enable, bool mode) {

--- a/src/modules/SX127x/SX1278.cpp
+++ b/src/modules/SX127x/SX1278.cpp
@@ -381,60 +381,42 @@ int16_t SX1278::setDataShapingOOK(uint8_t sh) {
   return(state);
 }
 
-float SX1278::getRSSI(bool skipReceive) {
+float SX1278::getRSSI(bool packet, bool skipReceive) {
   if(getActiveModem() == RADIOLIB_SX127X_LORA) {
-    // for LoRa, get RSSI of the last packet
-    float lastPacketRSSI;
 
+    if (packet) {
+    // for LoRa, get RSSI of the last packet
+      float lastPacketRSSI;
     // RSSI calculation uses different constant for low-frequency and high-frequency ports
-    if(_freq < 868.0) {
-      lastPacketRSSI = -164 + _mod->SPIgetRegValue(RADIOLIB_SX127X_REG_PKT_RSSI_VALUE);
-    } else {
-      lastPacketRSSI = -157 + _mod->SPIgetRegValue(RADIOLIB_SX127X_REG_PKT_RSSI_VALUE);
-    }
+      if(_freq < 868.0) {
+        lastPacketRSSI = -164 + _mod->SPIgetRegValue(RADIOLIB_SX127X_REG_PKT_RSSI_VALUE);
+      } else {
+        lastPacketRSSI = -157 + _mod->SPIgetRegValue(RADIOLIB_SX127X_REG_PKT_RSSI_VALUE);
+      }
 
     // spread-spectrum modulation signal can be received below noise floor
     // check last packet SNR and if it's less than 0, add it to reported RSSI to get the correct value
-    float lastPacketSNR = SX127x::getSNR();
-    if(lastPacketSNR < 0.0) {
-      lastPacketRSSI += lastPacketSNR;
-    }
+      float lastPacketSNR = SX127x::getSNR();
+      if(lastPacketSNR < 0.0) {
+        lastPacketRSSI += lastPacketSNR;
+      }
+      return(lastPacketRSSI);
 
-    return(lastPacketRSSI);
+    } else {
 
-  } else {
-    // enable listen mode
-    if(!skipReceive) {
-      startReceive();
-    }
-
-    // read the value for FSK
-    float rssi = (float)_mod->SPIgetRegValue(RADIOLIB_SX127X_REG_RSSI_VALUE_FSK) / -2.0;
-
-    // set mode back to standby
-    if(!skipReceive) {
-      standby();
-    }
-
-    // return the value
-    return(rssi);
-  }
-}
-
-float SX1278::getInstRSSI(bool skipReceive) {
-  if(getActiveModem() == RADIOLIB_SX127X_LORA) {
     // for LoRa, get current RSSI
-    float currentRSSI;
+      float currentRSSI;
 
     // RSSI calculation uses different constant for low-frequency and high-frequency ports
-    if(_freq < 868.0) {
-      currentRSSI = -164 + _mod->SPIgetRegValue(RADIOLIB_SX127X_REG_RSSI_VALUE);
-    } else {
-      currentRSSI = -157 + _mod->SPIgetRegValue(RADIOLIB_SX127X_REG_RSSI_VALUE);
+      if(_freq < 868.0) {
+        currentRSSI = -164 + _mod->SPIgetRegValue(RADIOLIB_SX127X_REG_RSSI_VALUE);
+      } else {
+        currentRSSI = -157 + _mod->SPIgetRegValue(RADIOLIB_SX127X_REG_RSSI_VALUE);
+      }
+      return(currentRSSI);
     }
 
-    return(currentRSSI);
-
+  
   } else {
     // enable listen mode
     if(!skipReceive) {

--- a/src/modules/SX127x/SX1278.h
+++ b/src/modules/SX127x/SX1278.h
@@ -258,6 +258,15 @@ class SX1278: public SX127x {
     float getRSSI(bool skipReceive = false);
 
     /*!
+      \brief Gets current signal strength indicator of for LoRa modem, or current RSSI level for FSK modem.
+
+      \param skipReceive Set to true to skip putting radio in receive mode for the RSSI measurement in FKS/OOK mode.
+
+      \returns Current packet RSSI for LoRa modem, or FSK modem.
+    */
+    float getInstRSSI(bool skipReceive = false);
+
+    /*!
       \brief Enables/disables CRC check of received packets.
 
       \param enable Enable (true) or disable (false) CRC.

--- a/src/modules/SX127x/SX1278.h
+++ b/src/modules/SX127x/SX1278.h
@@ -249,13 +249,13 @@ class SX1278: public SX127x {
     int16_t setDataShapingOOK(uint8_t sh);
 
     /*!
-      \brief Gets recorded signal strength indicator of the latest received packet for LoRa modem, or current RSSI level for FSK modem.
+      \brief Gets recorded signal strength indicator.
 
-      \param packet Set to false to gets current RSSI measurement in LoRa mode.
+      \param packet Whether to read last packet RSSI, or the current value. LoRa mode only, ignored for FSK.
 
-      \param skipReceive Set to true to skip putting radio in receive mode for the RSSI measurement in FKS/OOK mode.
+      \param skipReceive Set to true to skip putting radio in receive mode for the RSSI measurement in FSK/OOK mode.
 
-      \returns Last packet RSSI for LoRa modem, or current RSSI level for FSK modem.
+      \returns RSSI value in dBm.
     */
     float getRSSI(bool packet = true, bool skipReceive = false);
 

--- a/src/modules/SX127x/SX1278.h
+++ b/src/modules/SX127x/SX1278.h
@@ -251,20 +251,13 @@ class SX1278: public SX127x {
     /*!
       \brief Gets recorded signal strength indicator of the latest received packet for LoRa modem, or current RSSI level for FSK modem.
 
+      \param packet Set to false to gets current RSSI measurement in LoRa mode.
+
       \param skipReceive Set to true to skip putting radio in receive mode for the RSSI measurement in FKS/OOK mode.
 
       \returns Last packet RSSI for LoRa modem, or current RSSI level for FSK modem.
     */
-    float getRSSI(bool skipReceive = false);
-
-    /*!
-      \brief Gets current signal strength indicator of for LoRa modem, or current RSSI level for FSK modem.
-
-      \param skipReceive Set to true to skip putting radio in receive mode for the RSSI measurement in FKS/OOK mode.
-
-      \returns Current packet RSSI for LoRa modem, or FSK modem.
-    */
-    float getInstRSSI(bool skipReceive = false);
+    float getRSSI(bool packet = true, bool skipReceive = false);
 
     /*!
       \brief Enables/disables CRC check of received packets.

--- a/src/modules/SX127x/SX127x.cpp
+++ b/src/modules/SX127x/SX127x.cpp
@@ -1552,4 +1552,45 @@ int16_t SX127x::setDIOPreambleDetect(bool usePreambleDetect) {
   return _mod->SPIsetRegValue(RADIOLIB_SX127X_REG_DIO_MAPPING_2, (usePreambleDetect) ? RADIOLIB_SX127X_DIO_MAP_PREAMBLE_DETECT : RADIOLIB_SX127X_DIO_MAP_RSSI, 0, 0);
 }
 
+float SX127x::getRSSI(bool packet, bool skipReceive, int16_t offset) {
+  if(getActiveModem() == RADIOLIB_SX127X_LORA) {
+    if(packet) {
+      // LoRa packet mode, get RSSI of the last packet
+      float lastPacketRSSI = offset + _mod->SPIgetRegValue(RADIOLIB_SX127X_REG_PKT_RSSI_VALUE);
+
+      // spread-spectrum modulation signal can be received below noise floor
+      // check last packet SNR and if it's less than 0, add it to reported RSSI to get the correct value
+      float lastPacketSNR = SX127x::getSNR();
+      if(lastPacketSNR < 0.0) {
+        lastPacketRSSI += lastPacketSNR;
+      }
+      return(lastPacketRSSI);
+
+    } else {
+      // LoRa instant, get current RSSI
+      float currentRSSI = offset + _mod->SPIgetRegValue(RADIOLIB_SX127X_REG_RSSI_VALUE);
+      return(currentRSSI);
+    }
+  
+  } else {
+    // for FSK, there is no packet RSSI
+
+    // enable listen mode
+    if(!skipReceive) {
+      startReceive();
+    }
+
+    // read the value for FSK
+    float rssi = (float)_mod->SPIgetRegValue(RADIOLIB_SX127X_REG_RSSI_VALUE_FSK) / -2.0;
+
+    // set mode back to standby
+    if(!skipReceive) {
+      standby();
+    }
+
+    // return the value
+    return(rssi);
+  }
+}
+
 #endif

--- a/src/modules/SX127x/SX127x.h
+++ b/src/modules/SX127x/SX127x.h
@@ -1244,6 +1244,17 @@ class SX127x: public PhysicalLayer {
     int16_t setDIOPreambleDetect(bool usePreambleDetect);
 
     /*!
+      \brief Gets recorded signal strength indicator.
+
+      \param packet Whether to read last packet RSSI, or the current value. LoRa mode only, ignored for FSK.
+
+      \param skipReceive Set to true to skip putting radio in receive mode for the RSSI measurement in FSK/OOK mode.
+
+      \returns RSSI value in dBm.
+    */
+    float getRSSI(bool packet, bool skipReceive, int16_t offset);
+
+    /*!
       \brief Sets the RSSI value above which the RSSI interrupt is signaled
 
       \param dbm A dBm value between -127.5 and 0 inclusive


### PR DESCRIPTION
This idea came from an user of tinyGS , that suggest to check the current RSSI of the module to check the actual noise floor, I just added this feature to the tinyGS beta and it work great.  If it's ok for you I can create it as well for SX126x and SX128x modules. 
Thanks