### PR TITLE
fix #709

### DIFF
--- a/src/BuildOpt.h
+++ b/src/BuildOpt.h
@@ -746,7 +746,7 @@
     #define RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(p)        digitalPinToInterrupt(p)
     #define RADIOLIB_NC                                 (0xFF)
     #define RADIOLIB_DEFAULT_SPI                        SPI
-    #define RADIOLIB_DEFAULT_SPI_SETTINGS               SPISettings(2000000, MSBFIRST, SPI_MODE0)
+    #define RADIOLIB_DEFAULT_SPI_SETTINGS               SPISettings(1000000, MSBFIRST, SPI_MODE0)
     #define RADIOLIB_NONVOLATILE                        PROGMEM
     #define RADIOLIB_NONVOLATILE_READ_BYTE(addr)        pgm_read_byte(addr)
     #define RADIOLIB_NONVOLATILE_READ_DWORD(addr)       pgm_read_dword(addr)


### PR DESCRIPTION
This simple fix makes my two cubecells (the Board V2 and the Board Plus) start up 100% of the times correctly. I have purchased a couple more and they will arrive next month. I'll test the old clock frequency again.