### PR TITLE
Improve hardware abstraction layer

### DIFF
--- a/examples/CC1101/CC1101_Receive_Interrupt/CC1101_Receive_Interrupt.ino
+++ b/examples/CC1101/CC1101_Receive_Interrupt/CC1101_Receive_Interrupt.ino
@@ -49,7 +49,7 @@ void setup() {
 
   // set the function that will be called
   // when new packet is received
-  radio.setGdo0Action(setFlag);
+  radio.setGdo0Action(setFlag, RISING);
 
   // start listening for packets
   Serial.print(F("[CC1101] Starting to listen ... "));

--- a/examples/CC1101/CC1101_Transmit_Interrupt/CC1101_Transmit_Interrupt.ino
+++ b/examples/CC1101/CC1101_Transmit_Interrupt/CC1101_Transmit_Interrupt.ino
@@ -51,7 +51,7 @@ void setup() {
   // NOTE: Unlike other modules (such as SX127x),
   //       different GDOx pins are used for
   //       transmit and receive interrupts!
-  radio.setGdo2Action(setFlag);
+  radio.setGdo2Action(setFlag, FALLING);
 
   // start transmitting the first packet
   Serial.print(F("[CC1101] Sending first packet ... "));

--- a/examples/NonArduino/Raspberry/main.cpp
+++ b/examples/NonArduino/Raspberry/main.cpp
@@ -1,0 +1,148 @@
+#include "RadioLib.h"
+#include "pigpio.h"
+
+class PiHal : public Hal {
+ public:
+  PiHal(uint8_t spiChannel = 0, uint32_t spiSpeed = 2000000)
+      : Hal(PI_INPUT, PI_OUTPUT, PI_LOW, PI_HIGH, RISING_EDGE, FALLING_EDGE),
+        _spiChannel(spiChannel),
+        _spiSpeed(spiSpeed) {}
+
+  void init() override {
+    gpioInitialise();
+    spiBegin();
+  }
+  void term() override {
+    spiEnd();
+    gpioTerminate();
+  }
+
+  void pinMode(uint32_t pin, uint32_t mode) override {
+    if (pin == RADIOLIB_NC) return;
+    gpioSetMode(pin, mode);
+  }
+
+  void digitalWrite(uint32_t pin, uint32_t value) override {
+    if (pin == RADIOLIB_NC) return;
+    gpioWrite(pin, value);
+  }
+
+  uint32_t digitalRead(uint32_t pin) override {
+    if (pin == RADIOLIB_NC) return 0;
+    return gpioRead(pin);
+  }
+
+  void attachInterrupt(uint32_t interruptNum, void (*interruptCb)(void),
+                       uint32_t mode) override {
+    if (interruptNum == RADIOLIB_NC) return;
+    gpioSetISRFunc(interruptNum, mode, 0, (gpioISRFunc_t)interruptCb);
+  }
+
+  void detachInterrupt(uint32_t interruptNum) override {
+    if (interruptNum == RADIOLIB_NC) return;
+    gpioSetISRFunc(interruptNum, NULL, NULL, nullptr);
+  }
+
+  void delay(unsigned long ms) override { gpioDelay(ms * 1000); }
+
+  void delayMicroseconds(unsigned long us) override { gpioDelay(us); }
+
+  unsigned long millis() override { return gpioTick() / 1000; }
+
+  unsigned long micros() override { return gpioTick(); }
+
+  long pulseIn(uint32_t pin, uint32_t state, unsigned long timeout) override {
+    if (pin == RADIOLIB_NC) return 0;
+    gpioSetMode(pin, PI_INPUT);
+    uint32_t start = gpioTick();
+    uint32_t curtick = gpioTick();
+
+    while (gpioRead(pin) == state)
+      if ((gpioTick() - curtick) > timeout) return 0;
+    while (gpioRead(pin) != state)
+      if ((gpioTick() - curtick) > timeout) return 0;
+    while (gpioRead(pin) == state)
+      if ((gpioTick() - curtick) > timeout) return 0;
+
+    return gpioTick() - start;
+  }
+
+  void spiBegin() {
+    if (_spiHandle < 0) {
+      _spiHandle = spiOpen(_spiChannel, _spiSpeed, 0);
+    }
+  }
+
+  void spiBeginTransaction() {}
+
+  uint8_t spiTransfer(uint8_t b) {
+    char ret;
+    spiXfer(_spiHandle, (char*)&b, &ret, 1);
+    return ret;
+  }
+
+  void spiEndTransaction() {}
+
+  void spiEnd() {
+    if (_spiHandle >= 0) {
+      spiClose(_spiHandle);
+      _spiHandle = -1;
+    }
+  }
+
+ private:
+  const unsigned int _spiSpeed;
+  const uint8_t _spiChannel;
+  int _spiHandle = -1;
+};
+
+CC1101 radio = new Module(new PiHal(), 8, 24, RADIOLIB_NC, 25);
+
+void onPacket() {
+  uint8_t* byteArr = new uint8_t[128];
+  int state = radio.readData(byteArr, sizeof(byteArr));
+
+  if (state == RADIOLIB_ERR_NONE) {
+    // packet was successfully received
+    printf("success!\n");
+
+    // print the data of the packet
+    printf("[CC1101] Data:\t\t");
+    for (int b = 0; b < sizeof(byteArr); b++){
+      printf("%X", byteArr[b]);
+    }
+    printf("\n");
+
+    // print RSSI (Received Signal Strength Indicator)
+    // of the last received packet
+    printf("[CC1101] RSSI:\t\t%d dBm\n", radio.getRSSI());
+
+    // print LQI (Link Quality Indicator)
+    // of the last received packet, lower is better
+    printf("[CC1101] LQI:\t\t%d\n", radio.getLQI());
+  } else if (state == RADIOLIB_ERR_RX_TIMEOUT) {
+    printf("timeout!\n");
+  } else if (state == RADIOLIB_ERR_CRC_MISMATCH) {
+    printf("CRC error!\n");
+  } else {
+    printf("failed, code %d\n", state);
+  }
+
+  radio.startReceive();
+}
+
+int main(int argc, char** argv) {
+  int state = radio.begin();
+  if (state != RADIOLIB_ERR_NONE) {
+    printf("init failed, code %d", state);
+    return 1;
+  }
+
+  radio.setGdo0Action(onPacket, RISING_EDGE);
+  state = radio.startReceive();
+  if (state != RADIOLIB_ERR_NONE) {
+    printf("start receive failed, code %d", state);
+    return 1;
+  }
+}
+

--- a/examples/STM32WLx/STM32WLx_Receive/STM32WLx_Receive.ino
+++ b/examples/STM32WLx/STM32WLx_Receive/STM32WLx_Receive.ino
@@ -32,7 +32,7 @@ STM32WLx radio = new STM32WLx_Module();
 
 // set RF switch configuration for Nucleo WL55JC1
 // NOTE: other boards may be different!
-static const RADIOLIB_PIN_TYPE rfswitch_pins[] =
+static const uint8_t rfswitch_pins[] =
                          {PC3,  PC4,  PC5};
 static const Module::RfSwitchMode_t rfswitch_table[] = {
   {STM32WLx::MODE_IDLE,  {LOW,  LOW,  LOW}},

--- a/examples/STM32WLx/STM32WLx_Receive/STM32WLx_Receive.ino
+++ b/examples/STM32WLx/STM32WLx_Receive/STM32WLx_Receive.ino
@@ -32,7 +32,7 @@ STM32WLx radio = new STM32WLx_Module();
 
 // set RF switch configuration for Nucleo WL55JC1
 // NOTE: other boards may be different!
-static const uint8_t rfswitch_pins[] =
+static const uint32_t rfswitch_pins[] =
                          {PC3,  PC4,  PC5};
 static const Module::RfSwitchMode_t rfswitch_table[] = {
   {STM32WLx::MODE_IDLE,  {LOW,  LOW,  LOW}},

--- a/examples/STM32WLx/STM32WLx_Receive_Interrupt/STM32WLx_Receive_Interrupt.ino
+++ b/examples/STM32WLx/STM32WLx_Receive_Interrupt/STM32WLx_Receive_Interrupt.ino
@@ -31,7 +31,7 @@ STM32WLx radio = new STM32WLx_Module();
 
 // set RF switch configuration for Nucleo WL55JC1
 // NOTE: other boards may be different!
-static const RADIOLIB_PIN_TYPE rfswitch_pins[] =
+static const uint8_t rfswitch_pins[] =
                          {PC3,  PC4,  PC5};
 static const Module::RfSwitchMode_t rfswitch_table[] = {
   {STM32WLx::MODE_IDLE,  {LOW,  LOW,  LOW}},

--- a/examples/STM32WLx/STM32WLx_Receive_Interrupt/STM32WLx_Receive_Interrupt.ino
+++ b/examples/STM32WLx/STM32WLx_Receive_Interrupt/STM32WLx_Receive_Interrupt.ino
@@ -31,7 +31,7 @@ STM32WLx radio = new STM32WLx_Module();
 
 // set RF switch configuration for Nucleo WL55JC1
 // NOTE: other boards may be different!
-static const uint8_t rfswitch_pins[] =
+static const uint32_t rfswitch_pins[] =
                          {PC3,  PC4,  PC5};
 static const Module::RfSwitchMode_t rfswitch_table[] = {
   {STM32WLx::MODE_IDLE,  {LOW,  LOW,  LOW}},

--- a/examples/STM32WLx/STM32WLx_Transmit/STM32WLx_Transmit.ino
+++ b/examples/STM32WLx/STM32WLx_Transmit/STM32WLx_Transmit.ino
@@ -28,7 +28,7 @@ STM32WLx radio = new STM32WLx_Module();
 
 // set RF switch configuration for Nucleo WL55JC1
 // NOTE: other boards may be different!
-static const uint8_t rfswitch_pins[] =
+static const uint32_t rfswitch_pins[] =
                          {PC3,  PC4,  PC5};
 static const Module::RfSwitchMode_t rfswitch_table[] = {
   {STM32WLx::MODE_IDLE,  {LOW,  LOW,  LOW}},

--- a/examples/STM32WLx/STM32WLx_Transmit/STM32WLx_Transmit.ino
+++ b/examples/STM32WLx/STM32WLx_Transmit/STM32WLx_Transmit.ino
@@ -28,7 +28,7 @@ STM32WLx radio = new STM32WLx_Module();
 
 // set RF switch configuration for Nucleo WL55JC1
 // NOTE: other boards may be different!
-static const RADIOLIB_PIN_TYPE rfswitch_pins[] =
+static const uint8_t rfswitch_pins[] =
                          {PC3,  PC4,  PC5};
 static const Module::RfSwitchMode_t rfswitch_table[] = {
   {STM32WLx::MODE_IDLE,  {LOW,  LOW,  LOW}},

--- a/examples/STM32WLx/STM32WLx_Transmit_Interrupt/STM32WLx_Transmit_Interrupt.ino
+++ b/examples/STM32WLx/STM32WLx_Transmit_Interrupt/STM32WLx_Transmit_Interrupt.ino
@@ -23,7 +23,7 @@ STM32WLx radio = new STM32WLx_Module();
 
 // set RF switch configuration for Nucleo WL55JC1
 // NOTE: other boards may be different!
-static const RADIOLIB_PIN_TYPE rfswitch_pins[] =
+static const uint8_t rfswitch_pins[] =
                          {PC3,  PC4,  PC5};
 static const Module::RfSwitchMode_t rfswitch_table[] = {
   {STM32WLx::MODE_IDLE,  {LOW,  LOW,  LOW}},

--- a/examples/STM32WLx/STM32WLx_Transmit_Interrupt/STM32WLx_Transmit_Interrupt.ino
+++ b/examples/STM32WLx/STM32WLx_Transmit_Interrupt/STM32WLx_Transmit_Interrupt.ino
@@ -23,7 +23,7 @@ STM32WLx radio = new STM32WLx_Module();
 
 // set RF switch configuration for Nucleo WL55JC1
 // NOTE: other boards may be different!
-static const uint8_t rfswitch_pins[] =
+static const uint32_t rfswitch_pins[] =
                          {PC3,  PC4,  PC5};
 static const Module::RfSwitchMode_t rfswitch_table[] = {
   {STM32WLx::MODE_IDLE,  {LOW,  LOW,  LOW}},

--- a/examples/SX127x/SX127x_Channel_Activity_Detection_Interrupt/SX127x_Channel_Activity_Detection_Interrupt.ino
+++ b/examples/SX127x/SX127x_Channel_Activity_Detection_Interrupt/SX127x_Channel_Activity_Detection_Interrupt.ino
@@ -47,11 +47,11 @@ void setup() {
 
   // set the function that will be called
   // when LoRa preamble is not detected within CAD timeout period
-  radio.setDio0Action(setFlagTimeout);
+  radio.setDio0Action(setFlagTimeout, RISING);
 
   // set the function that will be called
   // when LoRa preamble is detected
-  radio.setDio1Action(setFlagDetected);
+  radio.setDio1Action(setFlagDetected, RISING);
 
   // start scanning the channel
   Serial.print(F("[SX1278] Starting scan for LoRa preamble ... "));

--- a/examples/SX127x/SX127x_Channel_Activity_Detection_Receive/SX127x_Channel_Activity_Detection_Receive.ino
+++ b/examples/SX127x/SX127x_Channel_Activity_Detection_Receive/SX127x_Channel_Activity_Detection_Receive.ino
@@ -53,11 +53,11 @@ void setup() {
   // set the function that will be called
   // when LoRa preamble is not detected within CAD timeout period
   // or when a packet is received
-  radio.setDio0Action(setFlagTimeout);
+  radio.setDio0Action(setFlagTimeout, RISING);
 
   // set the function that will be called
   // when LoRa preamble is detected
-  radio.setDio1Action(setFlagDetected);
+  radio.setDio1Action(setFlagDetected, RISING);
 
   // start scanning the channel
   Serial.print(F("[SX1278] Starting scan for LoRa preamble ... "));

--- a/examples/SX127x/SX127x_PingPong/SX127x_PingPong.ino
+++ b/examples/SX127x/SX127x_PingPong/SX127x_PingPong.ino
@@ -60,7 +60,7 @@ void setup() {
 
   // set the function that will be called
   // when new packet is received
-  radio.setDio0Action(setFlag);
+  radio.setDio0Action(setFlag, RISING);
 
   #if defined(INITIATING_NODE)
     // send the first packet on this node

--- a/examples/SX127x/SX127x_Receive_FHSS/SX127x_Receive_FHSS.ino
+++ b/examples/SX127x/SX127x_Receive_FHSS/SX127x_Receive_FHSS.ino
@@ -96,10 +96,10 @@ void setup() {
   }
 
   // set the function to call when reception is finished
-  radio.setDio0Action(setRxFlag);
+  radio.setDio0Action(setRxFlag, RISING);
 
   // set the function to call when we need to change frequency
-  radio.setDio1Action(setFHSSFlag);
+  radio.setDio1Action(setFHSSFlag, RISING);
 
   // start listening for LoRa packets
   Serial.print(F("[SX1278] Starting to listen ... "));

--- a/examples/SX127x/SX127x_Receive_Interrupt/SX127x_Receive_Interrupt.ino
+++ b/examples/SX127x/SX127x_Receive_Interrupt/SX127x_Receive_Interrupt.ino
@@ -51,7 +51,7 @@ void setup() {
 
   // set the function that will be called
   // when new packet is received
-  radio.setDio0Action(setFlag);
+  radio.setDio0Action(setFlag, RISING);
 
   // start listening for LoRa packets
   Serial.print(F("[SX1278] Starting to listen ... "));

--- a/examples/SX127x/SX127x_Transmit_FHSS/SX127x_Transmit_FHSS.ino
+++ b/examples/SX127x/SX127x_Transmit_FHSS/SX127x_Transmit_FHSS.ino
@@ -108,10 +108,10 @@ void setup() {
   }
 
   // set the function to call when transmission is finished
-  radio.setDio0Action(setTxFlag);
+  radio.setDio0Action(setTxFlag, RISING);
 
   // set the function to call when we need to change frequency
-  radio.setDio1Action(setFHSSFlag);
+  radio.setDio1Action(setFHSSFlag, RISING);
 
   // start transmitting the first packet
   Serial.print(F("[SX1278] Sending first packet ... "));

--- a/examples/SX127x/SX127x_Transmit_Interrupt/SX127x_Transmit_Interrupt.ino
+++ b/examples/SX127x/SX127x_Transmit_Interrupt/SX127x_Transmit_Interrupt.ino
@@ -50,7 +50,7 @@ void setup() {
 
   // set the function that will be called
   // when packet transmission is finished
-  radio.setDio0Action(setFlag);
+  radio.setDio0Action(setFlag, RISING);
 
   // start transmitting the first packet
   Serial.print(F("[SX1278] Sending first packet ... "));

--- a/keywords.txt
+++ b/keywords.txt
@@ -9,6 +9,8 @@
 RadioLib	KEYWORD1
 RadioShield	KEYWORD1
 Module	KEYWORD1
+Hal	KEYWORD1
+ArduinoHal	KEYWORD1
 
 # modules
 CC1101	KEYWORD1

--- a/src/ArduinoHal.cpp
+++ b/src/ArduinoHal.cpp
@@ -84,7 +84,7 @@ void inline ArduinoHal::spiEnd() {
 void inline ArduinoHal::tone(uint8_t pin, unsigned int frequency, unsigned long duration) {
   #if !defined(RADIOLIB_TONE_UNSUPPORTED)
   if (pin == RADIOLIB_NC) {
-    return 0;
+    return;
   }
   ::tone(pin, frequency, duration);
   #elif defined(ESP32)
@@ -110,17 +110,17 @@ void inline ArduinoHal::tone(uint8_t pin, unsigned int frequency, unsigned long 
 void inline ArduinoHal::noTone(uint8_t pin) {
   #if !defined(RADIOLIB_TONE_UNSUPPORTED) and defined(ARDUINO_ARCH_STM32)
   if (pin == RADIOLIB_NC) {
-    return 0;
+    return;
   }
   ::noTone(pin, false);
   #elif !defined(RADIOLIB_TONE_UNSUPPORTED)
   if (pin == RADIOLIB_NC) {
-    return 0;
+    return;
   }
   ::noTone(pin);
   #elif defined(ESP32)
   if (pin == RADIOLIB_NC) {
-    return 0;
+    return;
   }
   // ESP32 tone() emulation
   ledcDetachPin(pin);
@@ -128,7 +128,7 @@ void inline ArduinoHal::noTone(uint8_t pin) {
   _prev = -1;
   #elif defined(RADIOLIB_MBED_TONE_OVERRIDE)
   if (pin == RADIOLIB_NC) {
-    return 0;
+    return;
   }
   // better tone for mbed OS boards
   (void)pin;

--- a/src/ArduinoHal.cpp
+++ b/src/ArduinoHal.cpp
@@ -18,31 +18,31 @@ void ArduinoHal::term() {
   }
 }
 
-void inline ArduinoHal::pinMode(uint8_t pin, uint8_t mode) {
+void inline ArduinoHal::pinMode(uint32_t pin, uint32_t mode) {
   if (pin == RADIOLIB_NC) {
     return;
   }
   ::pinMode(pin, RADIOLIB_ARDUINOHAL_PIN_MODE_CAST mode);
 }
-void inline ArduinoHal::digitalWrite(uint8_t pin, uint8_t value) {
+void inline ArduinoHal::digitalWrite(uint32_t pin, uint32_t value) {
   if (pin == RADIOLIB_NC) {
     return;
   }
   ::digitalWrite(pin, RADIOLIB_ARDUINOHAL_PIN_STATUS_CAST value);
 }
-uint8_t inline ArduinoHal::digitalRead(uint8_t pin) {
+uint32_t inline ArduinoHal::digitalRead(uint32_t pin) {
   if (pin == RADIOLIB_NC) {
     return 0;
   }
   return ::digitalRead(pin);
 }
-void inline ArduinoHal::attachInterrupt(uint8_t interruptNum, void (*interruptCb)(void), uint8_t mode) {
+void inline ArduinoHal::attachInterrupt(uint32_t interruptNum, void (*interruptCb)(void), uint32_t mode) {
   if (interruptNum == RADIOLIB_NC) {
     return;
   }
   ::attachInterrupt(interruptNum, interruptCb,  RADIOLIB_ARDUINOHAL_INTERRUPT_MODE_CAST mode);
 }
-void inline ArduinoHal::detachInterrupt(uint8_t interruptNum) {
+void inline ArduinoHal::detachInterrupt(uint32_t interruptNum) {
   if (interruptNum == RADIOLIB_NC) {
     return;
   }
@@ -60,7 +60,7 @@ unsigned long inline ArduinoHal::millis() {
 unsigned long inline ArduinoHal::micros() {
   return ::micros();
 }
-long inline ArduinoHal::pulseIn(uint8_t pin, uint8_t state, unsigned long timeout) {
+long inline ArduinoHal::pulseIn(uint32_t pin, uint32_t state, unsigned long timeout) {
   if (pin == RADIOLIB_NC) {
     return 0;
   }
@@ -81,7 +81,7 @@ void inline ArduinoHal::spiEndTransaction() {
 void inline ArduinoHal::spiEnd() {
   _spi->end();
 }
-void inline ArduinoHal::tone(uint8_t pin, unsigned int frequency, unsigned long duration) {
+void inline ArduinoHal::tone(uint32_t pin, unsigned int frequency, unsigned long duration) {
   #if !defined(RADIOLIB_TONE_UNSUPPORTED)
   if (pin == RADIOLIB_NC) {
     return;
@@ -107,7 +107,7 @@ void inline ArduinoHal::tone(uint8_t pin, unsigned int frequency, unsigned long 
   pwmPin->write(0.5);
   #endif
 }
-void inline ArduinoHal::noTone(uint8_t pin) {
+void inline ArduinoHal::noTone(uint32_t pin) {
   #if !defined(RADIOLIB_TONE_UNSUPPORTED) and defined(ARDUINO_ARCH_STM32)
   if (pin == RADIOLIB_NC) {
     return;
@@ -140,7 +140,7 @@ void inline ArduinoHal::yield() {
   ::yield();
   #endif
 }
-uint8_t inline ArduinoHal::pinToInterrupt(uint8_t pin) {
+uint32_t inline ArduinoHal::pinToInterrupt(uint32_t pin) {
   return digitalPinToInterrupt(pin);
 }
 #endif

--- a/src/ArduinoHal.cpp
+++ b/src/ArduinoHal.cpp
@@ -1,0 +1,146 @@
+#include "ArduinoHal.h"
+
+#if defined(RADIOLIB_BUILD_ARDUINO)
+
+ArduinoHal::ArduinoHal(SPIClass& spi, SPISettings spiSettings): Hal(INPUT, OUTPUT, LOW, HIGH, RISING, FALLING), _spi(&spi), _spiSettings(spiSettings) {}
+
+ArduinoHal::ArduinoHal(): Hal(INPUT, OUTPUT, LOW, HIGH, RISING, FALLING), _spi(&RADIOLIB_DEFAULT_SPI), _initInterface(true) {}
+
+void ArduinoHal::init() {
+  if(_initInterface) {
+    spiBegin();
+  }
+}
+
+void ArduinoHal::term() {
+  if(_initInterface) {
+    spiEnd();
+  }
+}
+
+void inline ArduinoHal::pinMode(uint8_t pin, uint8_t mode) {
+  if (pin == RADIOLIB_NC) {
+    return;
+  }
+  ::pinMode(pin, RADIOLIB_ARDUINOHAL_PIN_MODE_CAST mode);
+}
+void inline ArduinoHal::digitalWrite(uint8_t pin, uint8_t value) {
+  if (pin == RADIOLIB_NC) {
+    return;
+  }
+  ::digitalWrite(pin, RADIOLIB_ARDUINOHAL_PIN_STATUS_CAST value);
+}
+uint8_t inline ArduinoHal::digitalRead(uint8_t pin) {
+  if (pin == RADIOLIB_NC) {
+    return 0;
+  }
+  return ::digitalRead(pin);
+}
+void inline ArduinoHal::attachInterrupt(uint8_t interruptNum, void (*interruptCb)(void), uint8_t mode) {
+  if (interruptNum == RADIOLIB_NC) {
+    return;
+  }
+  ::attachInterrupt(interruptNum, interruptCb,  RADIOLIB_ARDUINOHAL_INTERRUPT_MODE_CAST mode);
+}
+void inline ArduinoHal::detachInterrupt(uint8_t interruptNum) {
+  if (interruptNum == RADIOLIB_NC) {
+    return;
+  }
+  ::detachInterrupt(interruptNum);
+}
+void inline ArduinoHal::delay(unsigned long ms) {
+  ::delay(ms);
+}
+void inline ArduinoHal::delayMicroseconds(unsigned long us) {
+  ::delayMicroseconds(us);
+}
+unsigned long inline ArduinoHal::millis() {
+  return ::millis();
+}
+unsigned long inline ArduinoHal::micros() {
+  return ::micros();
+}
+long inline ArduinoHal::pulseIn(uint8_t pin, uint8_t state, unsigned long timeout) {
+  if (pin == RADIOLIB_NC) {
+    return 0;
+  }
+  return ::pulseIn(pin, state, timeout);
+}
+void inline ArduinoHal::spiBegin() {
+  _spi->begin();
+}
+void inline ArduinoHal::spiBeginTransaction() {
+  _spi->beginTransaction(_spiSettings);
+}
+uint8_t inline ArduinoHal::spiTransfer(uint8_t b) {
+  return _spi->transfer(b);
+}
+void inline ArduinoHal::spiEndTransaction() {
+  _spi->endTransaction();
+}
+void inline ArduinoHal::spiEnd() {
+  _spi->end();
+}
+void inline ArduinoHal::tone(uint8_t pin, unsigned int frequency, unsigned long duration) {
+  #if !defined(RADIOLIB_TONE_UNSUPPORTED)
+  if (pin == RADIOLIB_NC) {
+    return 0;
+  }
+  ::tone(pin, frequency, duration);
+  #elif defined(ESP32)
+  // ESP32 tone() emulation
+  (void)duration;
+  if(_prev == -1) {
+    ledcAttachPin(pin, RADIOLIB_TONE_ESP32_CHANNEL);
+  }
+  if(_prev != frequency) {
+    ledcWriteTone(RADIOLIB_TONE_ESP32_CHANNEL, frequency);
+  }
+  _prev = frequency;
+  #elif defined(RADIOLIB_MBED_TONE_OVERRIDE)
+  // better tone for mbed OS boards
+  (void)duration;
+  if(!pwmPin) {
+    pwmPin = new mbed::PwmOut(digitalPinToPinName(pin));
+  }
+  pwmPin->period(1.0 / frequency);
+  pwmPin->write(0.5);
+  #endif
+}
+void inline ArduinoHal::noTone(uint8_t pin) {
+  #if !defined(RADIOLIB_TONE_UNSUPPORTED) and defined(ARDUINO_ARCH_STM32)
+  if (pin == RADIOLIB_NC) {
+    return 0;
+  }
+  ::noTone(pin, false);
+  #elif !defined(RADIOLIB_TONE_UNSUPPORTED)
+  if (pin == RADIOLIB_NC) {
+    return 0;
+  }
+  ::noTone(pin);
+  #elif defined(ESP32)
+  if (pin == RADIOLIB_NC) {
+    return 0;
+  }
+  // ESP32 tone() emulation
+  ledcDetachPin(pin);
+  ledcWrite(RADIOLIB_TONE_ESP32_CHANNEL, 0);
+  _prev = -1;
+  #elif defined(RADIOLIB_MBED_TONE_OVERRIDE)
+  if (pin == RADIOLIB_NC) {
+    return 0;
+  }
+  // better tone for mbed OS boards
+  (void)pin;
+  pwmPin->suspend();
+  #endif
+}
+void inline ArduinoHal::yield() {
+  #if !defined(RADIOLIB_YIELD_UNSUPPORTED)
+  ::yield();
+  #endif
+}
+uint8_t inline ArduinoHal::pinToInterrupt(uint8_t pin) {
+  return digitalPinToInterrupt(pin);
+}
+#endif

--- a/src/ArduinoHal.h
+++ b/src/ArduinoHal.h
@@ -14,6 +14,12 @@
 
 #include <SPI.h>
 
+/*!
+  \class ArduinoHal
+
+  \brief Arduino default hardware abstraction library implementation.
+  This class can be extended to support other Arduino platform or change behaviour of the default implementation
+*/
 class ArduinoHal : public Hal {
   public:
     /*!
@@ -33,25 +39,25 @@ class ArduinoHal : public Hal {
     void init() override;
     void term() override;
 
-    void pinMode(uint8_t pin, uint8_t mode) override;
-    void digitalWrite(uint8_t pin, uint8_t value) override;
-    uint8_t digitalRead(uint8_t pin) override;
-    void attachInterrupt(uint8_t interruptNum, void (*interruptCb)(void), uint8_t mode) override;
-    void detachInterrupt(uint8_t interruptNum) override;
+    void pinMode(uint32_t pin, uint32_t mode) override;
+    void digitalWrite(uint32_t pin, uint32_t value) override;
+    uint32_t digitalRead(uint32_t pin) override;
+    void attachInterrupt(uint32_t interruptNum, void (*interruptCb)(void), uint32_t mode) override;
+    void detachInterrupt(uint32_t interruptNum) override;
     void delay(unsigned long ms) override;
     void delayMicroseconds(unsigned long us) override;
     unsigned long millis() override;
     unsigned long micros() override;
-    long pulseIn(uint8_t pin, uint8_t state, unsigned long timeout) override;
+    long pulseIn(uint32_t pin, uint32_t state, unsigned long timeout) override;
     void spiBegin() override;
     void spiBeginTransaction() override;
     uint8_t spiTransfer(uint8_t b) override;
     void spiEndTransaction() override;
     void spiEnd() override;
-    void tone(uint8_t pin, unsigned int frequency, unsigned long duration = 0) override;
-    void noTone(uint8_t pin) override;
+    void tone(uint32_t pin, unsigned int frequency, unsigned long duration = 0) override;
+    void noTone(uint32_t pin) override;
     void yield() override;
-    uint8_t pinToInterrupt(uint8_t pin) override;
+    uint32_t pinToInterrupt(uint32_t pin) override;
 
 #if !defined(RADIOLIB_GODMODE)
   private:

--- a/src/ArduinoHal.h
+++ b/src/ArduinoHal.h
@@ -16,7 +16,18 @@
 
 class ArduinoHal : public Hal {
   public:
+    /*!
+      \brief Arduino Hal constructor. Will use the default SPI interface and automatically initialize it.
+    */
     ArduinoHal();
+
+    /*!
+      \brief Arduino Hal constructor. Will not attempt SPI interface initialization.
+
+      \param spi SPI interface to be used, can also use software SPI implementations.
+
+      \param spiSettings SPI interface settings.
+    */
     ArduinoHal(SPIClass& spi, SPISettings spiSettings = RADIOLIB_DEFAULT_SPI_SETTINGS);
 
     void init() override;

--- a/src/ArduinoHal.h
+++ b/src/ArduinoHal.h
@@ -1,0 +1,62 @@
+#include "TypeDef.h"
+
+#if !defined(_RADIOLIB_ARDUINOHAL_H)
+#define _RADIOLIB_ARDUINOHAL_H
+
+#if defined(RADIOLIB_BUILD_ARDUINO)
+
+#if defined(RADIOLIB_MBED_TONE_OVERRIDE)
+#include "mbed.h"
+#endif
+
+#include "Hal.h"
+#include <stdint.h>
+
+#include <SPI.h>
+
+class ArduinoHal : public Hal {
+  public:
+    ArduinoHal();
+    ArduinoHal(SPIClass& spi, SPISettings spiSettings = RADIOLIB_DEFAULT_SPI_SETTINGS);
+
+    void init() override;
+    void term() override;
+
+    void pinMode(uint8_t pin, uint8_t mode) override;
+    void digitalWrite(uint8_t pin, uint8_t value) override;
+    uint8_t digitalRead(uint8_t pin) override;
+    void attachInterrupt(uint8_t interruptNum, void (*interruptCb)(void), uint8_t mode) override;
+    void detachInterrupt(uint8_t interruptNum) override;
+    void delay(unsigned long ms) override;
+    void delayMicroseconds(unsigned long us) override;
+    unsigned long millis() override;
+    unsigned long micros() override;
+    long pulseIn(uint8_t pin, uint8_t state, unsigned long timeout) override;
+    void spiBegin() override;
+    void spiBeginTransaction() override;
+    uint8_t spiTransfer(uint8_t b) override;
+    void spiEndTransaction() override;
+    void spiEnd() override;
+    void tone(uint8_t pin, unsigned int frequency, unsigned long duration = 0) override;
+    void noTone(uint8_t pin) override;
+    void yield() override;
+    uint8_t pinToInterrupt(uint8_t pin) override;
+
+#if !defined(RADIOLIB_GODMODE)
+  private:
+#endif
+    SPIClass* _spi = NULL;
+    SPISettings _spiSettings = RADIOLIB_DEFAULT_SPI_SETTINGS;
+    bool _initInterface = false;
+
+    #if defined(RADIOLIB_MBED_TONE_OVERRIDE)
+    mbed::PwmOut *pwmPin = NULL;
+    #endif
+
+    #if defined(ESP32)
+    int32_t _prev = -1;
+    #endif
+};
+
+#endif
+#endif

--- a/src/BuildOpt.h
+++ b/src/BuildOpt.h
@@ -221,7 +221,7 @@
 #endif
 
   #if !defined(RADIOLIB_NC)
-  #define RADIOLIB_NC                                 (0xFF)
+  #define RADIOLIB_NC                                 (0xFFFFFFFF)
   #endif
   #if !defined(RADIOLIB_DEFAULT_SPI)
   #define RADIOLIB_DEFAULT_SPI                        SPI

--- a/src/BuildOpt.h
+++ b/src/BuildOpt.h
@@ -7,21 +7,16 @@
   #define RADIOLIB_BUILD_ARDUINO
 #else
   // generic build
+  #include <stdio.h>
   #define RADIOLIB_BUILD_GENERIC
 #endif
 
 #if defined(RADIOLIB_BUILD_ARDUINO)
-
 /*
  * Platform-specific configuration.
  *
  * RADIOLIB_PLATFORM - platform name, used in debugging to quickly check the correct platform is detected.
- * RADIOLIB_PIN_TYPE - which type should be used for pin numbers in functions like digitalRead().
- * RADIOLIB_PIN_MODE - which type should be used for pin modes in functions like pinMode().
- * RADIOLIB_PIN_STATUS - which type should be used for pin values in functions like digitalWrite().
- * RADIOLIB_INTERRUPT_STATUS - which type should be used for pin changes in functions like attachInterrupt().
- * RADIOLIB_DIGITAL_PIN_TO_INTERRUPT - function/macro to be used to convert digital pin number to interrupt pin number.
- * RADIOLIB_NC - alias for unused pin, usually the largest possible value of RADIOLIB_PIN_TYPE.
+ * RADIOLIB_NC - alias for unused pin, usually the largest possible value of uint8_t.
  * RADIOLIB_DEFAULT_SPI - default SPIClass instance to use.
  * RADIOLIB_NONVOLATILE - macro to place variable into program storage (usually Flash).
  * RADIOLIB_NONVOLATILE_READ_BYTE - function/macro to read variables saved in program storage (usually Flash).
@@ -36,51 +31,16 @@
  * platform detection.
  */
 
-// uncomment to enable custom platform definition
-//#define RADIOLIB_CUSTOM_ARDUINO
+  // uncomment to enable custom platform definition
+  //#define RADIOLIB_CUSTOM_ARDUINO
 
 #if defined(RADIOLIB_CUSTOM_ARDUINO)
   // name for your platform
   #define RADIOLIB_PLATFORM                           "Custom"
 
-  // the following parameters must always be defined
-  #define RADIOLIB_PIN_TYPE                           uint8_t
-  #define RADIOLIB_PIN_MODE                           uint8_t
-  #define RADIOLIB_PIN_STATUS                         uint8_t
-  #define RADIOLIB_INTERRUPT_STATUS                   RADIOLIB_PIN_STATUS
-  #define RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(p)        digitalPinToInterrupt(p)
-  #define RADIOLIB_NC                                 (0xFF)
-  #define RADIOLIB_DEFAULT_SPI                        SPI
-  #define RADIOLIB_DEFAULT_SPI_SETTINGS               SPISettings(2000000, MSBFIRST, SPI_MODE0)
-  #define RADIOLIB_NONVOLATILE                        PROGMEM
-  #define RADIOLIB_NONVOLATILE_READ_BYTE(addr)        pgm_read_byte(addr)
-  #define RADIOLIB_TYPE_ALIAS(type, alias)            using alias = type;
-
-  // Arduino API callbacks
-  // the following are signatures of Arduino API functions of the custom platform
-  // for example, pinMode on Arduino Uno is defined as void pinMode(uint8_t pin, uint8_t mode)
-  // all of the callbacks below are taken from Arduino Uno
-  #define RADIOLIB_CB_ARGS_PIN_MODE                   (void, pinMode, uint8_t pin, uint8_t mode)
-  #define RADIOLIB_CB_ARGS_DIGITAL_WRITE              (void, digitalWrite, uint8_t pin, uint8_t value)
-  #define RADIOLIB_CB_ARGS_DIGITAL_READ               (int, digitalRead, uint8_t pin)
-  #define RADIOLIB_CB_ARGS_TONE                       (void, tone, uint8_t _pin, unsigned int frequency, unsigned long duration)
-  #define RADIOLIB_CB_ARGS_NO_TONE                    (void, noTone, uint8_t _pin)
-  #define RADIOLIB_CB_ARGS_ATTACH_INTERRUPT           (void, attachInterrupt, uint8_t interruptNum, void (*userFunc)(void), int mode)
-  #define RADIOLIB_CB_ARGS_DETACH_INTERRUPT           (void, detachInterrupt, uint8_t interruptNum)
-  #define RADIOLIB_CB_ARGS_YIELD                      (void, yield, void)
-  #define RADIOLIB_CB_ARGS_DELAY                      (void, delay, unsigned long ms)
-  #define RADIOLIB_CB_ARGS_DELAY_MICROSECONDS         (void, delayMicroseconds, unsigned int us)
-  #define RADIOLIB_CB_ARGS_MILLIS                     (unsigned long, millis, void)
-  #define RADIOLIB_CB_ARGS_MICROS                     (unsigned long, micros, void)
-  #define RADIOLIB_CB_ARGS_PULSE_IN                   (unsigned long, pulseIn, uint8_t pin, uint8_t state, unsigned long timeout)
-  #define RADIOLIB_CB_ARGS_SPI_BEGIN                  (void, SPIbegin, void)
-  #define RADIOLIB_CB_ARGS_SPI_BEGIN_TRANSACTION      (void, SPIbeginTransaction, void)
-  #define RADIOLIB_CB_ARGS_SPI_TRANSFER               (uint8_t, SPItransfer, uint8_t b)
-  #define RADIOLIB_CB_ARGS_SPI_END_TRANSACTION        (void, SPIendTransaction, void)
-  #define RADIOLIB_CB_ARGS_SPI_END                    (void, SPIend, void)
-
-  // the following must be defined if the Arduino core does not support tone function
+  // the following must be defined if the Arduino core does not support tone or yield function
   //#define RADIOLIB_TONE_UNSUPPORTED
+  //#define RADIOLIB_YIELD_UNSUPPORTED
 
   // some of RadioLib drivers may be excluded, to prevent collisions with platforms (or to speed up build process)
   // the following is a complete list of all possible exclusion macros, uncomment any of them to disable that driver
@@ -105,833 +65,218 @@
   //#define RADIOLIB_EXCLUDE_RTTY
   //#define RADIOLIB_EXCLUDE_SSTV
   //#define RADIOLIB_EXCLUDE_DIRECT_RECEIVE
+#elif defined(__AVR__) && !(defined(ARDUINO_AVR_UNO_WIFI_REV2) || defined(ARDUINO_AVR_NANO_EVERY) || defined(ARDUINO_ARCH_MEGAAVR))
+  // Arduino AVR boards (except for megaAVR) - Uno, Mega etc.
+  #define RADIOLIB_PLATFORM                           "Arduino AVR"
+#elif defined(ESP8266)
+  // ESP8266 boards
+  #define RADIOLIB_PLATFORM                           "ESP8266"
+#elif defined(ESP32)
+  // ESP32 boards
+  #define RADIOLIB_PLATFORM                           "ESP32"
+  // ESP32 doesn't support tone(), but it can be emulated via LED control peripheral
+  #define RADIOLIB_TONE_UNSUPPORTED
+  #define RADIOLIB_TONE_ESP32_CHANNEL                 (1)
+#elif defined(ARDUINO_ARCH_STM32)
+  // official STM32 Arduino core (https://github.com/stm32duino/Arduino_Core_STM32)
+  #define RADIOLIB_PLATFORM                           "Arduino STM32 (official)"
+#elif defined(SAMD_SERIES)
+  // Adafruit SAMD boards (M0 and M4)
+  #define RADIOLIB_PLATFORM                           "Adafruit SAMD"
+#elif defined(ARDUINO_ARCH_SAMD)
+  // Arduino SAMD (Zero, MKR, etc.)
+  #define RADIOLIB_PLATFORM                           "Arduino SAMD"
 
-#else
-  #if defined(__AVR__) && !(defined(ARDUINO_AVR_UNO_WIFI_REV2) || defined(ARDUINO_AVR_NANO_EVERY) || defined(ARDUINO_ARCH_MEGAAVR))
-    // Arduino AVR boards (except for megaAVR) - Uno, Mega etc.
-    #define RADIOLIB_PLATFORM                           "Arduino AVR"
-    #define RADIOLIB_PIN_TYPE                           uint8_t
-    #define RADIOLIB_PIN_MODE                           uint8_t
-    #define RADIOLIB_PIN_STATUS                         uint8_t
-    #define RADIOLIB_INTERRUPT_STATUS                   RADIOLIB_PIN_STATUS
-    #define RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(p)        digitalPinToInterrupt(p)
-    #define RADIOLIB_NC                                 (0xFF)
-    #define RADIOLIB_DEFAULT_SPI                        SPI
-    #define RADIOLIB_DEFAULT_SPI_SETTINGS               SPISettings(2000000, MSBFIRST, SPI_MODE0)
-    #define RADIOLIB_NONVOLATILE                        PROGMEM
-    #define RADIOLIB_NONVOLATILE_READ_BYTE(addr)        pgm_read_byte(addr)
-    #define RADIOLIB_NONVOLATILE_READ_DWORD(addr)       pgm_read_dword(addr)
-    #define RADIOLIB_TYPE_ALIAS(type, alias)            using alias = type;
+  #define RADIOLIB_ARDUINOHAL_PIN_MODE_CAST (PinMode)
+  #define RADIOLIB_ARDUINOHAL_PIN_STATUS_CAST (PinStatus)
+  #define RADIOLIB_ARDUINOHAL_INTERRUPT_MODE_CAST (PinStatus)  
+#elif defined(__SAM3X8E__)
+  // Arduino Due
+  #define RADIOLIB_PLATFORM                           "Arduino Due"
+  #define RADIOLIB_TONE_UNSUPPORTED
+#elif (defined(NRF52832_XXAA) || defined(NRF52840_XXAA)) && !defined(ARDUINO_ARDUINO_NANO33BLE)
+  // Adafruit nRF52 boards
+  #define RADIOLIB_PLATFORM                           "Adafruit nRF52"
+#elif defined(ARDUINO_ARC32_TOOLS)
+  // Intel Curie
+  #define RADIOLIB_PLATFORM                           "Intel Curie"
+#elif defined(ARDUINO_AVR_UNO_WIFI_REV2) || defined(ARDUINO_AVR_NANO_EVERY) || defined(PORTDUINO)
+  // Arduino megaAVR boards - Uno Wifi Rev.2, Nano Every
+  #define RADIOLIB_PLATFORM                           "Arduino megaAVR"
+#elif defined(ARDUINO_ARCH_APOLLO3)
+  // Sparkfun Apollo3 boards
+  #define RADIOLIB_PLATFORM                           "Sparkfun Apollo3"
 
-    // Arduino API callbacks
-    #define RADIOLIB_CB_ARGS_PIN_MODE                   (void, pinMode, uint8_t pin, uint8_t mode)
-    #define RADIOLIB_CB_ARGS_DIGITAL_WRITE              (void, digitalWrite, uint8_t pin, uint8_t value)
-    #define RADIOLIB_CB_ARGS_DIGITAL_READ               (int, digitalRead, uint8_t pin)
-    #define RADIOLIB_CB_ARGS_TONE                       (void, tone, uint8_t _pin, unsigned int frequency, unsigned long duration)
-    #define RADIOLIB_CB_ARGS_NO_TONE                    (void, noTone, uint8_t _pin)
-    #define RADIOLIB_CB_ARGS_ATTACH_INTERRUPT           (void, attachInterrupt, uint8_t interruptNum, void (*userFunc)(void), int mode)
-    #define RADIOLIB_CB_ARGS_DETACH_INTERRUPT           (void, detachInterrupt, uint8_t interruptNum)
-    #define RADIOLIB_CB_ARGS_YIELD                      (void, yield, void)
-    #define RADIOLIB_CB_ARGS_DELAY                      (void, delay, unsigned long ms)
-    #define RADIOLIB_CB_ARGS_DELAY_MICROSECONDS         (void, delayMicroseconds, unsigned int us)
-    #define RADIOLIB_CB_ARGS_MILLIS                     (unsigned long, millis, void)
-    #define RADIOLIB_CB_ARGS_MICROS                     (unsigned long, micros, void)
-    #define RADIOLIB_CB_ARGS_PULSE_IN                   (unsigned long, pulseIn, uint8_t pin, uint8_t state, unsigned long timeout)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN                  (void, SPIbegin, void)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN_TRANSACTION      (void, SPIbeginTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_TRANSFER               (uint8_t, SPItransfer, uint8_t b)
-    #define RADIOLIB_CB_ARGS_SPI_END_TRANSACTION        (void, SPIendTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_END                    (void, SPIend, void)
+  #define RADIOLIB_ARDUINOHAL_PIN_MODE_CAST (Arduino_PinMode)
+  #define RADIOLIB_ARDUINOHAL_PIN_STATUS_CAST (PinStatus)
+  #define RADIOLIB_ARDUINOHAL_INTERRUPT_MODE_CAST (PinStatus)
+#elif defined(ARDUINO_ARDUINO_NANO33BLE)
+  // Arduino Nano 33 BLE
+  #define RADIOLIB_PLATFORM                           "Arduino Nano 33 BLE"
 
-  #elif defined(ESP8266)
-    // ESP8266 boards
-    #define RADIOLIB_PLATFORM                           "ESP8266"
-    #define RADIOLIB_PIN_TYPE                           uint8_t
-    #define RADIOLIB_PIN_MODE                           uint8_t
-    #define RADIOLIB_PIN_STATUS                         uint8_t
-    #define RADIOLIB_INTERRUPT_STATUS                   RADIOLIB_PIN_STATUS
-    #define RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(p)        digitalPinToInterrupt(p)
-    #define RADIOLIB_NC                                 (0xFF)
-    #define RADIOLIB_DEFAULT_SPI                        SPI
-    #define RADIOLIB_DEFAULT_SPI_SETTINGS               SPISettings(2000000, MSBFIRST, SPI_MODE0)
-    #define RADIOLIB_NONVOLATILE                        PROGMEM
-    #define RADIOLIB_NONVOLATILE_READ_BYTE(addr)        pgm_read_byte(addr)
-    #define RADIOLIB_NONVOLATILE_READ_DWORD(addr)       pgm_read_dword(addr)
-    #define RADIOLIB_TYPE_ALIAS(type, alias)            using alias = type;
+  #define RADIOLIB_ARDUINOHAL_PIN_MODE_CAST (PinMode)
+  #define RADIOLIB_ARDUINOHAL_PIN_STATUS_CAST (PinStatus)
+  #define RADIOLIB_ARDUINOHAL_INTERRUPT_MODE_CAST (PinStatus)
 
-    // Arduino API callbacks
-    #define RADIOLIB_CB_ARGS_PIN_MODE                   (void, pinMode, uint8_t pin, uint8_t mode)
-    #define RADIOLIB_CB_ARGS_DIGITAL_WRITE              (void, digitalWrite, uint8_t pin, uint8_t value)
-    #define RADIOLIB_CB_ARGS_DIGITAL_READ               (int, digitalRead, uint8_t pin)
-    #define RADIOLIB_CB_ARGS_TONE                       (void, tone, uint8_t _pin, unsigned int frequency, unsigned long duration)
-    #define RADIOLIB_CB_ARGS_NO_TONE                    (void, noTone, uint8_t _pin)
-    #define RADIOLIB_CB_ARGS_ATTACH_INTERRUPT           (void, attachInterrupt, uint8_t pin, void (*)(void), int mode)
-    #define RADIOLIB_CB_ARGS_DETACH_INTERRUPT           (void, detachInterrupt, uint8_t interruptNum)
-    #define RADIOLIB_CB_ARGS_YIELD                      (void, yield, void)
-    #define RADIOLIB_CB_ARGS_DELAY                      (void, delay, unsigned long)
-    #define RADIOLIB_CB_ARGS_DELAY_MICROSECONDS         (void, delayMicroseconds, unsigned int us)
-    #define RADIOLIB_CB_ARGS_MILLIS                     (unsigned long, millis, void)
-    #define RADIOLIB_CB_ARGS_MICROS                     (unsigned long, micros, void)
-    #define RADIOLIB_CB_ARGS_PULSE_IN                   (unsigned long, pulseIn, uint8_t pin, uint8_t state, unsigned long timeout)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN                  (void, SPIbegin, void)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN_TRANSACTION      (void, SPIbeginTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_TRANSFER               (uint8_t, SPItransfer, uint8_t b)
-    #define RADIOLIB_CB_ARGS_SPI_END_TRANSACTION        (void, SPIendTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_END                    (void, SPIend, void)
+  // Arduino mbed OS boards have a really bad tone implementation which will crash after a couple seconds
+  #define RADIOLIB_TONE_UNSUPPORTED
+  #define RADIOLIB_MBED_TONE_OVERRIDE
+#elif defined(ARDUINO_PORTENTA_H7_M7) || defined(ARDUINO_PORTENTA_H7_M4)
+  // Arduino Portenta H7
+  #define RADIOLIB_PLATFORM                           "Portenta H7"
 
-  #elif defined(ESP32)
-    // ESP32 boards
-    #define RADIOLIB_PLATFORM                           "ESP32"
-    #define RADIOLIB_PIN_TYPE                           uint8_t
-    #define RADIOLIB_PIN_MODE                           uint8_t
-    #define RADIOLIB_PIN_STATUS                         uint8_t
-    #define RADIOLIB_INTERRUPT_STATUS                   RADIOLIB_PIN_STATUS
-    #define RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(p)        digitalPinToInterrupt(p)
-    #define RADIOLIB_NC                                 (0xFF)
-    #define RADIOLIB_DEFAULT_SPI                        SPI
-    #define RADIOLIB_DEFAULT_SPI_SETTINGS               SPISettings(2000000, MSBFIRST, SPI_MODE0)
-    #define RADIOLIB_NONVOLATILE                        PROGMEM
-    #define RADIOLIB_NONVOLATILE_READ_BYTE(addr)        pgm_read_byte(addr)
-    #define RADIOLIB_NONVOLATILE_READ_DWORD(addr)       pgm_read_dword(addr)
-    #define RADIOLIB_TYPE_ALIAS(type, alias)            using alias = type;
+  #define RADIOLIB_ARDUINOHAL_PIN_MODE_CAST (PinMode)
+  #define RADIOLIB_ARDUINOHAL_PIN_STATUS_CAST (PinStatus)
+  #define RADIOLIB_ARDUINOHAL_INTERRUPT_MODE_CAST (PinStatus)
 
-    // ESP32 doesn't support tone(), but it can be emulated via LED control peripheral
-    #define RADIOLIB_TONE_UNSUPPORTED
-    #define RADIOLIB_TONE_ESP32_CHANNEL                 (1)
+  // Arduino mbed OS boards have a really bad tone implementation which will crash after a couple seconds
+  #define RADIOLIB_TONE_UNSUPPORTED
+  #define RADIOLIB_MBED_TONE_OVERRIDE
+#elif defined(__STM32F4__) || defined(__STM32F1__)
+  // Arduino STM32 core by Roger Clark (https://github.com/rogerclarkmelbourne/Arduino_STM32)
+  #define RADIOLIB_PLATFORM                           "STM32duino (unofficial)"
 
-    // Arduino API callbacks
-    #define RADIOLIB_CB_ARGS_PIN_MODE                   (void, pinMode, uint8_t pin, uint8_t mode)
-    #define RADIOLIB_CB_ARGS_DIGITAL_WRITE              (void, digitalWrite, uint8_t pin, uint8_t value)
-    #define RADIOLIB_CB_ARGS_DIGITAL_READ               (int, digitalRead, uint8_t pin)
-    #define RADIOLIB_CB_ARGS_TONE                       (void, tone, void)
-    #define RADIOLIB_CB_ARGS_NO_TONE                    (void, noTone, void)
-    #define RADIOLIB_CB_ARGS_ATTACH_INTERRUPT           (void, attachInterrupt, uint8_t pin, void (*)(void), int mode)
-    #define RADIOLIB_CB_ARGS_DETACH_INTERRUPT           (void, detachInterrupt, uint8_t pin)
-    #define RADIOLIB_CB_ARGS_YIELD                      (void, yield, void)
-    #define RADIOLIB_CB_ARGS_DELAY                      (void, delay, uint32_t)
-    #define RADIOLIB_CB_ARGS_DELAY_MICROSECONDS         (void, delayMicroseconds, uint32_t us)
-    #define RADIOLIB_CB_ARGS_MILLIS                     (unsigned long, millis, void)
-    #define RADIOLIB_CB_ARGS_MICROS                     (unsigned long, micros, void)
-    #define RADIOLIB_CB_ARGS_PULSE_IN                   (unsigned long, pulseIn, uint8_t pin, uint8_t state, unsigned long timeout)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN                  (void, SPIbegin, void)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN_TRANSACTION      (void, SPIbeginTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_TRANSFER               (uint8_t, SPItransfer, uint8_t b)
-    #define RADIOLIB_CB_ARGS_SPI_END_TRANSACTION        (void, SPIendTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_END                    (void, SPIend, void)
+  #define RADIOLIB_ARDUINOHAL_PIN_MODE_CAST (WiringPinMode)
+  #define RADIOLIB_ARDUINOHAL_INTERRUPT_MODE_CAST (ExtIntTriggerMode)
+#elif defined(ARDUINO_ARCH_MEGAAVR)
+  // MegaCoreX by MCUdude (https://github.com/MCUdude/MegaCoreX)
+  #define RADIOLIB_PLATFORM                           "MegaCoreX"
+#elif defined(ARDUINO_ARCH_MBED_RP2040)
+  // Raspberry Pi Pico (official mbed core)
+  #define RADIOLIB_PLATFORM                           "Raspberry Pi Pico"
 
-  #elif defined(ARDUINO_ARCH_STM32)
-    // official STM32 Arduino core (https://github.com/stm32duino/Arduino_Core_STM32)
-    #define RADIOLIB_PLATFORM                           "Arduino STM32 (official)"
-    #define RADIOLIB_PIN_TYPE                           uint32_t
-    #define RADIOLIB_PIN_MODE                           uint32_t
-    #define RADIOLIB_PIN_STATUS                         uint32_t
-    #define RADIOLIB_INTERRUPT_STATUS                   RADIOLIB_PIN_STATUS
-    #define RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(p)        digitalPinToInterrupt(p)
-    #define RADIOLIB_NC                                 (0xFFFFFFFF)
-    #define RADIOLIB_DEFAULT_SPI                        SPI
-    #define RADIOLIB_DEFAULT_SPI_SETTINGS               SPISettings(2000000, MSBFIRST, SPI_MODE0)
-    #define RADIOLIB_NONVOLATILE                        PROGMEM
-    #define RADIOLIB_NONVOLATILE_READ_BYTE(addr)        pgm_read_byte(addr)
-    #define RADIOLIB_NONVOLATILE_READ_DWORD(addr)       pgm_read_dword(addr)
-    #define RADIOLIB_TYPE_ALIAS(type, alias)            using alias = type;
+  #define RADIOLIB_ARDUINOHAL_PIN_MODE_CAST (PinMode)
+  #define RADIOLIB_ARDUINOHAL_PIN_STATUS_CAST (PinStatus)
+  #define RADIOLIB_ARDUINOHAL_INTERRUPT_MODE_CAST (PinStatus)
 
-    // Arduino API callbacks
-    #define RADIOLIB_CB_ARGS_PIN_MODE                   (void, pinMode, uint32_t dwPin, uint32_t dwMode)
-    #define RADIOLIB_CB_ARGS_DIGITAL_WRITE              (void, digitalWrite, uint32_t dwPin, uint32_t dwVal)
-    #define RADIOLIB_CB_ARGS_DIGITAL_READ               (int, digitalRead, uint32_t ulPin)
-    #define RADIOLIB_CB_ARGS_TONE                       (void, tone, uint8_t _pin, unsigned int frequency, unsigned long duration)
-    #define RADIOLIB_CB_ARGS_NO_TONE                    (void, noTone, uint8_t _pin, bool destruct)
-    #define RADIOLIB_CB_ARGS_ATTACH_INTERRUPT           (void, attachInterrupt, uint32_t pin, callback_function_t callback, uint32_t mode)
-    #define RADIOLIB_CB_ARGS_DETACH_INTERRUPT           (void, detachInterrupt, uint32_t pin)
-    #define RADIOLIB_CB_ARGS_YIELD                      (void, yield, void)
-    #define RADIOLIB_CB_ARGS_DELAY                      (void, delay, uint32_t ms)
-    #define RADIOLIB_CB_ARGS_DELAY_MICROSECONDS         (void, delayMicroseconds, uint32_t us)
-    #define RADIOLIB_CB_ARGS_MILLIS                     (uint32_t, millis, void)
-    #define RADIOLIB_CB_ARGS_MICROS                     (uint32_t, micros, void)
-    #define RADIOLIB_CB_ARGS_PULSE_IN                   (uint32_t, pulseIn, uint32_t pin, uint32_t state, uint32_t timeout)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN                  (void, SPIbegin, void)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN_TRANSACTION      (void, SPIbeginTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_TRANSFER               (uint8_t, SPItransfer, uint8_t b)
-    #define RADIOLIB_CB_ARGS_SPI_END_TRANSACTION        (void, SPIendTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_END                    (void, SPIend, void)
+  // Arduino mbed OS boards have a really bad tone implementation which will crash after a couple seconds
+  #define RADIOLIB_TONE_UNSUPPORTED
+  #define RADIOLIB_MBED_TONE_OVERRIDE
+#elif defined(ARDUINO_ARCH_RP2040)
+  // Raspberry Pi Pico (unofficial core)
+  #define RADIOLIB_PLATFORM                           "Raspberry Pi Pico (unofficial)"
 
-  #elif defined(SAMD_SERIES)
-    // Adafruit SAMD boards (M0 and M4)
-    #define RADIOLIB_PLATFORM                           "Adafruit SAMD"
-    #define RADIOLIB_PIN_TYPE                           uint32_t
-    #define RADIOLIB_PIN_MODE                           uint32_t
-    #define RADIOLIB_PIN_STATUS                         uint32_t
-    #define RADIOLIB_INTERRUPT_STATUS                   RADIOLIB_PIN_STATUS
-    #define RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(p)        digitalPinToInterrupt(p)
-    #define RADIOLIB_NC                                 (0xFFFFFFFF)
-    #define RADIOLIB_DEFAULT_SPI                        SPI
-    #define RADIOLIB_DEFAULT_SPI_SETTINGS               SPISettings(2000000, MSBFIRST, SPI_MODE0)
-    #define RADIOLIB_NONVOLATILE                        PROGMEM
-    #define RADIOLIB_NONVOLATILE_READ_BYTE(addr)        pgm_read_byte(addr)
-    #define RADIOLIB_NONVOLATILE_READ_DWORD(addr)       pgm_read_dword(addr)
-    #define RADIOLIB_TYPE_ALIAS(type, alias)            using alias = type;
+  #define RADIOLIB_ARDUINOHAL_PIN_MODE_CAST (PinMode)
+  #define RADIOLIB_ARDUINOHAL_PIN_STATUS_CAST (PinStatus)
+  #define RADIOLIB_ARDUINOHAL_INTERRUPT_MODE_CAST (PinStatus)
+#elif defined(__ASR6501__) || defined(ARDUINO_ARCH_ASR650X) || defined(DARDUINO_ARCH_ASR6601)
+  // CubeCell
+  #define RADIOLIB_PLATFORM                           "CubeCell"
+  #define RADIOLIB_DEFAULT_SPI_SETTINGS               SPISettings(1000000, MSBFIRST, SPI_MODE0) // see issue #709
 
-    // Arduino API callbacks
-    #define RADIOLIB_CB_ARGS_PIN_MODE                   (void, pinMode, uint32_t dwPin, uint32_t dwMode)
-    #define RADIOLIB_CB_ARGS_DIGITAL_WRITE              (void, digitalWrite, uint32_t dwPin, uint32_t dwVal)
-    #define RADIOLIB_CB_ARGS_DIGITAL_READ               (int, digitalRead, uint32_t ulPin)
-    #define RADIOLIB_CB_ARGS_TONE                       (void, tone, uint32_t _pin, uint32_t frequency, uint32_t duration)
-    #define RADIOLIB_CB_ARGS_NO_TONE                    (void, noTone, uint32_t _pin)
-    #define RADIOLIB_CB_ARGS_ATTACH_INTERRUPT           (void, attachInterrupt, uint32_t pin, voidFuncPtr callback, uint32_t mode)
-    #define RADIOLIB_CB_ARGS_DETACH_INTERRUPT           (void, detachInterrupt, uint32_t pin)
-    #define RADIOLIB_CB_ARGS_YIELD                      (void, yield, void)
-    #define RADIOLIB_CB_ARGS_DELAY                      (void, delay, unsigned long dwMs)
-    #define RADIOLIB_CB_ARGS_DELAY_MICROSECONDS         (void, delayMicroseconds, unsigned int)
-    #define RADIOLIB_CB_ARGS_MILLIS                     (unsigned long, millis, void)
-    #define RADIOLIB_CB_ARGS_MICROS                     (unsigned long, micros, void)
-    #define RADIOLIB_CB_ARGS_PULSE_IN                   (uint32_t, pulseIn, uint32_t pin, uint32_t state, uint32_t timeout)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN                  (void, SPIbegin, void)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN_TRANSACTION      (void, SPIbeginTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_TRANSFER               (uint8_t, SPItransfer, uint8_t b)
-    #define RADIOLIB_CB_ARGS_SPI_END_TRANSACTION        (void, SPIendTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_END                    (void, SPIend, void)
+  #define RADIOLIB_ARDUINOHAL_PIN_MODE_CAST (PINMODE)
+  #define RADIOLIB_ARDUINOHAL_INTERRUPT_MODE_CAST (IrqModes)
 
-  #elif defined(ARDUINO_ARCH_SAMD)
-    // Arduino SAMD (Zero, MKR, etc.)
-    #define RADIOLIB_PLATFORM                           "Arduino SAMD"
-    #define RADIOLIB_PIN_TYPE                           pin_size_t
-    #define RADIOLIB_PIN_MODE                           PinMode
-    #define RADIOLIB_PIN_STATUS                         PinStatus
-    #define RADIOLIB_INTERRUPT_STATUS                   RADIOLIB_PIN_STATUS
-    #define RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(p)        digitalPinToInterrupt(p)
-    #define RADIOLIB_NC                                 (0xFF)
-    #define RADIOLIB_DEFAULT_SPI                        SPI
-    #define RADIOLIB_DEFAULT_SPI_SETTINGS               SPISettings(2000000, MSBFIRST, SPI_MODE0)
-    #define RADIOLIB_NONVOLATILE                        PROGMEM
-    #define RADIOLIB_NONVOLATILE_READ_BYTE(addr)        pgm_read_byte(addr)
-    #define RADIOLIB_NONVOLATILE_READ_DWORD(addr)       pgm_read_dword(addr)
-    #define RADIOLIB_TYPE_ALIAS(type, alias)            using alias = type;
+  // provide an easy access to the on-board module
+  #include "board-config.h"
+  #define RADIOLIB_BUILTIN_MODULE                      RADIO_NSS, RADIO_DIO_1, RADIO_RESET, RADIO_BUSY
 
-    // Arduino API callbacks
-    #define RADIOLIB_CB_ARGS_PIN_MODE                   (void, pinMode, pin_size_t pinNumber, PinMode pinMode)
-    #define RADIOLIB_CB_ARGS_DIGITAL_WRITE              (void, digitalWrite, pin_size_t pinNumber, PinStatus status)
-    #define RADIOLIB_CB_ARGS_DIGITAL_READ               (PinStatus, digitalRead, pin_size_t pinNumber)
-    #define RADIOLIB_CB_ARGS_TONE                       (void, tone, unsigned char outputPin, unsigned int frequency, unsigned long duration)
-    #define RADIOLIB_CB_ARGS_NO_TONE                    (void, noTone, uint8_t outputPin)
-    #define RADIOLIB_CB_ARGS_ATTACH_INTERRUPT           (void, attachInterrupt, pin_size_t pin, voidFuncPtr callback, PinStatus mode)
-    #define RADIOLIB_CB_ARGS_DETACH_INTERRUPT           (void, detachInterrupt, pin_size_t pin)
-    #define RADIOLIB_CB_ARGS_YIELD                      (void, yield, void)
-    #define RADIOLIB_CB_ARGS_DELAY                      (void, delay, unsigned long)
-    #define RADIOLIB_CB_ARGS_DELAY_MICROSECONDS         (void, delayMicroseconds, unsigned int us)
-    #define RADIOLIB_CB_ARGS_MILLIS                     (unsigned long, millis, void)
-    #define RADIOLIB_CB_ARGS_MICROS                     (unsigned long, micros, void)
-    #define RADIOLIB_CB_ARGS_PULSE_IN                   (uint32_t, pulseIn, pin_size_t pin, uint8_t state, uint32_t timeout)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN                  (void, SPIbegin, void)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN_TRANSACTION      (void, SPIbeginTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_TRANSFER               (uint8_t, SPItransfer, uint8_t b)
-    #define RADIOLIB_CB_ARGS_SPI_END_TRANSACTION        (void, SPIendTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_END                    (void, SPIend, void)
+  // CubeCell doesn't seem to define nullptr, let's do something like that now
+  #define nullptr                                     NULL
 
-  #elif defined(__SAM3X8E__)
-    // Arduino Due
-    #define RADIOLIB_PLATFORM                           "Arduino Due"
-    #define RADIOLIB_PIN_TYPE                           uint32_t
-    #define RADIOLIB_PIN_MODE                           uint32_t
-    #define RADIOLIB_PIN_STATUS                         uint32_t
-    #define RADIOLIB_INTERRUPT_STATUS                   RADIOLIB_PIN_STATUS
-    #define RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(p)        digitalPinToInterrupt(p)
-    #define RADIOLIB_NC                                 (0xFFFFFFFF)
-    #define RADIOLIB_DEFAULT_SPI                        SPI
-    #define RADIOLIB_DEFAULT_SPI_SETTINGS               SPISettings(2000000, MSBFIRST, SPI_MODE0)
-    #define RADIOLIB_NONVOLATILE                        PROGMEM
-    #define RADIOLIB_NONVOLATILE_READ_BYTE(addr)        pgm_read_byte(addr)
-    #define RADIOLIB_NONVOLATILE_READ_DWORD(addr)       pgm_read_dword(addr)
-    #define RADIOLIB_TYPE_ALIAS(type, alias)            using alias = type;
-    #define RADIOLIB_TONE_UNSUPPORTED
+  // ... and also defines pinMode() as a macro, which is by far the stupidest thing I have seen on Arduino
+  #undef pinMode
 
-    // Arduino API callbacks
-    #define RADIOLIB_CB_ARGS_PIN_MODE                   (void, pinMode, uint32_t dwPin, uint32_t dwMode)
-    #define RADIOLIB_CB_ARGS_DIGITAL_WRITE              (void, digitalWrite, uint32_t dwPin, uint32_t dwVal)
-    #define RADIOLIB_CB_ARGS_DIGITAL_READ               (int, digitalRead, uint32_t ulPin)
-    #define RADIOLIB_CB_ARGS_TONE                       (void, tone, void)
-    #define RADIOLIB_CB_ARGS_NO_TONE                    (void, noTone, void)
-    #define RADIOLIB_CB_ARGS_ATTACH_INTERRUPT           (void, attachInterrupt, uint32_t pin, void (*callback)(void), uint32_t mode)
-    #define RADIOLIB_CB_ARGS_DETACH_INTERRUPT           (void, detachInterrupt, uint32_t pin)
-    #define RADIOLIB_CB_ARGS_YIELD                      (void, yield, void)
-    #define RADIOLIB_CB_ARGS_DELAY                      (void, delay, uint32_t dwMs)
-    #define RADIOLIB_CB_ARGS_DELAY_MICROSECONDS         (void, delayMicroseconds, uint32_t usec)
-    #define RADIOLIB_CB_ARGS_MILLIS                     (uint32_t, millis, void)
-    #define RADIOLIB_CB_ARGS_MICROS                     (uint32_t, micros, void)
-    #define RADIOLIB_CB_ARGS_PULSE_IN                   (uint32_t, pulseIn, uint32_t pin, uint32_t state, uint32_t timeout)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN                  (void, SPIbegin, void)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN_TRANSACTION      (void, SPIbeginTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_TRANSFER               (uint8_t, SPItransfer, uint8_t b)
-    #define RADIOLIB_CB_ARGS_SPI_END_TRANSACTION        (void, SPIendTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_END                    (void, SPIend, void)
+  // ... and uses an outdated GCC which does not support type aliases
+  #define RADIOLIB_TYPE_ALIAS(type, alias)            typedef class type alias;
 
-  #elif (defined(NRF52832_XXAA) || defined(NRF52840_XXAA)) && !defined(ARDUINO_ARDUINO_NANO33BLE)
-    // Adafruit nRF52 boards
-    #define RADIOLIB_PLATFORM                           "Adafruit nRF52"
-    #define RADIOLIB_PIN_TYPE                           uint32_t
-    #define RADIOLIB_PIN_MODE                           uint32_t
-    #define RADIOLIB_PIN_STATUS                         uint32_t
-    #define RADIOLIB_INTERRUPT_STATUS                   RADIOLIB_PIN_STATUS
-    #define RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(p)        digitalPinToInterrupt(p)
-    #define RADIOLIB_NC                                 (0xFFFFFFFF)
-    #define RADIOLIB_DEFAULT_SPI                        SPI
-    #define RADIOLIB_DEFAULT_SPI_SETTINGS               SPISettings(2000000, MSBFIRST, SPI_MODE0)
-    #define RADIOLIB_NONVOLATILE                        PROGMEM
-    #define RADIOLIB_NONVOLATILE_READ_BYTE(addr)        pgm_read_byte(addr)
-    #define RADIOLIB_NONVOLATILE_READ_DWORD(addr)       pgm_read_dword(addr)
-    #define RADIOLIB_TYPE_ALIAS(type, alias)            using alias = type;
+  // ... and it also has no tone(). This platform was designed by an idiot.
+  #define RADIOLIB_TONE_UNSUPPORTED
 
-    // Arduino API callbacks
-    #define RADIOLIB_CB_ARGS_PIN_MODE                   (void, pinMode, uint32_t dwPin, uint32_t dwMode)
-    #define RADIOLIB_CB_ARGS_DIGITAL_WRITE              (void, digitalWrite, uint32_t dwPin, uint32_t dwVal)
-    #define RADIOLIB_CB_ARGS_DIGITAL_READ               (int, digitalRead, uint32_t ulPin)
-    #define RADIOLIB_CB_ARGS_TONE                       (void, tone, uint8_t pin, unsigned int frequency, unsigned long duration)
-    #define RADIOLIB_CB_ARGS_NO_TONE                    (void, noTone, uint8_t pin)
-    #define RADIOLIB_CB_ARGS_ATTACH_INTERRUPT           (int, attachInterrupt, uint32_t pin, voidFuncPtr callback, uint32_t mode)
-    #define RADIOLIB_CB_ARGS_DETACH_INTERRUPT           (void, detachInterrupt, uint32_t pin)
-    #define RADIOLIB_CB_ARGS_YIELD                      (void, yield, void)
-    #define RADIOLIB_CB_ARGS_DELAY                      (void, delay, uint32_t dwMs)
-    #define RADIOLIB_CB_ARGS_DELAY_MICROSECONDS         (void, delayMicroseconds, uint32_t usec)
-    #define RADIOLIB_CB_ARGS_MILLIS                     (uint32_t, millis, void)
-    #define RADIOLIB_CB_ARGS_MICROS                     (uint32_t, micros, void)
-    #define RADIOLIB_CB_ARGS_PULSE_IN                   (uint32_t, pulseIn, uint32_t pin, uint32_t state, uint32_t timeout)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN                  (void, SPIbegin, void)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN_TRANSACTION      (void, SPIbeginTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_TRANSFER               (uint8_t, SPItransfer, uint8_t b)
-    #define RADIOLIB_CB_ARGS_SPI_END_TRANSACTION        (void, SPIendTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_END                    (void, SPIend, void)
-
-  #elif defined(ARDUINO_ARC32_TOOLS)
-    // Intel Curie
-    #define RADIOLIB_PLATFORM                           "Intel Curie"
-    #define RADIOLIB_PIN_TYPE                           uint8_t
-    #define RADIOLIB_PIN_MODE                           uint8_t
-    #define RADIOLIB_PIN_STATUS                         uint8_t
-    #define RADIOLIB_INTERRUPT_STATUS                   RADIOLIB_PIN_STATUS
-    #define RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(p)        digitalPinToInterrupt(p)
-    #define RADIOLIB_NC                                 (0xFF)
-    #define RADIOLIB_DEFAULT_SPI                        SPI
-    #define RADIOLIB_DEFAULT_SPI_SETTINGS               SPISettings(2000000, MSBFIRST, SPI_MODE0)
-    #define RADIOLIB_NONVOLATILE                        PROGMEM
-    #define RADIOLIB_NONVOLATILE_READ_BYTE(addr)        pgm_read_byte(addr)
-    #define RADIOLIB_NONVOLATILE_READ_DWORD(addr)       pgm_read_dword(addr)
-    #define RADIOLIB_TYPE_ALIAS(type, alias)            using alias = type;
-
-    // Arduino API callbacks
-    #define RADIOLIB_CB_ARGS_PIN_MODE                   (void, pinMode, uint8_t pin, uint8_t mode)
-    #define RADIOLIB_CB_ARGS_DIGITAL_WRITE              (void, digitalWrite, uint8_t pin, uint8_t val)
-    #define RADIOLIB_CB_ARGS_DIGITAL_READ               (int, digitalRead, uint8_t pin)
-    #define RADIOLIB_CB_ARGS_TONE                       (void, tone, uint32_t _pin, unsigned int frequency, unsigned long duration)
-    #define RADIOLIB_CB_ARGS_NO_TONE                    (void, noTone, uint32_t _pin)
-    #define RADIOLIB_CB_ARGS_ATTACH_INTERRUPT           (void, attachInterrupt, uint32_t pin, void (*callback)(void), uint32_t mode)
-    #define RADIOLIB_CB_ARGS_DETACH_INTERRUPT           (void, detachInterrupt, uint32_t pin)
-    #define RADIOLIB_CB_ARGS_YIELD                      (void, yield, void)
-    #define RADIOLIB_CB_ARGS_DELAY                      (void, delay, uint32_t dwMs)
-    #define RADIOLIB_CB_ARGS_DELAY_MICROSECONDS         (void, delayMicroseconds, uint32_t dwUs)
-    #define RADIOLIB_CB_ARGS_MILLIS                     (uint64_t, millis, void)
-    #define RADIOLIB_CB_ARGS_MICROS                     (uint64_t, micros, void)
-    #define RADIOLIB_CB_ARGS_PULSE_IN                   (uint32_t, pulseIn, uint32_t pin, uint32_t state, uint32_t timeout)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN                  (void, SPIbegin, void)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN_TRANSACTION      (void, SPIbeginTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_TRANSFER               (uint8_t, SPItransfer, uint8_t b)
-    #define RADIOLIB_CB_ARGS_SPI_END_TRANSACTION        (void, SPIendTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_END                    (void, SPIend, void)
-
-  #elif defined(ARDUINO_AVR_UNO_WIFI_REV2) || defined(ARDUINO_AVR_NANO_EVERY) || defined(PORTDUINO)
-    // Arduino megaAVR boards - Uno Wifi Rev.2, Nano Every
-    #define RADIOLIB_PLATFORM                           "Arduino megaAVR"
-    #define RADIOLIB_PIN_TYPE                           uint8_t
-    #define RADIOLIB_PIN_MODE                           PinMode
-    #define RADIOLIB_PIN_STATUS                         PinStatus
-    #define RADIOLIB_INTERRUPT_STATUS                   RADIOLIB_PIN_STATUS
-    #define RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(p)        digitalPinToInterrupt(p)
-    #define RADIOLIB_NC                                 (0xFF)
-    #define RADIOLIB_DEFAULT_SPI                        SPI
-    #define RADIOLIB_DEFAULT_SPI_SETTINGS               SPISettings(2000000, MSBFIRST, SPI_MODE0)
-    #define RADIOLIB_NONVOLATILE                        PROGMEM
-    #define RADIOLIB_NONVOLATILE_READ_BYTE(addr)        pgm_read_byte(addr)
-    #define RADIOLIB_NONVOLATILE_READ_DWORD(addr)       pgm_read_dword(addr)
-    #define RADIOLIB_TYPE_ALIAS(type, alias)            using alias = type;
-
-    // Arduino API callbacks
-    #define RADIOLIB_CB_ARGS_PIN_MODE                   (void, pinMode, uint8_t pin, PinMode mode)
-    #define RADIOLIB_CB_ARGS_DIGITAL_WRITE              (void, digitalWrite, uint8_t pin, PinStatus val)
-    #define RADIOLIB_CB_ARGS_DIGITAL_READ               (PinStatus, digitalRead, uint8_t pin)
-    #define RADIOLIB_CB_ARGS_TONE                       (void, tone, uint8_t pin, unsigned int frequency, unsigned long duration)
-    #define RADIOLIB_CB_ARGS_NO_TONE                    (void, noTone, uint8_t pin)
-    #define RADIOLIB_CB_ARGS_ATTACH_INTERRUPT           (void, attachInterrupt, uint8_t pin, void (*userFunc)(void), PinStatus mode)
-    #define RADIOLIB_CB_ARGS_DETACH_INTERRUPT           (void, detachInterrupt, uint8_t pin)
-    #define RADIOLIB_CB_ARGS_YIELD                      (void, yield, void)
-    #define RADIOLIB_CB_ARGS_DELAY                      (void, delay, unsigned long ms)
-    #define RADIOLIB_CB_ARGS_DELAY_MICROSECONDS         (void, delayMicroseconds, unsigned int us)
-    #define RADIOLIB_CB_ARGS_MILLIS                     (unsigned long, millis, void)
-    #define RADIOLIB_CB_ARGS_MICROS                     (unsigned long, micros, void)
-    #define RADIOLIB_CB_ARGS_PULSE_IN                   (unsigned long, pulseIn, uint8_t pin, uint8_t state, unsigned long timeout)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN                  (void, SPIbegin, void)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN_TRANSACTION      (void, SPIbeginTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_TRANSFER               (uint8_t, SPItransfer, uint8_t b)
-    #define RADIOLIB_CB_ARGS_SPI_END_TRANSACTION        (void, SPIendTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_END                    (void, SPIend, void)
-
-  #elif defined(ARDUINO_ARCH_APOLLO3)
-    // Sparkfun Apollo3 boards
-    #define RADIOLIB_PLATFORM                           "Sparkfun Apollo3"
-    #define RADIOLIB_PIN_TYPE                           pin_size_t
-    #define RADIOLIB_PIN_MODE                           Arduino_PinMode
-    #define RADIOLIB_PIN_STATUS                         PinStatus
-    #define RADIOLIB_INTERRUPT_STATUS                   RADIOLIB_PIN_STATUS
-    #define RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(p)        digitalPinToInterrupt(p)
-    #define RADIOLIB_NC                                 (0xFF)
-    #define RADIOLIB_DEFAULT_SPI                        SPI
-    #define RADIOLIB_DEFAULT_SPI_SETTINGS               SPISettings(2000000, MSBFIRST, SPI_MODE0)
-    #define RADIOLIB_NONVOLATILE                        PROGMEM
-    #define RADIOLIB_NONVOLATILE_READ_BYTE(addr)        pgm_read_byte(addr)
-    #define RADIOLIB_NONVOLATILE_READ_DWORD(addr)       pgm_read_dword(addr)
-    #define RADIOLIB_TYPE_ALIAS(type, alias)            using alias = type;
-
-    // Arduino API callbacks
-    #define RADIOLIB_CB_ARGS_PIN_MODE                   (void, pinMode, pin_size_t pinName, Arduino_PinMode pinMode)
-    #define RADIOLIB_CB_ARGS_DIGITAL_WRITE              (void, digitalWrite, pin_size_t pinName, PinStatus val)
-    #define RADIOLIB_CB_ARGS_DIGITAL_READ               (PinStatus, digitalRead, pin_size_t pinName)
-    #define RADIOLIB_CB_ARGS_TONE                       (void, tone, uint8_t _pin, unsigned int frequency, unsigned long duration)
-    #define RADIOLIB_CB_ARGS_NO_TONE                    (void, noTone, uint8_t _pin)
-    #define RADIOLIB_CB_ARGS_ATTACH_INTERRUPT           (void, attachInterrupt, pin_size_t interruptNumber, voidFuncPtr callback, PinStatus mode)
-    #define RADIOLIB_CB_ARGS_DETACH_INTERRUPT           (void, detachInterrupt, pin_size_t interruptNumber)
-    #define RADIOLIB_CB_ARGS_YIELD                      (void, yield, void)
-    #define RADIOLIB_CB_ARGS_DELAY                      (void, delay, unsigned long ms)
-    #define RADIOLIB_CB_ARGS_DELAY_MICROSECONDS         (void, delayMicroseconds, unsigned int us)
-    #define RADIOLIB_CB_ARGS_MILLIS                     (unsigned long, millis, void)
-    #define RADIOLIB_CB_ARGS_MICROS                     (unsigned long, micros, void)
-    #define RADIOLIB_CB_ARGS_PULSE_IN                   (unsigned long, pulseIn, pin_size_t pin, uint8_t state, unsigned long timeout)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN                  (void, SPIbegin, void)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN_TRANSACTION      (void, SPIbeginTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_TRANSFER               (uint8_t, SPItransfer, uint8_t b)
-    #define RADIOLIB_CB_ARGS_SPI_END_TRANSACTION        (void, SPIendTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_END                    (void, SPIend, void)
-
-  #elif defined(ARDUINO_ARDUINO_NANO33BLE)
-    // Arduino Nano 33 BLE
-    #define RADIOLIB_PLATFORM                           "Arduino Nano 33 BLE"
-    #define RADIOLIB_PIN_TYPE                           pin_size_t
-    #define RADIOLIB_PIN_MODE                           PinMode
-    #define RADIOLIB_PIN_STATUS                         PinStatus
-    #define RADIOLIB_INTERRUPT_STATUS                   RADIOLIB_PIN_STATUS
-    #define RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(p)        digitalPinToInterrupt(p)
-    #define RADIOLIB_NC                                 (0xFF)
-    #define RADIOLIB_DEFAULT_SPI                        SPI
-    #define RADIOLIB_DEFAULT_SPI_SETTINGS               SPISettings(2000000, MSBFIRST, SPI_MODE0)
-    #define RADIOLIB_NONVOLATILE                        PROGMEM
-    #define RADIOLIB_NONVOLATILE_READ_BYTE(addr)        pgm_read_byte(addr)
-    #define RADIOLIB_NONVOLATILE_READ_DWORD(addr)       pgm_read_dword(addr)
-    #define RADIOLIB_TYPE_ALIAS(type, alias)            using alias = type;
-
-    // Arduino mbed OS boards have a really bad tone implementation which will crash after a couple seconds
-    #define RADIOLIB_TONE_UNSUPPORTED
-    #define RADIOLIB_MBED_TONE_OVERRIDE
-
-    // Arduino API callbacks
-    #define RADIOLIB_CB_ARGS_PIN_MODE                   (void, pinMode, pin_size_t pin, PinMode mode)
-    #define RADIOLIB_CB_ARGS_DIGITAL_WRITE              (void, digitalWrite, pin_size_t pin, PinStatus val)
-    #define RADIOLIB_CB_ARGS_DIGITAL_READ               (PinStatus, digitalRead, pin_size_t pin)
-    #define RADIOLIB_CB_ARGS_TONE                       (void, tone, uint8_t pin, unsigned int frequency, unsigned long duration)
-    #define RADIOLIB_CB_ARGS_NO_TONE                    (void, noTone, uint8_t pin)
-    #define RADIOLIB_CB_ARGS_ATTACH_INTERRUPT           (void, attachInterrupt, pin_size_t interruptNum, voidFuncPtr func, PinStatus mode)
-    #define RADIOLIB_CB_ARGS_DETACH_INTERRUPT           (void, detachInterrupt, pin_size_t interruptNum)
-    #define RADIOLIB_CB_ARGS_YIELD                      (void, yield, void)
-    #define RADIOLIB_CB_ARGS_DELAY                      (void, delay, unsigned long ms)
-    #define RADIOLIB_CB_ARGS_DELAY_MICROSECONDS         (void, delayMicroseconds, unsigned int us)
-    #define RADIOLIB_CB_ARGS_MILLIS                     (unsigned long, millis, void)
-    #define RADIOLIB_CB_ARGS_MICROS                     (unsigned long, micros, void)
-    #define RADIOLIB_CB_ARGS_PULSE_IN                   (unsigned long, pulseIn, pin_size_t pin, uint8_t state, unsigned long timeout)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN                  (void, SPIbegin, void)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN_TRANSACTION      (void, SPIbeginTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_TRANSFER               (uint8_t, SPItransfer, uint8_t b)
-    #define RADIOLIB_CB_ARGS_SPI_END_TRANSACTION        (void, SPIendTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_END                    (void, SPIend, void)
-
-  #elif defined(ARDUINO_PORTENTA_H7_M7) || defined(ARDUINO_PORTENTA_H7_M4)
-    // Arduino Portenta H7
-    #define RADIOLIB_PLATFORM                           "Portenta H7"
-    #define RADIOLIB_PIN_TYPE                           pin_size_t
-    #define RADIOLIB_PIN_MODE                           PinMode
-    #define RADIOLIB_PIN_STATUS                         PinStatus
-    #define RADIOLIB_INTERRUPT_STATUS                   RADIOLIB_PIN_STATUS
-    #define RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(p)        digitalPinToInterrupt(p)
-    #define RADIOLIB_NC                                 (0xFF)
-    #define RADIOLIB_DEFAULT_SPI                        SPI
-    #define RADIOLIB_DEFAULT_SPI_SETTINGS               SPISettings(2000000, MSBFIRST, SPI_MODE0)
-    #define RADIOLIB_NONVOLATILE                        PROGMEM
-    #define RADIOLIB_NONVOLATILE_READ_BYTE(addr)        pgm_read_byte(addr)
-    #define RADIOLIB_NONVOLATILE_READ_DWORD(addr)       pgm_read_dword(addr)
-    #define RADIOLIB_TYPE_ALIAS(type, alias)            using alias = type;
-
-    // Arduino mbed OS boards have a really bad tone implementation which will crash after a couple seconds
-    #define RADIOLIB_TONE_UNSUPPORTED
-    #define RADIOLIB_MBED_TONE_OVERRIDE
-
-    // Arduino API callbacks
-    #define RADIOLIB_CB_ARGS_PIN_MODE                   (void, pinMode, pin_size_t pin, PinMode mode)
-    #define RADIOLIB_CB_ARGS_DIGITAL_WRITE              (void, digitalWrite, pin_size_t pin, PinStatus val)
-    #define RADIOLIB_CB_ARGS_DIGITAL_READ               (PinStatus, digitalRead, pin_size_t pin)
-    #define RADIOLIB_CB_ARGS_TONE                       (void, tone, uint8_t pin, unsigned int frequency, unsigned long duration)
-    #define RADIOLIB_CB_ARGS_NO_TONE                    (void, noTone, uint8_t pin)
-    #define RADIOLIB_CB_ARGS_ATTACH_INTERRUPT           (void, attachInterrupt, pin_size_t interruptNum, voidFuncPtr func, PinStatus mode)
-    #define RADIOLIB_CB_ARGS_DETACH_INTERRUPT           (void, detachInterrupt, pin_size_t interruptNum)
-    #define RADIOLIB_CB_ARGS_YIELD                      (void, yield, void)
-    #define RADIOLIB_CB_ARGS_DELAY                      (void, delay, unsigned long ms)
-    #define RADIOLIB_CB_ARGS_DELAY_MICROSECONDS         (void, delayMicroseconds, unsigned int us)
-    #define RADIOLIB_CB_ARGS_MILLIS                     (unsigned long, millis, void)
-    #define RADIOLIB_CB_ARGS_MICROS                     (unsigned long, micros, void)
-    #define RADIOLIB_CB_ARGS_PULSE_IN                   (unsigned long, pulseIn, pin_size_t pin, uint8_t state, unsigned long timeout)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN                  (void, SPIbegin, void)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN_TRANSACTION      (void, SPIbeginTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_TRANSFER               (uint8_t, SPItransfer, uint8_t b)
-    #define RADIOLIB_CB_ARGS_SPI_END_TRANSACTION        (void, SPIendTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_END                    (void, SPIend, void)
-
-  #elif defined(__STM32F4__) || defined(__STM32F1__)
-    // Arduino STM32 core by Roger Clark (https://github.com/rogerclarkmelbourne/Arduino_STM32)
-    #define RADIOLIB_PLATFORM                           "STM32duino (unofficial)"
-    #define RADIOLIB_PIN_TYPE                           uint8_t
-    #define RADIOLIB_PIN_MODE                           WiringPinMode
-    #define RADIOLIB_PIN_STATUS                         uint8_t
-    #define RADIOLIB_INTERRUPT_STATUS                   ExtIntTriggerMode
-    #define RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(p)        digitalPinToInterrupt(p)
-    #define RADIOLIB_NC                                 (0xFF)
-    #define RADIOLIB_DEFAULT_SPI                        SPI
-    #define RADIOLIB_DEFAULT_SPI_SETTINGS               SPISettings(2000000, MSBFIRST, SPI_MODE0)
-    #define RADIOLIB_NONVOLATILE                        PROGMEM
-    #define RADIOLIB_NONVOLATILE_READ_BYTE(addr)        pgm_read_byte(addr)
-    #define RADIOLIB_NONVOLATILE_READ_DWORD(addr)       pgm_read_dword(addr)
-    #define RADIOLIB_TYPE_ALIAS(type, alias)            using alias = type;
-
-    // Arduino API callbacks
-    #define RADIOLIB_CB_ARGS_PIN_MODE                   (void, pinMode, uint8 pin, WiringPinMode mode)
-    #define RADIOLIB_CB_ARGS_DIGITAL_WRITE              (void, digitalWrite, uint8 pin, uint8 val)
-    #define RADIOLIB_CB_ARGS_DIGITAL_READ               (uint32_t, digitalRead, uint8 pin)
-    #define RADIOLIB_CB_ARGS_TONE                       (void, tone, uint32_t _pin, uint32_t frequency, uint32_t duration)
-    #define RADIOLIB_CB_ARGS_NO_TONE                    (void, noTone, uint32_t _pin)
-    #define RADIOLIB_CB_ARGS_ATTACH_INTERRUPT           (void, attachInterrupt, uint8 pin, voidFuncPtr handler, ExtIntTriggerMode mode)
-    #define RADIOLIB_CB_ARGS_DETACH_INTERRUPT           (void, detachInterrupt, uint8 pin)
-    #define RADIOLIB_CB_ARGS_YIELD                      (void, yield, void)
-    #define RADIOLIB_CB_ARGS_DELAY                      (void, delay, unsigned long ms)
-    #define RADIOLIB_CB_ARGS_DELAY_MICROSECONDS         (void, delayMicroseconds, uint32 us)
-    #define RADIOLIB_CB_ARGS_MILLIS                     (uint32_t, millis, void)
-    #define RADIOLIB_CB_ARGS_MICROS                     (uint32_t, micros, void)
-    #define RADIOLIB_CB_ARGS_PULSE_IN                   (uint32_t, pulseIn, uint32_t ulPin, uint32_t ulState, uint32_t ulTimeout)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN                  (void, SPIbegin, void)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN_TRANSACTION      (void, SPIbeginTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_TRANSFER               (uint8_t, SPItransfer, uint8_t b)
-    #define RADIOLIB_CB_ARGS_SPI_END_TRANSACTION        (void, SPIendTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_END                    (void, SPIend, void)
-
-  #elif defined(ARDUINO_ARCH_MEGAAVR)
-    // MegaCoreX by MCUdude (https://github.com/MCUdude/MegaCoreX)
-    #define RADIOLIB_PLATFORM                           "MegaCoreX"
-    #define RADIOLIB_PIN_TYPE                           uint8_t
-    #define RADIOLIB_PIN_MODE                           uint8_t
-    #define RADIOLIB_PIN_STATUS                         uint8_t
-    #define RADIOLIB_INTERRUPT_STATUS                   RADIOLIB_PIN_STATUS
-    #define RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(p)        digitalPinToInterrupt(p)
-    #define RADIOLIB_NC                                 (0xFF)
-    #define RADIOLIB_DEFAULT_SPI                        SPI
-    #define RADIOLIB_DEFAULT_SPI_SETTINGS               SPISettings(2000000, MSBFIRST, SPI_MODE0)
-    #define RADIOLIB_NONVOLATILE                        PROGMEM
-    #define RADIOLIB_NONVOLATILE_READ_BYTE(addr)        pgm_read_byte(addr)
-    #define RADIOLIB_NONVOLATILE_READ_DWORD(addr)       pgm_read_dword(addr)
-    #define RADIOLIB_TYPE_ALIAS(type, alias)            using alias = type;
-
-    // Arduino API callbacks
-    #define RADIOLIB_CB_ARGS_PIN_MODE                   (void, pinMode, uint8_t pin, uint8_t mode)
-    #define RADIOLIB_CB_ARGS_DIGITAL_WRITE              (void, digitalWrite, uint8_t pin, uint8_t value)
-    #define RADIOLIB_CB_ARGS_DIGITAL_READ               (uint8_t, digitalRead, uint8_t pin)
-    #define RADIOLIB_CB_ARGS_TONE                       (void, tone, uint8_t _pin, unsigned int frequency, unsigned long duration)
-    #define RADIOLIB_CB_ARGS_NO_TONE                    (void, noTone, uint8_t _pin)
-    #define RADIOLIB_CB_ARGS_ATTACH_INTERRUPT           (void, attachInterrupt, uint8_t pin, void (*userFunc)(void), uint8_t mode)
-    #define RADIOLIB_CB_ARGS_DETACH_INTERRUPT           (void, detachInterrupt, uint8_t interruptNum)
-    #define RADIOLIB_CB_ARGS_YIELD                      (void, yield, void)
-    #define RADIOLIB_CB_ARGS_DELAY                      (void, delay, unsigned long ms)
-    #define RADIOLIB_CB_ARGS_DELAY_MICROSECONDS         (void, delayMicroseconds, unsigned int us)
-    #define RADIOLIB_CB_ARGS_MILLIS                     (unsigned long, millis, void)
-    #define RADIOLIB_CB_ARGS_MICROS                     (unsigned long, micros, void)
-    #define RADIOLIB_CB_ARGS_PULSE_IN                   (unsigned long, pulseIn, uint8_t pin, uint8_t state, unsigned long timeout)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN                  (void, SPIbegin, void)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN_TRANSACTION      (void, SPIbeginTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_TRANSFER               (uint8_t, SPItransfer, uint8_t b)
-    #define RADIOLIB_CB_ARGS_SPI_END_TRANSACTION        (void, SPIendTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_END                    (void, SPIend, void)
-
-  #elif defined(ARDUINO_ARCH_MBED_RP2040)
-    // Raspberry Pi Pico (official mbed core)
-    #define RADIOLIB_PLATFORM                           "Raspberry Pi Pico"
-    #define RADIOLIB_PIN_TYPE                           pin_size_t
-    #define RADIOLIB_PIN_MODE                           PinMode
-    #define RADIOLIB_PIN_STATUS                         PinStatus
-    #define RADIOLIB_INTERRUPT_STATUS                   RADIOLIB_PIN_STATUS
-    #define RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(p)        digitalPinToInterrupt(p)
-    #define RADIOLIB_NC                                 (0xFF)
-    #define RADIOLIB_DEFAULT_SPI                        SPI
-    #define RADIOLIB_DEFAULT_SPI_SETTINGS               SPISettings(2000000, MSBFIRST, SPI_MODE0)
-    #define RADIOLIB_NONVOLATILE                        PROGMEM
-    #define RADIOLIB_NONVOLATILE_READ_BYTE(addr)        pgm_read_byte(addr)
-    #define RADIOLIB_NONVOLATILE_READ_DWORD(addr)       pgm_read_dword(addr)
-    #define RADIOLIB_TYPE_ALIAS(type, alias)            using alias = type;
-
-    // Arduino mbed OS boards have a really bad tone implementation which will crash after a couple seconds
-    #define RADIOLIB_TONE_UNSUPPORTED
-    #define RADIOLIB_MBED_TONE_OVERRIDE
-
-    // Arduino API callbacks
-    #define RADIOLIB_CB_ARGS_PIN_MODE                   (void, pinMode, pin_size_t pin, PinMode mode)
-    #define RADIOLIB_CB_ARGS_DIGITAL_WRITE              (void, digitalWrite, pin_size_t pin, PinStatus val)
-    #define RADIOLIB_CB_ARGS_DIGITAL_READ               (PinStatus, digitalRead, pin_size_t pin)
-    #define RADIOLIB_CB_ARGS_TONE                       (void, tone, uint8_t pin, unsigned int frequency, unsigned long duration)
-    #define RADIOLIB_CB_ARGS_NO_TONE                    (void, noTone, uint8_t pin)
-    #define RADIOLIB_CB_ARGS_ATTACH_INTERRUPT           (void, attachInterrupt, pin_size_t interruptNum, voidFuncPtr func, PinStatus mode)
-    #define RADIOLIB_CB_ARGS_DETACH_INTERRUPT           (void, detachInterrupt, pin_size_t interruptNum)
-    #define RADIOLIB_CB_ARGS_YIELD                      (void, yield, void)
-    #define RADIOLIB_CB_ARGS_DELAY                      (void, delay, unsigned long ms)
-    #define RADIOLIB_CB_ARGS_DELAY_MICROSECONDS         (void, delayMicroseconds, unsigned int us)
-    #define RADIOLIB_CB_ARGS_MILLIS                     (unsigned long, millis, void)
-    #define RADIOLIB_CB_ARGS_MICROS                     (unsigned long, micros, void)
-    #define RADIOLIB_CB_ARGS_PULSE_IN                   (unsigned long, pulseIn, pin_size_t pin, uint8_t state, unsigned long timeout)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN                  (void, SPIbegin, void)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN_TRANSACTION      (void, SPIbeginTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_TRANSFER               (uint8_t, SPItransfer, uint8_t b)
-    #define RADIOLIB_CB_ARGS_SPI_END_TRANSACTION        (void, SPIendTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_END                    (void, SPIend, void)
-
-  #elif defined(ARDUINO_ARCH_RP2040)
-    // Raspberry Pi Pico (unofficial core)
-    #define RADIOLIB_PLATFORM                           "Raspberry Pi Pico (unofficial)"
-    #define RADIOLIB_PIN_TYPE                           pin_size_t
-    #define RADIOLIB_PIN_MODE                           PinMode
-    #define RADIOLIB_PIN_STATUS                         PinStatus
-    #define RADIOLIB_INTERRUPT_STATUS                   RADIOLIB_PIN_STATUS
-    #define RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(p)        digitalPinToInterrupt(p)
-    #define RADIOLIB_NC                                 (0xFF)
-    #define RADIOLIB_DEFAULT_SPI                        SPI
-    #define RADIOLIB_DEFAULT_SPI_SETTINGS               SPISettings(2000000, MSBFIRST, SPI_MODE0)
-    #define RADIOLIB_NONVOLATILE                        PROGMEM
-    #define RADIOLIB_NONVOLATILE_READ_BYTE(addr)        pgm_read_byte(addr)
-    #define RADIOLIB_NONVOLATILE_READ_DWORD(addr)       pgm_read_dword(addr)
-    #define RADIOLIB_TYPE_ALIAS(type, alias)            using alias = type;
-
-    // Arduino API callbacks
-    #define RADIOLIB_CB_ARGS_PIN_MODE                   (void, pinMode, pin_size_t pin, PinMode mode)
-    #define RADIOLIB_CB_ARGS_DIGITAL_WRITE              (void, digitalWrite, pin_size_t pin, PinStatus val)
-    #define RADIOLIB_CB_ARGS_DIGITAL_READ               (PinStatus, digitalRead, pin_size_t pin)
-    #define RADIOLIB_CB_ARGS_TONE                       (void, tone, uint8_t pin, unsigned int frequency, unsigned long duration)
-    #define RADIOLIB_CB_ARGS_NO_TONE                    (void, noTone, uint8_t pin)
-    #define RADIOLIB_CB_ARGS_ATTACH_INTERRUPT           (void, attachInterrupt, pin_size_t interruptNum, voidFuncPtr func, PinStatus mode)
-    #define RADIOLIB_CB_ARGS_DETACH_INTERRUPT           (void, detachInterrupt, pin_size_t interruptNum)
-    #define RADIOLIB_CB_ARGS_YIELD                      (void, yield, void)
-    #define RADIOLIB_CB_ARGS_DELAY                      (void, delay, unsigned long ms)
-    #define RADIOLIB_CB_ARGS_DELAY_MICROSECONDS         (void, delayMicroseconds, unsigned int us)
-    #define RADIOLIB_CB_ARGS_MILLIS                     (unsigned long, millis, void)
-    #define RADIOLIB_CB_ARGS_MICROS                     (unsigned long, micros, void)
-    #define RADIOLIB_CB_ARGS_PULSE_IN                   (unsigned long, pulseIn, pin_size_t pin, uint8_t state, unsigned long timeout)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN                  (void, SPIbegin, void)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN_TRANSACTION      (void, SPIbeginTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_TRANSFER               (uint8_t, SPItransfer, uint8_t b)
-    #define RADIOLIB_CB_ARGS_SPI_END_TRANSACTION        (void, SPIendTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_END                    (void, SPIend, void)
-
-  #elif defined(__ASR6501__) || defined(ARDUINO_ARCH_ASR650X) || defined(DARDUINO_ARCH_ASR6601)
-    // CubeCell
-    #define RADIOLIB_PLATFORM                           "CubeCell"
-    #define RADIOLIB_PIN_TYPE                           uint8_t
-    #define RADIOLIB_PIN_MODE                           PINMODE
-    #define RADIOLIB_PIN_STATUS                         uint8_t
-    #define RADIOLIB_INTERRUPT_STATUS                   IrqModes
-    #define RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(p)        digitalPinToInterrupt(p)
-    #define RADIOLIB_NC                                 (0xFF)
-    #define RADIOLIB_DEFAULT_SPI                        SPI
-    #define RADIOLIB_DEFAULT_SPI_SETTINGS               SPISettings(1000000, MSBFIRST, SPI_MODE0) // see issue #709
-    #define RADIOLIB_NONVOLATILE                        PROGMEM
-    #define RADIOLIB_NONVOLATILE_READ_BYTE(addr)        pgm_read_byte(addr)
-    #define RADIOLIB_NONVOLATILE_READ_DWORD(addr)       pgm_read_dword(addr)
-
-    // Arduino API callbacks
-    #define RADIOLIB_CB_ARGS_PIN_MODE                   (void, pinMode, uint8_t pin, PINMODE mode)
-    #define RADIOLIB_CB_ARGS_DIGITAL_WRITE              (void, digitalWrite, uint8_t pin_name, uint8_t level)
-    #define RADIOLIB_CB_ARGS_DIGITAL_READ               (uint8_t, digitalRead, uint8_t pin_name)
-    #define RADIOLIB_CB_ARGS_TONE                       (void, tone, void)
-    #define RADIOLIB_CB_ARGS_NO_TONE                    (void, noTone, void)
-    #define RADIOLIB_CB_ARGS_ATTACH_INTERRUPT           (void, attachInterrupt, uint8_t pin_name, GpioIrqHandler GpioIrqHandlerCallback, IrqModes interrupt_mode)
-    #define RADIOLIB_CB_ARGS_DETACH_INTERRUPT           (void, detachInterrupt, uint8_t pin_name)
-    #define RADIOLIB_CB_ARGS_YIELD                      (void, yield, void)
-    #define RADIOLIB_CB_ARGS_DELAY                      (void, delay, uint32_t milliseconds)
-    #define RADIOLIB_CB_ARGS_DELAY_MICROSECONDS         (void, delayMicroseconds, uint16 microseconds)
-    #define RADIOLIB_CB_ARGS_MILLIS                     (uint32_t, millis, void)
-    #define RADIOLIB_CB_ARGS_MICROS                     (uint32_t, micros, void)
-    #define RADIOLIB_CB_ARGS_PULSE_IN                   (uint32_t, pulseIn, uint8_t pin_name, uint8_t mode, uint32_t timeout)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN                  (void, SPIbegin, void)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN_TRANSACTION      (void, SPIbeginTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_TRANSFER               (uint8_t, SPItransfer, uint8_t b)
-    #define RADIOLIB_CB_ARGS_SPI_END_TRANSACTION        (void, SPIendTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_END                    (void, SPIend, void)
-
-    // provide an easy access to the on-board module
-    #include "board-config.h"
-    #define RADIOLIB_BUILTIN_MODULE                      RADIO_NSS, RADIO_DIO_1, RADIO_RESET, RADIO_BUSY
-
-    // CubeCell doesn't seem to define nullptr, let's do something like that now
-    #define nullptr                                     NULL
-
-    // ... and also defines pinMode() as a macro, which is by far the stupidest thing I have seen on Arduino
-    #undef pinMode
-
-    // ... and uses an outdated GCC which does not support type aliases
-    #define RADIOLIB_TYPE_ALIAS(type, alias)            typedef class type alias;
-
-    // ... and it also has no tone(). This platform was designed by an idiot.
-    #define RADIOLIB_TONE_UNSUPPORTED
-
-    // ... AND as the (hopefully) final nail in the coffin, IT F*CKING DEFINES YIELD() AS A MACRO THAT DOES NOTHING!!!
-    #define RADIOLIB_YIELD_UNSUPPORTED
-    #if defined(yield)
-    #undef yield
-    #endif
-
-  #elif defined(RASPI)
-    // RaspiDuino framework (https://github.com/me-no-dev/RasPiArduino)
-    #define RADIOLIB_PLATFORM                           "RasPiArduino"
-    #define RADIOLIB_PIN_TYPE                           uint8_t
-    #define RADIOLIB_PIN_MODE                           uint8_t
-    #define RADIOLIB_PIN_STATUS                         uint8_t
-    #define RADIOLIB_INTERRUPT_STATUS                   RADIOLIB_PIN_STATUS
-    #define RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(p)        digitalPinToInterrupt(p)
-    #define RADIOLIB_NC                                 (0xFF)
-    #define RADIOLIB_DEFAULT_SPI                        SPI
-    #define RADIOLIB_DEFAULT_SPI_SETTINGS               SPISettings(2000000, MSBFIRST, SPI_MODE0)
-    #define RADIOLIB_NONVOLATILE                        PROGMEM
-    #define RADIOLIB_NONVOLATILE_READ_BYTE(addr)        pgm_read_byte(addr)
-    #define RADIOLIB_NONVOLATILE_READ_DWORD(addr)       pgm_read_dword(addr)
-    #define RADIOLIB_TYPE_ALIAS(type, alias)            using alias = type;
-
-    // Arduino API callbacks
-    #define RADIOLIB_CB_ARGS_PIN_MODE                   (void, pinMode, uint8_t pin, uint8_t mode)
-    #define RADIOLIB_CB_ARGS_DIGITAL_WRITE              (void, digitalWrite, uint8_t pin, uint8_t value)
-    #define RADIOLIB_CB_ARGS_DIGITAL_READ               (int, digitalRead, uint8_t pin)
-    #define RADIOLIB_CB_ARGS_TONE                       (void, tone, uint8_t _pin, unsigned int frequency, unsigned long duration)
-    #define RADIOLIB_CB_ARGS_NO_TONE                    (void, noTone, uint8_t _pin)
-    #define RADIOLIB_CB_ARGS_ATTACH_INTERRUPT           (void, attachInterrupt, uint8_t interruptNum, void (*userFunc)(void), int mode)
-    #define RADIOLIB_CB_ARGS_DETACH_INTERRUPT           (void, detachInterrupt, uint8_t interruptNum)
-    #define RADIOLIB_CB_ARGS_YIELD                      (void, yield, void)
-    #define RADIOLIB_CB_ARGS_DELAY                      (void, delay, uint32_t ms)
-    #define RADIOLIB_CB_ARGS_DELAY_MICROSECONDS         (void, delayMicroseconds, unsigned int us)
-    #define RADIOLIB_CB_ARGS_MILLIS                     (unsigned long, millis, void)
-    #define RADIOLIB_CB_ARGS_MICROS                     (unsigned long, micros, void)
-    #define RADIOLIB_CB_ARGS_PULSE_IN                   (unsigned long, pulseIn, uint8_t pin, uint8_t state, unsigned long timeout)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN                  (void, SPIbegin, void)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN_TRANSACTION      (void, SPIbeginTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_TRANSFER               (uint8_t, SPItransfer, uint8_t b)
-    #define RADIOLIB_CB_ARGS_SPI_END_TRANSACTION        (void, SPIendTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_END                    (void, SPIend, void)
-
-    // let's start off easy - no tone on this platform, that can happen
-    #define RADIOLIB_TONE_UNSUPPORTED
-
-    // hmm, no yield either - weird on something like Raspberry PI, but sure, we can handle it
-    #define RADIOLIB_YIELD_UNSUPPORTED
-
-    // aight, getting to the juicy stuff - PGM_P seems missing, that's the first time
-    #define PGM_P                                       const char *
-
-    // ... and for the grand finale, we have millis() and micros() DEFINED AS MACROS!
-    #if defined(millis)
-    #undef millis
-    inline unsigned long millis() { return((unsigned long)(STCV / 1000)); };
-    #endif
-
-    #if defined(micros)
-    #undef micros
-    inline unsigned long micros() { return((unsigned long)(STCV)); };
-    #endif
-
-  #elif defined(TEENSYDUINO)
-    // Teensy
-    #define RADIOLIB_PLATFORM                           "Teensy"
-    #define RADIOLIB_PIN_TYPE                           uint8_t
-    #define RADIOLIB_PIN_MODE                           uint8_t
-    #define RADIOLIB_PIN_STATUS                         uint8_t
-    #define RADIOLIB_INTERRUPT_STATUS                   RADIOLIB_PIN_STATUS
-    #define RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(p)        digitalPinToInterrupt(p)
-    #define RADIOLIB_NC                                 (0xFF)
-    #define RADIOLIB_DEFAULT_SPI                        SPI
-    #define RADIOLIB_DEFAULT_SPI_SETTINGS               SPISettings(2000000, MSBFIRST, SPI_MODE0)
-    #define RADIOLIB_NONVOLATILE                        PROGMEM
-    #define RADIOLIB_NONVOLATILE_READ_BYTE(addr)        pgm_read_byte(addr)
-    #define RADIOLIB_NONVOLATILE_READ_DWORD(addr)       pgm_read_dword(addr)
-    #define RADIOLIB_TYPE_ALIAS(type, alias)            using alias = type;
-
-    // Arduino API callbacks
-    #define RADIOLIB_CB_ARGS_PIN_MODE                   (void, pinMode, uint8_t pin, uint8_t mode)
-    #define RADIOLIB_CB_ARGS_DIGITAL_WRITE              (void, digitalWrite, uint8_t pin, uint8_t value)
-    #define RADIOLIB_CB_ARGS_DIGITAL_READ               (uint8_t, digitalRead, uint8_t pin)
-    #define RADIOLIB_CB_ARGS_TONE                       (void, tone, uint8_t _pin, short unsigned int frequency, long unsigned int duration)
-    #define RADIOLIB_CB_ARGS_NO_TONE                    (void, noTone, uint8_t _pin)
-    #define RADIOLIB_CB_ARGS_ATTACH_INTERRUPT           (void, attachInterrupt, uint8_t interruptNum, void (*userFunc)(void), int mode)
-    #define RADIOLIB_CB_ARGS_DETACH_INTERRUPT           (void, detachInterrupt, uint8_t interruptNum)
-    #define RADIOLIB_CB_ARGS_YIELD                      (void, yield, void)
-    #define RADIOLIB_CB_ARGS_DELAY                      (void, delay, unsigned long ms)
-    #define RADIOLIB_CB_ARGS_DELAY_MICROSECONDS         (void, delayMicroseconds, long unsigned int us)
-    #define RADIOLIB_CB_ARGS_MILLIS                     (unsigned long, millis, void)
-    #define RADIOLIB_CB_ARGS_MICROS                     (unsigned long, micros, void)
-    #define RADIOLIB_CB_ARGS_PULSE_IN                   (unsigned long, pulseIn, uint8_t pin, uint8_t state, unsigned long timeout)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN                  (void, SPIbegin, void)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN_TRANSACTION      (void, SPIbeginTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_TRANSFER               (uint8_t, SPItransfer, uint8_t b)
-    #define RADIOLIB_CB_ARGS_SPI_END_TRANSACTION        (void, SPIendTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_END                    (void, SPIend, void)
-
-  #else
-    // other Arduino platforms not covered by the above list - this may or may not work
-    #define RADIOLIB_PLATFORM                           "Unknown Arduino"
-    #define RADIOLIB_UNKNOWN_PLATFORM
-    #define RADIOLIB_PIN_TYPE                           uint8_t
-    #define RADIOLIB_PIN_MODE                           uint8_t
-    #define RADIOLIB_PIN_STATUS                         uint8_t
-    #define RADIOLIB_INTERRUPT_STATUS                   RADIOLIB_PIN_STATUS
-    #define RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(p)        digitalPinToInterrupt(p)
-    #define RADIOLIB_NC                                 (0xFF)
-    #define RADIOLIB_DEFAULT_SPI                        SPI
-    #define RADIOLIB_DEFAULT_SPI_SETTINGS               SPISettings(2000000, MSBFIRST, SPI_MODE0)
-    #define RADIOLIB_NONVOLATILE                        PROGMEM
-    #define RADIOLIB_NONVOLATILE_READ_BYTE(addr)        pgm_read_byte(addr)
-    #define RADIOLIB_NONVOLATILE_READ_DWORD(addr)       pgm_read_dword(addr)
-    #define RADIOLIB_TYPE_ALIAS(type, alias)            using alias = type;
-
-    // Arduino API callbacks
-    #define RADIOLIB_CB_ARGS_PIN_MODE                   (void, pinMode, uint8_t pin, uint8_t mode)
-    #define RADIOLIB_CB_ARGS_DIGITAL_WRITE              (void, digitalWrite, uint8_t pin, uint8_t value)
-    #define RADIOLIB_CB_ARGS_DIGITAL_READ               (int, digitalRead, uint8_t pin)
-    #define RADIOLIB_CB_ARGS_TONE                       (void, tone, uint8_t _pin, unsigned int frequency, unsigned long duration)
-    #define RADIOLIB_CB_ARGS_NO_TONE                    (void, noTone, uint8_t _pin)
-    #define RADIOLIB_CB_ARGS_ATTACH_INTERRUPT           (void, attachInterrupt, uint8_t interruptNum, void (*userFunc)(void), int mode)
-    #define RADIOLIB_CB_ARGS_DETACH_INTERRUPT           (void, detachInterrupt, uint8_t interruptNum)
-    #define RADIOLIB_CB_ARGS_YIELD                      (void, yield, void)
-    #define RADIOLIB_CB_ARGS_DELAY                      (void, delay, unsigned long ms)
-    #define RADIOLIB_CB_ARGS_DELAY_MICROSECONDS         (void, delayMicroseconds, unsigned int us)
-    #define RADIOLIB_CB_ARGS_MILLIS                     (unsigned long, millis, void)
-    #define RADIOLIB_CB_ARGS_MICROS                     (unsigned long, micros, void)
-    #define RADIOLIB_CB_ARGS_PULSE_IN                   (unsigned long, pulseIn, uint8_t pin, uint8_t state, unsigned long timeout)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN                  (void, SPIbegin, void)
-    #define RADIOLIB_CB_ARGS_SPI_BEGIN_TRANSACTION      (void, SPIbeginTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_TRANSFER               (uint8_t, SPItransfer, uint8_t b)
-    #define RADIOLIB_CB_ARGS_SPI_END_TRANSACTION        (void, SPIendTransaction, void)
-    #define RADIOLIB_CB_ARGS_SPI_END                    (void, SPIend, void)
-
+  // ... AND as the (hopefully) final nail in the coffin, IT F*CKING DEFINES YIELD() AS A MACRO THAT DOES NOTHING!!!
+  #define RADIOLIB_YIELD_UNSUPPORTED
+  #if defined(yield)
+  #undef yield
   #endif
+#elif defined(RASPI)
+  // RaspiDuino framework (https://github.com/me-no-dev/RasPiArduino)
+  #define RADIOLIB_PLATFORM                           "RasPiArduino"
+
+  // let's start off easy - no tone on this platform, that can happen
+  #define RADIOLIB_TONE_UNSUPPORTED
+
+  // hmm, no yield either - weird on something like Raspberry PI, but sure, we can handle it
+  #define RADIOLIB_YIELD_UNSUPPORTED
+
+  // aight, getting to the juicy stuff - PGM_P seems missing, that's the first time
+  #define PGM_P                                       const char *
+
+  // ... and for the grand finale, we have millis() and micros() DEFINED AS MACROS!
+  #if defined(millis)
+  #undef millis
+  inline unsigned long millis() { return((unsigned long)(STCV / 1000)); };
+  #endif
+
+  #if defined(micros)
+  #undef micros
+  inline unsigned long micros() { return((unsigned long)(STCV)); };
+  #endif
+#elif defined(TEENSYDUINO)
+  // Teensy
+  #define RADIOLIB_PLATFORM                           "Teensy"
+#else
+  // other Arduino platforms not covered by the above list - this may or may not work
+  #define RADIOLIB_PLATFORM                           "Unknown Arduino"
+  #define RADIOLIB_UNKNOWN_PLATFORM
 #endif
 
+  #if !defined(RADIOLIB_NC)
+  #define RADIOLIB_NC                                 (0xFF)
+  #endif
+  #if !defined(RADIOLIB_DEFAULT_SPI)
+  #define RADIOLIB_DEFAULT_SPI                        SPI
+  #endif
+  #if !defined(RADIOLIB_DEFAULT_SPI_SETTINGS)
+  #define RADIOLIB_DEFAULT_SPI_SETTINGS               SPISettings(2000000, MSBFIRST, SPI_MODE0)
+  #endif
+  #if !defined(RADIOLIB_NONVOLATILE)
+  #define RADIOLIB_NONVOLATILE                        PROGMEM
+  #endif
+  #if !defined(RADIOLIB_NONVOLATILE_READ_BYTE)
+  #define RADIOLIB_NONVOLATILE_READ_BYTE(addr)        pgm_read_byte(addr)
+  #endif
+  #if !defined(RADIOLIB_NONVOLATILE_READ_DWORD)
+  #define RADIOLIB_NONVOLATILE_READ_DWORD(addr)       pgm_read_dword(addr)
+  #endif
+  #if !defined(RADIOLIB_TYPE_ALIAS)
+  #define RADIOLIB_TYPE_ALIAS(type, alias)            using alias = type;
+  #endif
+
+  #if !defined(RADIOLIB_ARDUINOHAL_PIN_MODE_CAST)
+  #define RADIOLIB_ARDUINOHAL_PIN_MODE_CAST
+  #endif
+  #if !defined(RADIOLIB_ARDUINOHAL_PIN_STATUS_CAST)
+  #define RADIOLIB_ARDUINOHAL_PIN_STATUS_CAST
+  #endif
+  #if !defined(RADIOLIB_ARDUINOHAL_INTERRUPT_MODE_CAST)
+  #define RADIOLIB_ARDUINOHAL_INTERRUPT_MODE_CAST
+  #endif
 #else
   // generic non-Arduino platform
   #define RADIOLIB_PLATFORM                           "Generic"
 
-  // platform properties may be defined here, or somewhere else in the build system
-  #include "noarduino.h"
+  #define RADIOLIB_NC                                 (0xFF)
+  #define RADIOLIB_NONVOLATILE
+  #define RADIOLIB_NONVOLATILE_READ_BYTE(addr)        (*((uint8_t *)(void *)(addr)))
+  #define RADIOLIB_NONVOLATILE_READ_DWORD(addr)       (*((uint32_t *)(void *)(addr)))
+  #define RADIOLIB_TYPE_ALIAS(type, alias)            using alias = type;
 
+  #if !defined(RADIOLIB_DEBUG_PORT)
+    #define RADIOLIB_DEBUG_PORT   stdout
+  #endif
+
+  #define DEC 10
+  #define HEX 16
+  #define OCT 8
+  #define BIN 2
+
+  #include <algorithm>
+  #include <stdint.h>
+
+  typedef uint8_t byte;
+
+  using std::max;
+  using std::min;
 #endif
 
 /*
@@ -950,7 +295,7 @@
 
 // set which output port should be used for debug output
 // may be Serial port (on Arduino) or file like stdout or stderr (on generic platforms)
-#if !defined(RADIOLIB_DEBUG_PORT)
+#if defined(RADIOLIB_BUILD_ARDUINO) && !defined(RADIOLIB_DEBUG_PORT)
   #define RADIOLIB_DEBUG_PORT   Serial
 #endif
 
@@ -1068,24 +413,6 @@
 */
 #define RADIOLIB_ASSERT(STATEVAR) { if((STATEVAR) != RADIOLIB_ERR_NONE) { return(STATEVAR); } }
 
-/*
- * Macros that create callback for the hardware abstraction layer.
- *
- * This is the most evil thing I have ever created. I am deeply sorry to anyone currently reading this text.
- * Come one, come all and witness the horror:
- * Variadics, forced expansions, inlined function, string concatenation, and it even messes up access specifiers.
- */
-#define RADIOLIB_FIRST(arg, ...) arg
-#define RADIOLIB_REST(arg, ...) __VA_ARGS__
-#define RADIOLIB_EXP(...) __VA_ARGS__
-
-#define RADIOLIB_GENERATE_CALLBACK_RET_FUNC(RET, FUNC, ...) public: typedef RET (*FUNC##_cb_t)(__VA_ARGS__); void setCb_##FUNC(FUNC##_cb_t cb) { cb_##FUNC = cb; }; private: FUNC##_cb_t cb_##FUNC = nullptr;
-#define RADIOLIB_GENERATE_CALLBACK_RET(RET, ...) RADIOLIB_GENERATE_CALLBACK_RET_FUNC(RET, __VA_ARGS__)
-#define RADIOLIB_GENERATE_CALLBACK(CB) RADIOLIB_GENERATE_CALLBACK_RET(RADIOLIB_EXP(RADIOLIB_FIRST CB), RADIOLIB_EXP(RADIOLIB_REST CB))
-
-#define RADIOLIB_GENERATE_CALLBACK_SPI_RET_FUNC(RET, FUNC, ...) public: typedef RET (Module::*FUNC##_cb_t)(__VA_ARGS__); void setCb_##FUNC(FUNC##_cb_t cb) { cb_##FUNC = cb; }; private: FUNC##_cb_t cb_##FUNC = nullptr;
-#define RADIOLIB_GENERATE_CALLBACK_SPI_RET(RET, ...) RADIOLIB_GENERATE_CALLBACK_SPI_RET_FUNC(RET, __VA_ARGS__)
-#define RADIOLIB_GENERATE_CALLBACK_SPI(CB) RADIOLIB_GENERATE_CALLBACK_SPI_RET(RADIOLIB_EXP(RADIOLIB_FIRST CB), RADIOLIB_EXP(RADIOLIB_REST CB))
 
 /*!
   \brief Macro to check variable is within constraints - this is commonly used to check parameter ranges. Requires RADIOLIB_CHECK_RANGE to be enabled

--- a/src/BuildOpt.h
+++ b/src/BuildOpt.h
@@ -273,8 +273,6 @@
   #include <algorithm>
   #include <stdint.h>
 
-  typedef uint8_t byte;
-
   using std::max;
   using std::min;
 #endif

--- a/src/Hal.cpp
+++ b/src/Hal.cpp
@@ -1,0 +1,17 @@
+#include <stdint.h>
+#include "Hal.h"
+
+Hal::Hal(const uint8_t input, const uint8_t output, const uint8_t low, const uint8_t high, const uint8_t rising, const uint8_t falling)
+    : GpioModeInput(input),
+      GpioModeOutput(output),
+      GpioLevelLow(high),
+      GpioLevelHigh(low),
+      GpioInterruptRising(rising),
+      GpioInterruptFalling(falling) {}
+
+void Hal::init(){};
+void Hal::term(){};
+void Hal::tone(uint8_t pin, unsigned int frequency, unsigned long duration){};
+void Hal::noTone(uint8_t pin){};
+void Hal::yield(){};
+uint8_t Hal::pinToInterrupt(uint8_t pin) { return pin; };

--- a/src/Hal.cpp
+++ b/src/Hal.cpp
@@ -1,7 +1,7 @@
 #include <stdint.h>
 #include "Hal.h"
 
-Hal::Hal(const uint8_t input, const uint8_t output, const uint8_t low, const uint8_t high, const uint8_t rising, const uint8_t falling)
+Hal::Hal(const uint32_t input, const uint32_t output, const uint32_t low, const uint32_t high, const uint32_t rising, const uint32_t falling)
     : GpioModeInput(input),
       GpioModeOutput(output),
       GpioLevelLow(low),
@@ -11,15 +11,15 @@ Hal::Hal(const uint8_t input, const uint8_t output, const uint8_t low, const uin
 
 void Hal::init(){};
 void Hal::term(){};
-void Hal::tone(uint8_t pin, unsigned int frequency, unsigned long duration){
+void Hal::tone(uint32_t pin, unsigned int frequency, unsigned long duration){
   (void)pin;
   (void)frequency;
   (void)duration;
 };
-void Hal::noTone(uint8_t pin){
+void Hal::noTone(uint32_t pin){
   (void)pin;
 };
 void Hal::yield(){};
-uint8_t Hal::pinToInterrupt(uint8_t pin) {
+uint32_t Hal::pinToInterrupt(uint32_t pin) {
   return pin;
 };

--- a/src/Hal.cpp
+++ b/src/Hal.cpp
@@ -4,8 +4,8 @@
 Hal::Hal(const uint8_t input, const uint8_t output, const uint8_t low, const uint8_t high, const uint8_t rising, const uint8_t falling)
     : GpioModeInput(input),
       GpioModeOutput(output),
-      GpioLevelLow(high),
-      GpioLevelHigh(low),
+      GpioLevelLow(low),
+      GpioLevelHigh(high),
       GpioInterruptRising(rising),
       GpioInterruptFalling(falling) {}
 

--- a/src/Hal.cpp
+++ b/src/Hal.cpp
@@ -11,7 +11,15 @@ Hal::Hal(const uint8_t input, const uint8_t output, const uint8_t low, const uin
 
 void Hal::init(){};
 void Hal::term(){};
-void Hal::tone(uint8_t pin, unsigned int frequency, unsigned long duration){};
-void Hal::noTone(uint8_t pin){};
+void Hal::tone(uint8_t pin, unsigned int frequency, unsigned long duration){
+  (void)pin;
+  (void)frequency;
+  (void)duration;
+};
+void Hal::noTone(uint8_t pin){
+  (void)pin;
+};
 void Hal::yield(){};
-uint8_t Hal::pinToInterrupt(uint8_t pin) { return pin; };
+uint8_t Hal::pinToInterrupt(uint8_t pin) {
+  return pin;
+};

--- a/src/Hal.h
+++ b/src/Hal.h
@@ -1,0 +1,42 @@
+#include <stdint.h>
+#include <stddef.h>
+#if !defined(_RADIOLIB_HAL_H)
+#define _RADIOLIB_HAL_H
+
+class Hal {
+  public:
+    const uint8_t GpioModeInput;
+    const uint8_t GpioModeOutput;
+    const uint8_t GpioLevelLow;
+    const uint8_t GpioLevelHigh;
+    const uint8_t GpioInterruptRising;
+    const uint8_t GpioInterruptFalling;
+
+    Hal(const uint8_t input, const uint8_t output, const uint8_t low, const uint8_t high, const uint8_t rising, const uint8_t falling);
+
+    virtual void init();
+    virtual void term();
+
+    virtual void pinMode(uint8_t pin, uint8_t mode) = 0;
+    virtual void digitalWrite(uint8_t pin, uint8_t value) = 0;
+    virtual uint8_t digitalRead(uint8_t pin) = 0;
+    virtual void attachInterrupt(uint8_t interruptNum, void (*interruptCb)(void), uint8_t mode) = 0;
+    virtual void detachInterrupt(uint8_t interruptNum) = 0;
+    virtual void delay(unsigned long ms) = 0;
+    virtual void delayMicroseconds(unsigned long us) = 0;
+    virtual unsigned long millis() = 0;
+    virtual unsigned long micros() = 0;
+    virtual long pulseIn(uint8_t pin, uint8_t state, unsigned long timeout) = 0;
+    virtual void spiBegin() = 0;
+    virtual void spiBeginTransaction() = 0;
+    virtual uint8_t spiTransfer(uint8_t b) = 0;
+    virtual void spiEndTransaction() = 0;
+    virtual void spiEnd() = 0;
+
+    virtual void tone(uint8_t pin, unsigned int frequency, unsigned long duration = 0);
+    virtual void noTone(uint8_t pin);
+    virtual void yield();
+    virtual uint8_t pinToInterrupt(uint8_t pin);
+};
+
+#endif

--- a/src/Hal.h
+++ b/src/Hal.h
@@ -3,40 +3,45 @@
 #if !defined(_RADIOLIB_HAL_H)
 #define _RADIOLIB_HAL_H
 
+/*!
+  \class Hal
+
+  \brief Hardware abstraction library base interface.
+*/
 class Hal {
   public:
-    const uint8_t GpioModeInput;
-    const uint8_t GpioModeOutput;
-    const uint8_t GpioLevelLow;
-    const uint8_t GpioLevelHigh;
-    const uint8_t GpioInterruptRising;
-    const uint8_t GpioInterruptFalling;
+    const uint32_t GpioModeInput;
+    const uint32_t GpioModeOutput;
+    const uint32_t GpioLevelLow;
+    const uint32_t GpioLevelHigh;
+    const uint32_t GpioInterruptRising;
+    const uint32_t GpioInterruptFalling;
 
-    Hal(const uint8_t input, const uint8_t output, const uint8_t low, const uint8_t high, const uint8_t rising, const uint8_t falling);
+    Hal(const uint32_t input, const uint32_t output, const uint32_t low, const uint32_t high, const uint32_t rising, const uint32_t falling);
 
     virtual void init();
     virtual void term();
 
-    virtual void pinMode(uint8_t pin, uint8_t mode) = 0;
-    virtual void digitalWrite(uint8_t pin, uint8_t value) = 0;
-    virtual uint8_t digitalRead(uint8_t pin) = 0;
-    virtual void attachInterrupt(uint8_t interruptNum, void (*interruptCb)(void), uint8_t mode) = 0;
-    virtual void detachInterrupt(uint8_t interruptNum) = 0;
+    virtual void pinMode(uint32_t pin, uint32_t mode) = 0;
+    virtual void digitalWrite(uint32_t pin, uint32_t value) = 0;
+    virtual uint32_t digitalRead(uint32_t pin) = 0;
+    virtual void attachInterrupt(uint32_t interruptNum, void (*interruptCb)(void), uint32_t mode) = 0;
+    virtual void detachInterrupt(uint32_t interruptNum) = 0;
     virtual void delay(unsigned long ms) = 0;
     virtual void delayMicroseconds(unsigned long us) = 0;
     virtual unsigned long millis() = 0;
     virtual unsigned long micros() = 0;
-    virtual long pulseIn(uint8_t pin, uint8_t state, unsigned long timeout) = 0;
+    virtual long pulseIn(uint32_t pin, uint32_t state, unsigned long timeout) = 0;
     virtual void spiBegin() = 0;
     virtual void spiBeginTransaction() = 0;
     virtual uint8_t spiTransfer(uint8_t b) = 0;
     virtual void spiEndTransaction() = 0;
     virtual void spiEnd() = 0;
 
-    virtual void tone(uint8_t pin, unsigned int frequency, unsigned long duration = 0);
-    virtual void noTone(uint8_t pin);
+    virtual void tone(uint32_t pin, unsigned int frequency, unsigned long duration = 0);
+    virtual void noTone(uint32_t pin);
     virtual void yield();
-    virtual uint8_t pinToInterrupt(uint8_t pin);
+    virtual uint32_t pinToInterrupt(uint32_t pin);
 };
 
 #endif

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -6,16 +6,16 @@
 
 #if defined(RADIOLIB_BUILD_ARDUINO)
 #include "ArduinoHal.h"
-Module::Module(uint8_t cs, uint8_t irq, uint8_t rst, uint8_t gpio) : _cs(cs), _irq(irq), _rst(rst), _gpio(gpio) {
+Module::Module(uint32_t cs, uint32_t irq, uint32_t rst, uint32_t gpio) : _cs(cs), _irq(irq), _rst(rst), _gpio(gpio) {
   this->hal = new ArduinoHal;
 }
 
-Module::Module(uint8_t cs, uint8_t irq, uint8_t rst, uint8_t gpio, SPIClass& spi, SPISettings spiSettings) : _cs(cs), _irq(irq), _rst(rst), _gpio(gpio) {
+Module::Module(uint32_t cs, uint32_t irq, uint32_t rst, uint32_t gpio, SPIClass& spi, SPISettings spiSettings) : _cs(cs), _irq(irq), _rst(rst), _gpio(gpio) {
   this->hal = new ArduinoHal(spi, spiSettings);
 }
 #endif
 
-Module::Module(Hal *hal, uint8_t cs, uint8_t irq, uint8_t rst, uint8_t gpio) : _cs(cs), _irq(irq), _rst(rst), _gpio(gpio) {
+Module::Module(Hal *hal, uint32_t cs, uint32_t irq, uint32_t rst, uint32_t gpio) : _cs(cs), _irq(irq), _rst(rst), _gpio(gpio) {
   this->hal = hal;
 }
 
@@ -465,9 +465,9 @@ size_t Module::serialPrintf(const char* format, ...) {
 }
 #endif
 
-void Module::setRfSwitchPins(uint8_t rxEn, uint8_t txEn) {
+void Module::setRfSwitchPins(uint32_t rxEn, uint32_t txEn) {
   // This can be on the stack, setRfSwitchTable copies the contents
-  const uint8_t pins[] = {
+  const uint32_t pins[] = {
     rxEn, txEn, RADIOLIB_NC,
   };
   // This must be static, since setRfSwitchTable stores a reference.
@@ -480,7 +480,7 @@ void Module::setRfSwitchPins(uint8_t rxEn, uint8_t txEn) {
   setRfSwitchTable(pins, table);
 }
 
-void Module::setRfSwitchTable(const uint8_t (&pins)[3], const RfSwitchMode_t table[]) {
+void Module::setRfSwitchTable(const uint32_t (&pins)[3], const RfSwitchMode_t table[]) {
   memcpy(_rfSwitchPins, pins, sizeof(_rfSwitchPins));
   _rfSwitchTable = table;
   for(size_t i = 0; i < RFSWITCH_MAX_PINS; i++)
@@ -505,9 +505,9 @@ void Module::setRfSwitchState(uint8_t mode) {
   }
 
   // set pins
-  const uint8_t *value = &row->values[0];
+  const uint32_t *value = &row->values[0];
   for(size_t i = 0; i < RFSWITCH_MAX_PINS; i++) {
-    uint8_t pin = _rfSwitchPins[i];
+    uint32_t pin = _rfSwitchPins[i];
     if (pin != RADIOLIB_NC)
       this->hal->digitalWrite(pin, *value);
     ++value;

--- a/src/Module.h
+++ b/src/Module.h
@@ -46,7 +46,7 @@ class Module {
      */
     struct RfSwitchMode_t {
       uint8_t mode;
-      uint8_t values[RFSWITCH_MAX_PINS];
+      uint32_t values[RFSWITCH_MAX_PINS];
     };
 
     /*!
@@ -81,7 +81,7 @@ class Module {
 
       \param gpio Arduino pin to be used as additional interrupt/GPIO.
     */
-    Module(uint8_t cs, uint8_t irq, uint8_t rst, uint8_t gpio = RADIOLIB_NC);
+    Module(uint32_t cs, uint32_t irq, uint32_t rst, uint32_t gpio = RADIOLIB_NC);
 
     /*!
       \brief Arduino Module constructor. Will not attempt SPI interface initialization.
@@ -98,7 +98,7 @@ class Module {
 
       \param spiSettings SPI interface settings.
     */
-    Module(uint8_t cs, uint8_t irq, uint8_t rst, uint8_t gpio, SPIClass& spi, SPISettings spiSettings = RADIOLIB_DEFAULT_SPI_SETTINGS);
+    Module(uint32_t cs, uint32_t irq, uint32_t rst, uint32_t gpio, SPIClass& spi, SPISettings spiSettings = RADIOLIB_DEFAULT_SPI_SETTINGS);
     #endif
 
     /*!
@@ -114,7 +114,7 @@ class Module {
 
       \param gpio Pin to be used as additional interrupt/GPIO.
     */
-    Module(Hal *hal, uint8_t cs, uint8_t irq, uint8_t rst, uint8_t gpio = RADIOLIB_NC);
+    Module(Hal *hal, uint32_t cs, uint32_t irq, uint32_t rst, uint32_t gpio = RADIOLIB_NC);
 
     /*!
       \brief Copy constructor.
@@ -410,28 +410,28 @@ class Module {
 
       \returns Pin number of SPI chip select configured in the constructor.
     */
-    uint8_t getCs() const { return(_cs); }
+    uint32_t getCs() const { return(_cs); }
 
     /*!
       \brief Access method to get the pin number of interrupt/GPIO.
 
       \returns Pin number of interrupt/GPIO configured in the constructor.
     */
-    uint8_t getIrq() const { return(_irq); }
+    uint32_t getIrq() const { return(_irq); }
 
     /*!
       \brief Access method to get the pin number of hardware reset pin.
 
       \returns Pin number of hardware reset pin configured in the constructor.
     */
-    uint8_t getRst() const { return(_rst); }
+    uint32_t getRst() const { return(_rst); }
 
     /*!
       \brief Access method to get the pin number of second interrupt/GPIO.
 
       \returns Pin number of second interrupt/GPIO configured in the constructor.
     */
-    uint8_t getGpio() const { return(_gpio); }
+    uint32_t getGpio() const { return(_gpio); }
 
     /*!
       \brief Some modules contain external RF switch controlled by pins.
@@ -449,7 +449,7 @@ class Module {
       \param rxEn RX enable pin.
       \param txEn TX enable pin.
     */
-    void setRfSwitchPins(uint8_t rxEn, uint8_t txEn);
+    void setRfSwitchPins(uint32_t rxEn, uint32_t txEn);
 
     /*!
       \brief Some modules contain external RF switch controlled by pins.
@@ -495,7 +495,7 @@ class Module {
 
       \code
       // In global scope, define the pin array and mode table
-      static const uint8_t rfswitch_pins[] =
+      static const uint32_t rfswitch_pins[] =
                              {PA0,  PA1,  RADIOLIB_NC};
       static const Module::RfSwitchMode_t rfswitch_table[] = {
         {Module::MODE_IDLE,  {LOW,  LOW}},
@@ -513,7 +513,7 @@ class Module {
       \endcode
     */
 
-    void setRfSwitchTable(const uint8_t (&pins)[RFSWITCH_MAX_PINS], const RfSwitchMode_t table[]);
+    void setRfSwitchTable(const uint32_t (&pins)[RFSWITCH_MAX_PINS], const RfSwitchMode_t table[]);
 
     /*!
      * \brief Find a mode in the RfSwitchTable.
@@ -581,13 +581,13 @@ class Module {
 #if !defined(RADIOLIB_GODMODE)
   private:
 #endif
-    uint8_t _cs = RADIOLIB_NC;
-    uint8_t _irq = RADIOLIB_NC;
-    uint8_t _rst = RADIOLIB_NC;
-    uint8_t _gpio = RADIOLIB_NC;
+    uint32_t _cs = RADIOLIB_NC;
+    uint32_t _irq = RADIOLIB_NC;
+    uint32_t _rst = RADIOLIB_NC;
+    uint32_t _gpio = RADIOLIB_NC;
 
     // RF switch pins and table
-    uint8_t _rfSwitchPins[RFSWITCH_MAX_PINS] = { RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC };
+    uint32_t _rfSwitchPins[RFSWITCH_MAX_PINS] = { RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC };
     const RfSwitchMode_t *_rfSwitchTable = nullptr;
 
     #if defined(RADIOLIB_INTERRUPT_TIMING)

--- a/src/Module.h
+++ b/src/Module.h
@@ -1,7 +1,8 @@
-#include "TypeDef.h"
-#include "Hal.h"
 #if !defined(_RADIOLIB_MODULE_H)
 #define _RADIOLIB_MODULE_H
+
+#include "TypeDef.h"
+#include "Hal.h"
 
 #if defined(RADIOLIB_BUILD_ARDUINO)
   #include <SPI.h>

--- a/src/Module.h
+++ b/src/Module.h
@@ -106,13 +106,13 @@ class Module {
 
       \param hal A Hardware abstraction layer instance. An ArduinoHal instance for example.
 
-      \param cs Arduino pin to be used as chip select.
+      \param cs Pin to be used as chip select.
 
-      \param irq Arduino pin to be used as interrupt/GPIO.
+      \param irq Pin to be used as interrupt/GPIO.
 
-      \param rst Arduino pin to be used as hardware reset for the module.
+      \param rst Pin to be used as hardware reset for the module.
 
-      \param gpio Arduino pin to be used as additional interrupt/GPIO.
+      \param gpio Pin to be used as additional interrupt/GPIO.
     */
     Module(Hal *hal, uint8_t cs, uint8_t irq, uint8_t rst, uint8_t gpio = RADIOLIB_NC);
 

--- a/src/Module.h
+++ b/src/Module.h
@@ -1,7 +1,7 @@
+#include "TypeDef.h"
+#include "Hal.h"
 #if !defined(_RADIOLIB_MODULE_H)
 #define _RADIOLIB_MODULE_H
-
-#include "TypeDef.h"
 
 #if defined(RADIOLIB_BUILD_ARDUINO)
   #include <SPI.h>
@@ -45,7 +45,7 @@ class Module {
      */
     struct RfSwitchMode_t {
       uint8_t mode;
-      RADIOLIB_PIN_STATUS values[RFSWITCH_MAX_PINS];
+      uint8_t values[RFSWITCH_MAX_PINS];
     };
 
     /*!
@@ -69,9 +69,8 @@ class Module {
     };
 
     #if defined(RADIOLIB_BUILD_ARDUINO)
-
     /*!
-      \brief Arduino Module constructor. Will use the default SPI interface and automatically initialize it
+      \brief Arduino Module constructor. Will use the default SPI interface and automatically initialize it.
 
       \param cs Arduino pin to be used as chip select.
 
@@ -81,7 +80,7 @@ class Module {
 
       \param gpio Arduino pin to be used as additional interrupt/GPIO.
     */
-    Module(RADIOLIB_PIN_TYPE cs, RADIOLIB_PIN_TYPE irq, RADIOLIB_PIN_TYPE rst, RADIOLIB_PIN_TYPE gpio = RADIOLIB_NC);
+    Module(uint8_t cs, uint8_t irq, uint8_t rst, uint8_t gpio = RADIOLIB_NC);
 
     /*!
       \brief Arduino Module constructor. Will not attempt SPI interface initialization.
@@ -98,24 +97,23 @@ class Module {
 
       \param spiSettings SPI interface settings.
     */
-    Module(RADIOLIB_PIN_TYPE cs, RADIOLIB_PIN_TYPE irq, RADIOLIB_PIN_TYPE rst, RADIOLIB_PIN_TYPE gpio, SPIClass& spi, SPISettings spiSettings = RADIOLIB_DEFAULT_SPI_SETTINGS);
-
-    #else
+    Module(uint8_t cs, uint8_t irq, uint8_t rst, uint8_t gpio, SPIClass& spi, SPISettings spiSettings = RADIOLIB_DEFAULT_SPI_SETTINGS);
+    #endif
 
     /*!
-      \brief Default constructor.
+      \brief Module constructor.
 
-      \param cs Pin to be used as chip select.
+      \param hal A Hardware abstraction layer instance. An ArduinoHal instance for example.
 
-      \param irq Pin to be used as interrupt/GPIO.
+      \param cs Arduino pin to be used as chip select.
 
-      \param rst Pin to be used as hardware reset for the module.
+      \param irq Arduino pin to be used as interrupt/GPIO.
 
-      \param gpio Pin to be used as additional interrupt/GPIO.
+      \param rst Arduino pin to be used as hardware reset for the module.
+
+      \param gpio Arduino pin to be used as additional interrupt/GPIO.
     */
-    Module(RADIOLIB_PIN_TYPE cs, RADIOLIB_PIN_TYPE irq, RADIOLIB_PIN_TYPE rst, RADIOLIB_PIN_TYPE gpio = RADIOLIB_NC);
-
-    #endif
+    Module(Hal *hal, uint8_t cs, uint8_t irq, uint8_t rst, uint8_t gpio = RADIOLIB_NC);
 
     /*!
       \brief Copy constructor.
@@ -132,6 +130,8 @@ class Module {
     Module& operator=(const Module& mod);
 
     // public member variables
+
+    Hal* hal = NULL;
 
     /*!
       \brief Basic SPI read command. Defaults to 0x00.
@@ -409,28 +409,28 @@ class Module {
 
       \returns Pin number of SPI chip select configured in the constructor.
     */
-    RADIOLIB_PIN_TYPE getCs() const { return(_cs); }
+    uint8_t getCs() const { return(_cs); }
 
     /*!
       \brief Access method to get the pin number of interrupt/GPIO.
 
       \returns Pin number of interrupt/GPIO configured in the constructor.
     */
-    RADIOLIB_PIN_TYPE getIrq() const { return(_irq); }
+    uint8_t getIrq() const { return(_irq); }
 
     /*!
       \brief Access method to get the pin number of hardware reset pin.
 
       \returns Pin number of hardware reset pin configured in the constructor.
     */
-    RADIOLIB_PIN_TYPE getRst() const { return(_rst); }
+    uint8_t getRst() const { return(_rst); }
 
     /*!
       \brief Access method to get the pin number of second interrupt/GPIO.
 
       \returns Pin number of second interrupt/GPIO configured in the constructor.
     */
-    RADIOLIB_PIN_TYPE getGpio() const { return(_gpio); }
+    uint8_t getGpio() const { return(_gpio); }
 
     /*!
       \brief Some modules contain external RF switch controlled by pins.
@@ -448,7 +448,7 @@ class Module {
       \param rxEn RX enable pin.
       \param txEn TX enable pin.
     */
-    void setRfSwitchPins(RADIOLIB_PIN_TYPE rxEn, RADIOLIB_PIN_TYPE txEn);
+    void setRfSwitchPins(uint8_t rxEn, uint8_t txEn);
 
     /*!
       \brief Some modules contain external RF switch controlled by pins.
@@ -494,7 +494,7 @@ class Module {
 
       \code
       // In global scope, define the pin array and mode table
-      static const RADIOLIB_PIN_TYPE rfswitch_pins[] =
+      static const uint8_t rfswitch_pins[] =
                              {PA0,  PA1,  RADIOLIB_NC};
       static const Module::RfSwitchMode_t rfswitch_table[] = {
         {Module::MODE_IDLE,  {LOW,  LOW}},
@@ -512,7 +512,7 @@ class Module {
       \endcode
     */
 
-    void setRfSwitchTable(const RADIOLIB_PIN_TYPE (&pins)[RFSWITCH_MAX_PINS], const RfSwitchMode_t table[]);
+    void setRfSwitchTable(const uint8_t (&pins)[RFSWITCH_MAX_PINS], const RfSwitchMode_t table[]);
 
     /*!
      * \brief Find a mode in the RfSwitchTable.
@@ -540,137 +540,6 @@ class Module {
       \param len Waiting duration, in microseconds;
     */
     void waitForMicroseconds(uint32_t start, uint32_t len);
-
-    // Arduino core overrides
-
-    /*!
-      \brief Arduino core pinMode override that checks RADIOLIB_NC as alias for unused pin.
-
-      \param pin Pin to change the mode of.
-
-      \param mode Which mode to set.
-    */
-    void pinMode(RADIOLIB_PIN_TYPE pin, RADIOLIB_PIN_MODE mode);
-
-    /*!
-      \brief Arduino core digitalWrite override that checks RADIOLIB_NC as alias for unused pin.
-
-      \param pin Pin to write to.
-
-      \param value Whether to set the pin high or low.
-    */
-    void digitalWrite(RADIOLIB_PIN_TYPE pin, RADIOLIB_PIN_STATUS value);
-
-    /*!
-      \brief Arduino core digitalWrite override that checks RADIOLIB_NC as alias for unused pin.
-
-      \param pin Pin to read from.
-
-      \returns Pin value.
-    */
-    RADIOLIB_PIN_STATUS digitalRead(RADIOLIB_PIN_TYPE pin);
-
-    /*!
-      \brief Arduino core tone override that checks RADIOLIB_NC as alias for unused pin and RADIOLIB_TONE_UNSUPPORTED to make sure the platform does support tone.
-
-      \param pin Pin to write to.
-
-      \param value Frequency to output.
-    */
-    void tone(RADIOLIB_PIN_TYPE pin, uint16_t value, uint32_t duration = 0);
-
-    /*!
-      \brief Arduino core noTone override that checks RADIOLIB_NC as alias for unused pin and RADIOLIB_TONE_UNSUPPORTED to make sure the platform does support tone.
-
-      \param pin Pin to write to.
-    */
-    void noTone(RADIOLIB_PIN_TYPE pin);
-
-    /*!
-      \brief Arduino core attachInterrupt override.
-
-      \param interruptNum Interrupt number.
-
-      \param userFunc Interrupt service routine.
-
-      \param mode Pin hcange direction.
-    */
-    void attachInterrupt(RADIOLIB_PIN_TYPE interruptNum, void (*userFunc)(void), RADIOLIB_INTERRUPT_STATUS mode);
-
-    /*!
-      \brief Arduino core detachInterrupt override.
-
-      \param interruptNum Interrupt number.
-    */
-    void detachInterrupt(RADIOLIB_PIN_TYPE interruptNum);
-
-    /*!
-      \brief Arduino core yield override.
-    */
-    void yield();
-
-    /*!
-      \brief Arduino core delay override.
-
-      \param ms Delay length in milliseconds.
-    */
-    void delay(uint32_t ms);
-
-    /*!
-      \brief Arduino core delayMicroseconds override.
-
-      \param us Delay length in microseconds.
-    */
-    void delayMicroseconds(uint32_t us);
-
-    /*!
-      \brief Arduino core millis override.
-    */
-    uint32_t millis();
-
-    /*!
-      \brief Arduino core micros override.
-    */
-    uint32_t micros();
-
-    /*!
-      \brief Arduino core pulseIn override.
-    */
-    uint32_t pulseIn(RADIOLIB_PIN_TYPE pin, RADIOLIB_PIN_STATUS state, uint32_t timeout);
-
-    /*!
-      \brief Arduino core SPI begin override.
-    */
-    void begin();
-
-    /*!
-      \brief Arduino core SPI beginTransaction override.
-    */
-    void beginTransaction();
-
-    /*!
-      \brief Arduino core SPI transfer override.
-    */
-    uint8_t transfer(uint8_t b);
-
-    /*!
-      \brief Arduino core SPI endTransaction override.
-    */
-    void endTransaction();
-
-    /*!
-      \brief Arduino core SPI end override.
-    */
-    void end();
-
-    // helper functions to set up SPI overrides on Arduino
-    #if defined(RADIOLIB_BUILD_ARDUINO)
-    void SPIbegin();
-    void SPIend();
-    virtual void SPIbeginTransaction();
-    virtual uint8_t SPItransfer(uint8_t b);
-    virtual void SPIendTransaction();
-    #endif
 
     /*!
       \brief Function to reflect bits within a byte.
@@ -711,57 +580,17 @@ class Module {
 #if !defined(RADIOLIB_GODMODE)
   private:
 #endif
-
-    // pins
-    RADIOLIB_PIN_TYPE _cs = RADIOLIB_NC;
-    RADIOLIB_PIN_TYPE _irq = RADIOLIB_NC;
-    RADIOLIB_PIN_TYPE _rst = RADIOLIB_NC;
-    RADIOLIB_PIN_TYPE _gpio = RADIOLIB_NC;
-
-    // SPI interface (Arduino only)
-    #if defined(RADIOLIB_BUILD_ARDUINO)
-    SPIClass* _spi = NULL;
-    SPISettings _spiSettings = RADIOLIB_DEFAULT_SPI_SETTINGS;
-    bool _initInterface = false;
-    #endif
+    uint8_t _cs = RADIOLIB_NC;
+    uint8_t _irq = RADIOLIB_NC;
+    uint8_t _rst = RADIOLIB_NC;
+    uint8_t _gpio = RADIOLIB_NC;
 
     // RF switch pins and table
-    RADIOLIB_PIN_TYPE _rfSwitchPins[RFSWITCH_MAX_PINS] = { RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC };
+    uint8_t _rfSwitchPins[RFSWITCH_MAX_PINS] = { RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC };
     const RfSwitchMode_t *_rfSwitchTable = nullptr;
 
     #if defined(RADIOLIB_INTERRUPT_TIMING)
     uint32_t _prevTimingLen = 0;
-    #endif
-
-    // hardware abstraction layer callbacks
-    // this is placed at the end of Module class because the callback generator macros
-    // screw with the private/public access specifiers
-    RADIOLIB_GENERATE_CALLBACK(RADIOLIB_CB_ARGS_PIN_MODE);
-    RADIOLIB_GENERATE_CALLBACK(RADIOLIB_CB_ARGS_DIGITAL_WRITE);
-    RADIOLIB_GENERATE_CALLBACK(RADIOLIB_CB_ARGS_DIGITAL_READ);
-    RADIOLIB_GENERATE_CALLBACK(RADIOLIB_CB_ARGS_TONE);
-    RADIOLIB_GENERATE_CALLBACK(RADIOLIB_CB_ARGS_NO_TONE);
-    RADIOLIB_GENERATE_CALLBACK(RADIOLIB_CB_ARGS_ATTACH_INTERRUPT);
-    RADIOLIB_GENERATE_CALLBACK(RADIOLIB_CB_ARGS_DETACH_INTERRUPT);
-    RADIOLIB_GENERATE_CALLBACK(RADIOLIB_CB_ARGS_YIELD);
-    RADIOLIB_GENERATE_CALLBACK(RADIOLIB_CB_ARGS_DELAY);
-    RADIOLIB_GENERATE_CALLBACK(RADIOLIB_CB_ARGS_DELAY_MICROSECONDS);
-    RADIOLIB_GENERATE_CALLBACK(RADIOLIB_CB_ARGS_MILLIS);
-    RADIOLIB_GENERATE_CALLBACK(RADIOLIB_CB_ARGS_MICROS);
-    RADIOLIB_GENERATE_CALLBACK(RADIOLIB_CB_ARGS_PULSE_IN);
-
-    #if defined(RADIOLIB_BUILD_ARDUINO)
-    RADIOLIB_GENERATE_CALLBACK_SPI(RADIOLIB_CB_ARGS_SPI_BEGIN);
-    RADIOLIB_GENERATE_CALLBACK_SPI(RADIOLIB_CB_ARGS_SPI_BEGIN_TRANSACTION);
-    RADIOLIB_GENERATE_CALLBACK_SPI(RADIOLIB_CB_ARGS_SPI_TRANSFER);
-    RADIOLIB_GENERATE_CALLBACK_SPI(RADIOLIB_CB_ARGS_SPI_END_TRANSACTION);
-    RADIOLIB_GENERATE_CALLBACK_SPI(RADIOLIB_CB_ARGS_SPI_END);
-    #else
-    RADIOLIB_GENERATE_CALLBACK(RADIOLIB_CB_ARGS_SPI_BEGIN);
-    RADIOLIB_GENERATE_CALLBACK(RADIOLIB_CB_ARGS_SPI_BEGIN_TRANSACTION);
-    RADIOLIB_GENERATE_CALLBACK(RADIOLIB_CB_ARGS_SPI_TRANSFER);
-    RADIOLIB_GENERATE_CALLBACK(RADIOLIB_CB_ARGS_SPI_END_TRANSACTION);
-    RADIOLIB_GENERATE_CALLBACK(RADIOLIB_CB_ARGS_SPI_END);
     #endif
 };
 

--- a/src/RadioLib.h
+++ b/src/RadioLib.h
@@ -38,6 +38,12 @@
 #include "TypeDef.h"
 #include "Module.h"
 
+#include "Hal.h"
+#if defined(RADIOLIB_BUILD_ARDUINO)
+#include "ArduinoHal.h"
+#endif
+
+
 // warnings are printed in this file since BuildOpt.h is compiled in multiple places
 
 // check God mode

--- a/src/modules/CC1101/CC1101.cpp
+++ b/src/modules/CC1101/CC1101.cpp
@@ -220,7 +220,7 @@ int16_t CC1101::packetMode() {
   return(state);
 }
 
-void CC1101::setGdo0Action(void (*func)(void), uint8_t dir) {
+void CC1101::setGdo0Action(void (*func)(void), uint32_t dir) {
   _mod->hal->attachInterrupt(_mod->hal->pinToInterrupt(_mod->getIrq()), func, dir);
 }
 
@@ -228,7 +228,7 @@ void CC1101::clearGdo0Action() {
   _mod->hal->detachInterrupt(_mod->hal->pinToInterrupt(_mod->getIrq()));
 }
 
-void CC1101::setGdo2Action(void (*func)(void), uint8_t dir) {
+void CC1101::setGdo2Action(void (*func)(void), uint32_t dir) {
   if(_mod->getGpio() == RADIOLIB_NC) {
     return;
   }

--- a/src/modules/CC1101/CC1101.cpp
+++ b/src/modules/CC1101/CC1101.cpp
@@ -899,11 +899,11 @@ int16_t CC1101::setEncoding(uint8_t encoding) {
   }
 }
 
-void CC1101::setRfSwitchPins(uint8_t rxEn, uint8_t txEn) {
+void CC1101::setRfSwitchPins(uint32_t rxEn, uint32_t txEn) {
   _mod->setRfSwitchPins(rxEn, txEn);
 }
 
-void CC1101::setRfSwitchTable(const uint8_t (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]) {
+void CC1101::setRfSwitchTable(const uint32_t (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]) {
   _mod->setRfSwitchTable(pins, table);
 }
 
@@ -936,12 +936,12 @@ void CC1101::setDirectAction(void (*func)(void)) {
   setGdo0Action(func, _mod->hal->GpioInterruptRising);
 }
 
-void CC1101::readBit(uint8_t pin) {
+void CC1101::readBit(uint32_t pin) {
   updateDirectBuffer((uint8_t)_mod->hal->digitalRead(pin));
 }
 #endif
 
-int16_t CC1101::setDIOMapping(uint8_t pin, uint8_t value) {
+int16_t CC1101::setDIOMapping(uint32_t pin, uint32_t value) {
   if (pin > 2)
     return RADIOLIB_ERR_INVALID_DIO_PIN;
 

--- a/src/modules/CC1101/CC1101.h
+++ b/src/modules/CC1101/CC1101.h
@@ -646,7 +646,7 @@ class CC1101: public PhysicalLayer {
 
       \param dir Signal change direction.
     */
-    void setGdo0Action(void (*func)(void), uint8_t dir);
+    void setGdo0Action(void (*func)(void), uint32_t dir);
 
     /*!
       \brief Clears interrupt service routine to call when GDO0 activates.
@@ -660,7 +660,7 @@ class CC1101: public PhysicalLayer {
 
       \param dir Signal change direction.
     */
-    void setGdo2Action(void (*func)(void), uint8_t dir);
+    void setGdo2Action(void (*func)(void), uint32_t dir);
 
     /*!
       \brief Clears interrupt service routine to call when GDO0 activates.

--- a/src/modules/CC1101/CC1101.h
+++ b/src/modules/CC1101/CC1101.h
@@ -644,9 +644,9 @@ class CC1101: public PhysicalLayer {
 
       \param func ISR to call.
 
-      \param dir Signal change direction. Defaults to RISING.
+      \param dir Signal change direction.
     */
-    void setGdo0Action(void (*func)(void), RADIOLIB_INTERRUPT_STATUS dir = RISING);
+    void setGdo0Action(void (*func)(void), uint8_t dir);
 
     /*!
       \brief Clears interrupt service routine to call when GDO0 activates.
@@ -658,9 +658,9 @@ class CC1101: public PhysicalLayer {
 
       \param func ISR to call.
 
-      \param dir Signal change direction. Defaults to FALLING.
+      \param dir Signal change direction.
     */
-    void setGdo2Action(void (*func)(void), RADIOLIB_INTERRUPT_STATUS dir = FALLING);
+    void setGdo2Action(void (*func)(void), uint8_t dir);
 
     /*!
       \brief Clears interrupt service routine to call when GDO0 activates.
@@ -953,10 +953,10 @@ class CC1101: public PhysicalLayer {
     int16_t setEncoding(uint8_t encoding) override;
 
     /*! \copydoc Module::setRfSwitchPins */
-    void setRfSwitchPins(RADIOLIB_PIN_TYPE rxEn, RADIOLIB_PIN_TYPE txEn);
+    void setRfSwitchPins(uint8_t rxEn, uint8_t txEn);
 
     /*! \copydoc Module::setRfSwitchTable */
-    void setRfSwitchTable(const RADIOLIB_PIN_TYPE (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]);
+    void setRfSwitchTable(const uint8_t (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]);
 
     /*!
      \brief Get one truly random byte from RSSI noise.
@@ -985,7 +985,7 @@ class CC1101: public PhysicalLayer {
 
       \param pin Pin on which to read.
     */
-    void readBit(RADIOLIB_PIN_TYPE pin);
+    void readBit(uint8_t pin);
     #endif
 
     /*!
@@ -997,7 +997,7 @@ class CC1101: public PhysicalLayer {
 
       \returns \ref status_codes
     */
-    int16_t setDIOMapping(RADIOLIB_PIN_TYPE pin, uint8_t value);
+    int16_t setDIOMapping(uint8_t pin, uint8_t value);
 
   #if !defined(RADIOLIB_GODMODE) && !defined(RADIOLIB_LOW_LEVEL)
     protected:

--- a/src/modules/CC1101/CC1101.h
+++ b/src/modules/CC1101/CC1101.h
@@ -953,10 +953,10 @@ class CC1101: public PhysicalLayer {
     int16_t setEncoding(uint8_t encoding) override;
 
     /*! \copydoc Module::setRfSwitchPins */
-    void setRfSwitchPins(uint8_t rxEn, uint8_t txEn);
+    void setRfSwitchPins(uint32_t rxEn, uint32_t txEn);
 
     /*! \copydoc Module::setRfSwitchTable */
-    void setRfSwitchTable(const uint8_t (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]);
+    void setRfSwitchTable(const uint32_t (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]);
 
     /*!
      \brief Get one truly random byte from RSSI noise.
@@ -985,7 +985,7 @@ class CC1101: public PhysicalLayer {
 
       \param pin Pin on which to read.
     */
-    void readBit(uint8_t pin);
+    void readBit(uint32_t pin);
     #endif
 
     /*!
@@ -997,7 +997,7 @@ class CC1101: public PhysicalLayer {
 
       \returns \ref status_codes
     */
-    int16_t setDIOMapping(uint8_t pin, uint8_t value);
+    int16_t setDIOMapping(uint32_t pin, uint32_t value);
 
   #if !defined(RADIOLIB_GODMODE) && !defined(RADIOLIB_LOW_LEVEL)
     protected:

--- a/src/modules/RF69/RF69.cpp
+++ b/src/modules/RF69/RF69.cpp
@@ -917,11 +917,11 @@ int16_t RF69::setRSSIThreshold(float dbm) {
   return _mod->SPIsetRegValue(RADIOLIB_RF69_REG_RSSI_THRESH, (uint8_t)(-2.0 * dbm), 7, 0);
 }
 
-void RF69::setRfSwitchPins(uint8_t rxEn, uint8_t txEn) {
+void RF69::setRfSwitchPins(uint32_t rxEn, uint32_t txEn) {
   _mod->setRfSwitchPins(rxEn, txEn);
 }
 
-void RF69::setRfSwitchTable(const uint8_t (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]) {
+void RF69::setRfSwitchTable(const uint32_t (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]) {
   _mod->setRfSwitchTable(pins, table);
 }
 
@@ -949,12 +949,12 @@ void RF69::setDirectAction(void (*func)(void)) {
   setDio1Action(func);
 }
 
-void RF69::readBit(uint8_t pin) {
+void RF69::readBit(uint32_t pin) {
   updateDirectBuffer((uint8_t)_mod->hal->digitalRead(pin));
 }
 #endif
 
-int16_t RF69::setDIOMapping(uint8_t pin, uint8_t value) {
+int16_t RF69::setDIOMapping(uint32_t pin, uint32_t value) {
   if(pin > 5) {
     return(RADIOLIB_ERR_INVALID_DIO_PIN);
   }

--- a/src/modules/RF69/RF69.cpp
+++ b/src/modules/RF69/RF69.cpp
@@ -1,4 +1,5 @@
 #include "RF69.h"
+#include <math.h>
 #if !defined(RADIOLIB_EXCLUDE_RF69)
 
 RF69::RF69(Module* module) : PhysicalLayer(RADIOLIB_RF69_FREQUENCY_STEP_SIZE, RADIOLIB_RF69_MAX_PACKET_LENGTH)  {
@@ -12,7 +13,7 @@ Module* RF69::getMod() {
 int16_t RF69::begin(float freq, float br, float freqDev, float rxBw, int8_t power, uint8_t preambleLen) {
   // set module properties
   _mod->init();
-  _mod->pinMode(_mod->getIrq(), INPUT);
+  _mod->hal->pinMode(_mod->getIrq(), _mod->hal->GpioModeInput);
 
   // try to find the RF69 chip
   uint8_t i = 0;
@@ -27,7 +28,7 @@ int16_t RF69::begin(float freq, float br, float freqDev, float rxBw, int8_t powe
       flagFound = true;
     } else {
       RADIOLIB_DEBUG_PRINTLN("RF69 not found! (%d of 10 tries) RADIOLIB_RF69_REG_VERSION == 0x%04X, expected 0x0024", i + 1, version);
-      _mod->delay(10);
+      _mod->hal->delay(10);
       i++;
     }
   }
@@ -94,11 +95,11 @@ int16_t RF69::begin(float freq, float br, float freqDev, float rxBw, int8_t powe
 }
 
 void RF69::reset() {
-  _mod->pinMode(_mod->getRst(), OUTPUT);
-  _mod->digitalWrite(_mod->getRst(), HIGH);
-  _mod->delay(1);
-  _mod->digitalWrite(_mod->getRst(), LOW);
-  _mod->delay(10);
+  _mod->hal->pinMode(_mod->getRst(), _mod->hal->GpioModeOutput);
+  _mod->hal->digitalWrite(_mod->getRst(), _mod->hal->GpioLevelHigh);
+  _mod->hal->delay(1);
+  _mod->hal->digitalWrite(_mod->getRst(), _mod->hal->GpioLevelLow);
+  _mod->hal->delay(10);
 }
 
 int16_t RF69::transmit(uint8_t* data, size_t len, uint8_t addr) {
@@ -110,11 +111,11 @@ int16_t RF69::transmit(uint8_t* data, size_t len, uint8_t addr) {
   RADIOLIB_ASSERT(state);
 
   // wait for transmission end or timeout
-  uint32_t start = _mod->micros();
-  while(!_mod->digitalRead(_mod->getIrq())) {
-    _mod->yield();
+  uint32_t start = _mod->hal->micros();
+  while(!_mod->hal->digitalRead(_mod->getIrq())) {
+    _mod->hal->yield();
 
-    if(_mod->micros() - start > timeout) {
+    if(_mod->hal->micros() - start > timeout) {
       finishTransmit();
       return(RADIOLIB_ERR_TX_TIMEOUT);
     }
@@ -132,11 +133,11 @@ int16_t RF69::receive(uint8_t* data, size_t len) {
   RADIOLIB_ASSERT(state);
 
   // wait for packet reception or timeout
-  uint32_t start = _mod->micros();
-  while(!_mod->digitalRead(_mod->getIrq())) {
-    _mod->yield();
+  uint32_t start = _mod->hal->micros();
+  while(!_mod->hal->digitalRead(_mod->getIrq())) {
+    _mod->hal->yield();
 
-    if(_mod->micros() - start > timeout) {
+    if(_mod->hal->micros() - start > timeout) {
       standby();
       clearIRQFlags();
       return(RADIOLIB_ERR_RX_TIMEOUT);
@@ -271,26 +272,26 @@ int16_t RF69::startReceive(uint32_t timeout, uint16_t irqFlags, uint16_t irqMask
 }
 
 void RF69::setDio0Action(void (*func)(void)) {
-  _mod->attachInterrupt(RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(_mod->getIrq()), func, RISING);
+  _mod->hal->attachInterrupt(_mod->hal->pinToInterrupt(_mod->getIrq()), func, _mod->hal->GpioInterruptRising);
 }
 
 void RF69::clearDio0Action() {
-  _mod->detachInterrupt(RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(_mod->getIrq()));
+  _mod->hal->detachInterrupt(_mod->hal->pinToInterrupt(_mod->getIrq()));
 }
 
 void RF69::setDio1Action(void (*func)(void)) {
   if(_mod->getGpio() == RADIOLIB_NC) {
     return;
   }
-  _mod->pinMode(_mod->getGpio(), INPUT);
-  _mod->attachInterrupt(RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(_mod->getGpio()), func, RISING);
+  _mod->hal->pinMode(_mod->getGpio(), _mod->hal->GpioModeInput);
+  _mod->hal->attachInterrupt(_mod->hal->pinToInterrupt(_mod->getGpio()), func, _mod->hal->GpioInterruptRising);
 }
 
 void RF69::clearDio1Action() {
   if(_mod->getGpio() == RADIOLIB_NC) {
     return;
   }
-  _mod->detachInterrupt(RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(_mod->getGpio()));
+  _mod->hal->detachInterrupt(_mod->hal->pinToInterrupt(_mod->getGpio()));
 }
 
 void RF69::setFifoEmptyAction(void (*func)(void)) {
@@ -298,10 +299,10 @@ void RF69::setFifoEmptyAction(void (*func)(void)) {
   if(_mod->getGpio() == RADIOLIB_NC) {
     return;
   }
-  _mod->pinMode(_mod->getGpio(), INPUT);
+  _mod->hal->pinMode(_mod->getGpio(), _mod->hal->GpioModeInput);
 
   // we need to invert the logic here (as compared to setDio1Action), since we are using the "FIFO not empty interrupt"
-  _mod->attachInterrupt(RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(_mod->getGpio()), func, FALLING);
+  _mod->hal->attachInterrupt(_mod->hal->pinToInterrupt(_mod->getGpio()), func, _mod->hal->GpioInterruptFalling);
 }
 
 void RF69::clearFifoEmptyAction() {
@@ -758,7 +759,7 @@ int16_t RF69::getTemperature() {
   // wait until measurement is finished
   while(_mod->SPIgetRegValue(RADIOLIB_RF69_REG_TEMP_1, 2, 2) == RADIOLIB_RF69_TEMP_MEAS_RUNNING) {
     // check every 10 us
-    _mod->delay(10);
+    _mod->hal->delay(10);
   }
   int8_t rawTemp = _mod->SPIgetRegValue(RADIOLIB_RF69_REG_TEMP_2);
 
@@ -916,11 +917,11 @@ int16_t RF69::setRSSIThreshold(float dbm) {
   return _mod->SPIsetRegValue(RADIOLIB_RF69_REG_RSSI_THRESH, (uint8_t)(-2.0 * dbm), 7, 0);
 }
 
-void RF69::setRfSwitchPins(RADIOLIB_PIN_TYPE rxEn, RADIOLIB_PIN_TYPE txEn) {
+void RF69::setRfSwitchPins(uint8_t rxEn, uint8_t txEn) {
   _mod->setRfSwitchPins(rxEn, txEn);
 }
 
-void RF69::setRfSwitchTable(const RADIOLIB_PIN_TYPE (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]) {
+void RF69::setRfSwitchTable(const uint8_t (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]) {
   _mod->setRfSwitchTable(pins, table);
 }
 
@@ -929,7 +930,7 @@ uint8_t RF69::randomByte() {
   setMode(RADIOLIB_RF69_RX);
 
   // wait a bit for the RSSI reading to stabilise
-  _mod->delay(10);
+  _mod->hal->delay(10);
 
   // read RSSI value 8 times, always keep just the least significant bit
   uint8_t randByte = 0x00;
@@ -948,12 +949,12 @@ void RF69::setDirectAction(void (*func)(void)) {
   setDio1Action(func);
 }
 
-void RF69::readBit(RADIOLIB_PIN_TYPE pin) {
-  updateDirectBuffer((uint8_t)_mod->digitalRead(pin));
+void RF69::readBit(uint8_t pin) {
+  updateDirectBuffer((uint8_t)_mod->hal->digitalRead(pin));
 }
 #endif
 
-int16_t RF69::setDIOMapping(RADIOLIB_PIN_TYPE pin, uint8_t value) {
+int16_t RF69::setDIOMapping(uint8_t pin, uint8_t value) {
   if(pin > 5) {
     return(RADIOLIB_ERR_INVALID_DIO_PIN);
   }

--- a/src/modules/RF69/RF69.h
+++ b/src/modules/RF69/RF69.h
@@ -1035,10 +1035,10 @@ class RF69: public PhysicalLayer {
     int16_t setRSSIThreshold(float dbm);
 
     /*! \copydoc Module::setRfSwitchPins */
-    void setRfSwitchPins(uint8_t rxEn, uint8_t txEn);
+    void setRfSwitchPins(uint32_t rxEn, uint32_t txEn);
 
     /*! \copydoc Module::setRfSwitchTable */
-    void setRfSwitchTable(const uint8_t (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]);
+    void setRfSwitchTable(const uint32_t (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]);
 
     /*!
      \brief Get one truly random byte from RSSI noise.
@@ -1067,7 +1067,7 @@ class RF69: public PhysicalLayer {
 
       \param pin Pin on which to read.
     */
-    void readBit(uint8_t pin);
+    void readBit(uint32_t pin);
     #endif
 
     /*!
@@ -1079,7 +1079,7 @@ class RF69: public PhysicalLayer {
 
       \returns \ref status_codes
     */
-    int16_t setDIOMapping(uint8_t pin, uint8_t value);
+    int16_t setDIOMapping(uint32_t pin, uint32_t value);
 
 #if !defined(RADIOLIB_GODMODE) && !defined(RADIOLIB_LOW_LEVEL)
   protected:

--- a/src/modules/RF69/RF69.h
+++ b/src/modules/RF69/RF69.h
@@ -1035,10 +1035,10 @@ class RF69: public PhysicalLayer {
     int16_t setRSSIThreshold(float dbm);
 
     /*! \copydoc Module::setRfSwitchPins */
-    void setRfSwitchPins(RADIOLIB_PIN_TYPE rxEn, RADIOLIB_PIN_TYPE txEn);
+    void setRfSwitchPins(uint8_t rxEn, uint8_t txEn);
 
     /*! \copydoc Module::setRfSwitchTable */
-    void setRfSwitchTable(const RADIOLIB_PIN_TYPE (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]);
+    void setRfSwitchTable(const uint8_t (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]);
 
     /*!
      \brief Get one truly random byte from RSSI noise.
@@ -1067,7 +1067,7 @@ class RF69: public PhysicalLayer {
 
       \param pin Pin on which to read.
     */
-    void readBit(RADIOLIB_PIN_TYPE pin);
+    void readBit(uint8_t pin);
     #endif
 
     /*!
@@ -1079,7 +1079,7 @@ class RF69: public PhysicalLayer {
 
       \returns \ref status_codes
     */
-    int16_t setDIOMapping(RADIOLIB_PIN_TYPE pin, uint8_t value);
+    int16_t setDIOMapping(uint8_t pin, uint8_t value);
 
 #if !defined(RADIOLIB_GODMODE) && !defined(RADIOLIB_LOW_LEVEL)
   protected:

--- a/src/modules/SX1231/SX1231.cpp
+++ b/src/modules/SX1231/SX1231.cpp
@@ -8,8 +8,8 @@ SX1231::SX1231(Module* mod) : RF69(mod) {
 int16_t SX1231::begin(float freq, float br, float freqDev, float rxBw, int8_t power, uint8_t preambleLen) {
   // set module properties
   _mod->init();
-  _mod->pinMode(_mod->getIrq(), INPUT);
-  _mod->pinMode(_mod->getRst(), OUTPUT);
+  _mod->hal->pinMode(_mod->getIrq(), _mod->hal->GpioModeInput);
+  _mod->hal->pinMode(_mod->getRst(), _mod->hal->GpioModeOutput);
 
   // try to find the SX1231 chip
   uint8_t i = 0;
@@ -21,7 +21,7 @@ int16_t SX1231::begin(float freq, float br, float freqDev, float rxBw, int8_t po
       _chipRevision = version;
     } else {
       RADIOLIB_DEBUG_PRINTLN("SX1231 not found! (%d of 10 tries) RF69_REG_VERSION == 0x%04X, expected 0x0021 / 0x0022 / 0x0023", i + 1, version);
-      _mod->delay(10);
+      _mod->hal->delay(10);
       i++;
     }
   }

--- a/src/modules/SX126x/STM32WLx_Module.cpp
+++ b/src/modules/SX126x/STM32WLx_Module.cpp
@@ -9,6 +9,8 @@ This file is licensed under the MIT License: https://opensource.org/licenses/MIT
 
 #if !defined(RADIOLIB_EXCLUDE_STM32WLX)
 
+#include "../../ArduinoHal.h"
+
 // This defines some dummy pin numbers (starting at NUM_DIGITAL_PINS to
 // guarantee these are not valid regular pin numbers) that can be passed
 // to the parent Module class, to be stored here and then passed back to
@@ -20,87 +22,85 @@ enum {
   RADIOLIB_STM32WLx_VIRTUAL_PIN_RESET,
 };
 
+class Stm32wlxHal : public ArduinoHal {
+  public:
+    Stm32wlxHal(): ArduinoHal(SubGhz.SPI, SubGhz.spi_settings) {}
+
+    void pinMode(uint8_t dwPin, uint8_t dwMode) {
+      switch(dwPin) {
+        case RADIOLIB_STM32WLx_VIRTUAL_PIN_NSS:
+        case RADIOLIB_STM32WLx_VIRTUAL_PIN_BUSY:
+        case RADIOLIB_STM32WLx_VIRTUAL_PIN_IRQ:
+        case RADIOLIB_STM32WLx_VIRTUAL_PIN_RESET:
+          // Nothing to do
+          break;
+        default:
+          ::pinMode(dwPin, dwMode);
+          break;
+      }
+    }
+
+    void digitalWrite(uint8_t dwPin, uint8_t dwVal) {
+      switch (dwPin) {
+        case RADIOLIB_STM32WLx_VIRTUAL_PIN_NSS:
+          SubGhz.setNssActive(dwVal == LOW);
+          break;
+
+        case RADIOLIB_STM32WLx_VIRTUAL_PIN_RESET:
+          SubGhz.setResetActive(dwVal == LOW);
+          break;
+
+        case RADIOLIB_STM32WLx_VIRTUAL_PIN_BUSY:
+        case RADIOLIB_STM32WLx_VIRTUAL_PIN_IRQ:
+          // Should not (and cannot) be written, just ignore
+          break;
+
+        default:
+          ::digitalWrite(dwPin, dwVal);
+          break;
+      }
+    }
+
+    uint8_t digitalRead(uint8_t ulPin) {
+      switch (ulPin) {
+        case RADIOLIB_STM32WLx_VIRTUAL_PIN_BUSY:
+          return(SubGhz.isBusy() ? HIGH : LOW);
+
+        case RADIOLIB_STM32WLx_VIRTUAL_PIN_IRQ:
+          // We cannot use the radio IRQ output directly, but since:
+          //  - the pending flag will be set whenever the IRQ output is set,
+          //    and
+          //  - the pending flag will be cleared (by
+          //    STM32WLx::clearIrqStatus()) whenever the radio IRQ output is
+          //    cleared,
+          // the pending flag should always reflect the current radio IRQ
+          // output. There is one exception: when the ISR starts the pending
+          // flag is cleared by hardware and not set again until after the
+          // ISR finishes, so the value is incorrect *inside* the ISR, but
+          // running RadioLib code inside the ISR (especially code that
+          // polls the IRQ flag) is not supported and probably broken in
+          // other ways too.
+          return(SubGhz.isInterruptPending() ? HIGH : LOW);
+
+        case RADIOLIB_STM32WLx_VIRTUAL_PIN_NSS:
+          return(SubGhz.isNssActive() ? LOW : HIGH);
+
+        case RADIOLIB_STM32WLx_VIRTUAL_PIN_RESET:
+          return(SubGhz.isResetActive() ? LOW : HIGH);
+
+        default:
+          return(::digitalRead(ulPin));
+      }
+    }
+};
 
 STM32WLx_Module::STM32WLx_Module():
   Module(
+    new Stm32wlxHal,
     RADIOLIB_STM32WLx_VIRTUAL_PIN_NSS,
     RADIOLIB_STM32WLx_VIRTUAL_PIN_IRQ,
     RADIOLIB_STM32WLx_VIRTUAL_PIN_RESET,
-    RADIOLIB_STM32WLx_VIRTUAL_PIN_BUSY,
-    SubGhz.SPI,
-    SubGhz.spi_settings
-  )
-{
-  setCb_pinMode(virtualPinMode);
-  setCb_digitalWrite(virtualDigitalWrite);
-  setCb_digitalRead(virtualDigitalRead);
-}
-
-void STM32WLx_Module::virtualPinMode(uint32_t dwPin, uint32_t dwMode) {
-  switch(dwPin) {
-    case RADIOLIB_STM32WLx_VIRTUAL_PIN_NSS:
-    case RADIOLIB_STM32WLx_VIRTUAL_PIN_BUSY:
-    case RADIOLIB_STM32WLx_VIRTUAL_PIN_IRQ:
-    case RADIOLIB_STM32WLx_VIRTUAL_PIN_RESET:
-      // Nothing to do
-      break;
-    default:
-      ::pinMode(dwPin, dwMode);
-      break;
-  }
-}
-
-void STM32WLx_Module::virtualDigitalWrite(uint32_t dwPin, uint32_t dwVal) {
-  switch (dwPin) {
-    case RADIOLIB_STM32WLx_VIRTUAL_PIN_NSS:
-      SubGhz.setNssActive(dwVal == LOW);
-      break;
-
-    case RADIOLIB_STM32WLx_VIRTUAL_PIN_RESET:
-      SubGhz.setResetActive(dwVal == LOW);
-      break;
-
-    case RADIOLIB_STM32WLx_VIRTUAL_PIN_BUSY:
-    case RADIOLIB_STM32WLx_VIRTUAL_PIN_IRQ:
-      // Should not (and cannot) be written, just ignore
-      break;
-
-    default:
-      ::digitalWrite(dwPin, dwVal);
-      break;
-  }
-}
-
-int STM32WLx_Module::virtualDigitalRead(uint32_t ulPin) {
-  switch (ulPin) {
-    case RADIOLIB_STM32WLx_VIRTUAL_PIN_BUSY:
-      return(SubGhz.isBusy() ? HIGH : LOW);
-
-    case RADIOLIB_STM32WLx_VIRTUAL_PIN_IRQ:
-      // We cannot use the radio IRQ output directly, but since:
-      //  - the pending flag will be set whenever the IRQ output is set,
-      //    and
-      //  - the pending flag will be cleared (by
-      //    STM32WLx::clearIrqStatus()) whenever the radio IRQ output is
-      //    cleared,
-      // the pending flag should always reflect the current radio IRQ
-      // output. There is one exception: when the ISR starts the pending
-      // flag is cleared by hardware and not set again until after the
-      // ISR finishes, so the value is incorrect *inside* the ISR, but
-      // running RadioLib code inside the ISR (especially code that
-      // polls the IRQ flag) is not supported and probably broken in
-      // other ways too.
-      return(SubGhz.isInterruptPending() ? HIGH : LOW);
-
-    case RADIOLIB_STM32WLx_VIRTUAL_PIN_NSS:
-      return(SubGhz.isNssActive() ? LOW : HIGH);
-
-    case RADIOLIB_STM32WLx_VIRTUAL_PIN_RESET:
-      return(SubGhz.isResetActive() ? LOW : HIGH);
-
-    default:
-      return(::digitalRead(ulPin));
-  }
-}
+    RADIOLIB_STM32WLx_VIRTUAL_PIN_BUSY
+  ) {}
 
 #endif // !defined(RADIOLIB_EXCLUDE_STM32WLX)

--- a/src/modules/SX126x/STM32WLx_Module.cpp
+++ b/src/modules/SX126x/STM32WLx_Module.cpp
@@ -26,7 +26,7 @@ class Stm32wlxHal : public ArduinoHal {
   public:
     Stm32wlxHal(): ArduinoHal(SubGhz.SPI, SubGhz.spi_settings) {}
 
-    void pinMode(uint8_t dwPin, uint8_t dwMode) {
+    void pinMode(uint32_t dwPin, uint32_t dwMode) {
       switch(dwPin) {
         case RADIOLIB_STM32WLx_VIRTUAL_PIN_NSS:
         case RADIOLIB_STM32WLx_VIRTUAL_PIN_BUSY:
@@ -40,7 +40,7 @@ class Stm32wlxHal : public ArduinoHal {
       }
     }
 
-    void digitalWrite(uint8_t dwPin, uint8_t dwVal) {
+    void digitalWrite(uint32_t dwPin, uint32_t dwVal) {
       switch (dwPin) {
         case RADIOLIB_STM32WLx_VIRTUAL_PIN_NSS:
           SubGhz.setNssActive(dwVal == LOW);
@@ -61,7 +61,7 @@ class Stm32wlxHal : public ArduinoHal {
       }
     }
 
-    uint8_t digitalRead(uint8_t ulPin) {
+    uint32_t digitalRead(uint32_t ulPin) {
       switch (ulPin) {
         case RADIOLIB_STM32WLx_VIRTUAL_PIN_BUSY:
           return(SubGhz.isBusy() ? HIGH : LOW);

--- a/src/modules/SX126x/STM32WLx_Module.h
+++ b/src/modules/SX126x/STM32WLx_Module.h
@@ -31,17 +31,6 @@ class STM32WLx_Module : public Module {
 
   public:
     STM32WLx_Module();
-
-#if !defined(RADIOLIB_GODMODE)
-  private:
-#endif
-
-    // Replacement callbacks to handle virtual pins. These are static,
-    // since they replace global functions that cannot take any this
-    // pointer for context.
-    static void virtualPinMode(uint32_t dwPin, uint32_t dwMode);
-    static void virtualDigitalWrite(uint32_t dwPin, uint32_t dwVal);
-    static int virtualDigitalRead(uint32_t ulPin);
 };
 
 #endif // !defined(RADIOLIB_EXCLUDE_STM32WLX)

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -1359,11 +1359,11 @@ int16_t SX126x::setEncoding(uint8_t encoding) {
   return(setWhitening(encoding));
 }
 
-void SX126x::setRfSwitchPins(uint8_t rxEn, uint8_t txEn) {
+void SX126x::setRfSwitchPins(uint32_t rxEn, uint32_t txEn) {
   _mod->setRfSwitchPins(rxEn, txEn);
 }
 
-void SX126x::setRfSwitchTable(const uint8_t (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]) {
+void SX126x::setRfSwitchTable(const uint32_t (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]) {
   _mod->setRfSwitchTable(pins, table);
 }
 
@@ -1435,7 +1435,7 @@ void SX126x::setDirectAction(void (*func)(void)) {
   setDio1Action(func);
 }
 
-void SX126x::readBit(uint8_t pin) {
+void SX126x::readBit(uint32_t pin) {
   updateDirectBuffer((uint8_t)_mod->hal->digitalRead(pin));
 }
 #endif

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -1,4 +1,6 @@
 #include "SX126x.h"
+#include <string.h>
+#include <math.h>
 #if !defined(RADIOLIB_EXCLUDE_SX126X)
 
 SX126x::SX126x(Module* mod) : PhysicalLayer(RADIOLIB_SX126X_FREQUENCY_STEP_SIZE, RADIOLIB_SX126X_MAX_PACKET_LENGTH) {
@@ -13,8 +15,8 @@ Module* SX126x::getMod() {
 int16_t SX126x::begin(uint8_t cr, uint8_t syncWord, uint16_t preambleLength, float tcxoVoltage, bool useRegulatorLDO) {
   // set module properties
   _mod->init();
-  _mod->pinMode(_mod->getIrq(), INPUT);
-  _mod->pinMode(_mod->getGpio(), INPUT);
+  _mod->hal->pinMode(_mod->getIrq(), _mod->hal->GpioModeInput);
+  _mod->hal->pinMode(_mod->getGpio(), _mod->hal->GpioModeInput);
   _mod->SPIreadCommand = RADIOLIB_SX126X_CMD_READ_REGISTER;
   _mod->SPIwriteCommand = RADIOLIB_SX126X_CMD_WRITE_REGISTER;
   _mod->SPInopCommand = RADIOLIB_SX126X_CMD_NOP;
@@ -95,8 +97,8 @@ int16_t SX126x::begin(uint8_t cr, uint8_t syncWord, uint16_t preambleLength, flo
 int16_t SX126x::beginFSK(float br, float freqDev, float rxBw, uint16_t preambleLength, float tcxoVoltage, bool useRegulatorLDO) {
   // set module properties
   _mod->init();
-  _mod->pinMode(_mod->getIrq(), INPUT);
-  _mod->pinMode(_mod->getGpio(), INPUT);
+  _mod->hal->pinMode(_mod->getIrq(), _mod->hal->GpioModeInput);
+  _mod->hal->pinMode(_mod->getGpio(), _mod->hal->GpioModeInput);
   _mod->SPIreadCommand = RADIOLIB_SX126X_CMD_READ_REGISTER;
   _mod->SPIwriteCommand = RADIOLIB_SX126X_CMD_WRITE_REGISTER;
   _mod->SPInopCommand = RADIOLIB_SX126X_CMD_NOP;
@@ -188,10 +190,10 @@ int16_t SX126x::beginFSK(float br, float freqDev, float rxBw, uint16_t preambleL
 
 int16_t SX126x::reset(bool verify) {
   // run the reset sequence
-  _mod->pinMode(_mod->getRst(), OUTPUT);
-  _mod->digitalWrite(_mod->getRst(), LOW);
-  _mod->delay(1);
-  _mod->digitalWrite(_mod->getRst(), HIGH);
+  _mod->hal->pinMode(_mod->getRst(), _mod->hal->GpioModeOutput);
+  _mod->hal->digitalWrite(_mod->getRst(), _mod->hal->GpioLevelLow);
+  _mod->hal->delay(1);
+  _mod->hal->digitalWrite(_mod->getRst(), _mod->hal->GpioLevelHigh);
 
   // return immediately when verification is disabled
   if(!verify) {
@@ -199,7 +201,7 @@ int16_t SX126x::reset(bool verify) {
   }
 
   // set mode to standby - SX126x often refuses first few commands after reset
-  uint32_t start = _mod->millis();
+  uint32_t start = _mod->hal->millis();
   while(true) {
     // try to set mode to standby
     int16_t state = standby();
@@ -209,13 +211,13 @@ int16_t SX126x::reset(bool verify) {
     }
 
     // standby command failed, check timeout and try again
-    if(_mod->millis() - start >= 1000) {
+    if(_mod->hal->millis() - start >= 1000) {
       // timed out, possibly incorrect wiring
       return(state);
     }
 
     // wait a bit to not spam the module
-    _mod->delay(100);
+    _mod->hal->delay(100);
   }
 }
 
@@ -252,15 +254,15 @@ int16_t SX126x::transmit(uint8_t* data, size_t len, uint8_t addr) {
   RADIOLIB_ASSERT(state);
 
   // wait for packet transmission or timeout
-  uint32_t start = _mod->micros();
-  while(!_mod->digitalRead(_mod->getIrq())) {
-    _mod->yield();
-    if(_mod->micros() - start > timeout) {
+  uint32_t start = _mod->hal->micros();
+  while(!_mod->hal->digitalRead(_mod->getIrq())) {
+    _mod->hal->yield();
+    if(_mod->hal->micros() - start > timeout) {
       finishTransmit();
       return(RADIOLIB_ERR_TX_TIMEOUT);
     }
   }
-  uint32_t elapsed = _mod->micros() - start;
+  uint32_t elapsed = _mod->hal->micros() - start;
 
   // update data rate
   _dataRate = (len*8.0)/((float)elapsed/1000000.0);
@@ -302,10 +304,10 @@ int16_t SX126x::receive(uint8_t* data, size_t len) {
   RADIOLIB_ASSERT(state);
 
   // wait for packet reception or timeout
-  uint32_t start = _mod->micros();
-  while(!_mod->digitalRead(_mod->getIrq())) {
-    _mod->yield();
-    if(_mod->micros() - start > timeout) {
+  uint32_t start = _mod->hal->micros();
+  while(!_mod->hal->digitalRead(_mod->getIrq())) {
+    _mod->hal->yield();
+    if(_mod->hal->micros() - start > timeout) {
       fixImplicitTimeout();
       clearIrqStatus();
       standby();
@@ -419,8 +421,8 @@ int16_t SX126x::scanChannel(uint8_t symbolNum, uint8_t detPeak, uint8_t detMin) 
   RADIOLIB_ASSERT(state);
 
   // wait for channel activity detected or timeout
-  while(!_mod->digitalRead(_mod->getIrq())) {
-    _mod->yield();
+  while(!_mod->hal->digitalRead(_mod->getIrq())) {
+    _mod->hal->yield();
   }
 
   // check CAD result
@@ -438,7 +440,7 @@ int16_t SX126x::sleep(bool retainConfig) {
   int16_t state = _mod->SPIwriteStream(RADIOLIB_SX126X_CMD_SET_SLEEP, &sleepMode, 1, false, false);
 
   // wait for SX126x to safely enter sleep mode
-  _mod->delay(1);
+  _mod->hal->delay(1);
 
   return(state);
 }
@@ -456,11 +458,11 @@ int16_t SX126x::standby(uint8_t mode) {
 }
 
 void SX126x::setDio1Action(void (*func)(void)) {
-  _mod->attachInterrupt(RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(_mod->getIrq()), func, RISING);
+  _mod->hal->attachInterrupt(_mod->hal->pinToInterrupt(_mod->getIrq()), func, _mod->hal->GpioInterruptRising);
 }
 
 void SX126x::clearDio1Action() {
-  _mod->detachInterrupt(RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(_mod->getIrq()));
+  _mod->hal->detachInterrupt(_mod->hal->pinToInterrupt(_mod->getIrq()));
 }
 
 int16_t SX126x::startTransmit(uint8_t* data, size_t len, uint8_t addr) {
@@ -517,8 +519,8 @@ int16_t SX126x::startTransmit(uint8_t* data, size_t len, uint8_t addr) {
   RADIOLIB_ASSERT(state);
 
   // wait for BUSY to go low (= PA ramp up done)
-  while(_mod->digitalRead(_mod->getGpio())) {
-    _mod->yield();
+  while(_mod->hal->digitalRead(_mod->getGpio())) {
+    _mod->hal->yield();
   }
 
   return(state);
@@ -1357,11 +1359,11 @@ int16_t SX126x::setEncoding(uint8_t encoding) {
   return(setWhitening(encoding));
 }
 
-void SX126x::setRfSwitchPins(RADIOLIB_PIN_TYPE rxEn, RADIOLIB_PIN_TYPE txEn) {
+void SX126x::setRfSwitchPins(uint8_t rxEn, uint8_t txEn) {
   _mod->setRfSwitchPins(rxEn, txEn);
 }
 
-void SX126x::setRfSwitchTable(const RADIOLIB_PIN_TYPE (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]) {
+void SX126x::setRfSwitchTable(const uint8_t (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]) {
   _mod->setRfSwitchTable(pins, table);
 }
 
@@ -1395,7 +1397,7 @@ uint8_t SX126x::randomByte() {
   setRx(RADIOLIB_SX126X_RX_TIMEOUT_INF);
 
   // wait a bit for the RSSI reading to stabilise
-  _mod->delay(10);
+  _mod->hal->delay(10);
 
   // read RSSI value 8 times, always keep just the least significant bit
   uint8_t randByte = 0x00;
@@ -1433,8 +1435,8 @@ void SX126x::setDirectAction(void (*func)(void)) {
   setDio1Action(func);
 }
 
-void SX126x::readBit(RADIOLIB_PIN_TYPE pin) {
-  updateDirectBuffer((uint8_t)_mod->digitalRead(pin));
+void SX126x::readBit(uint8_t pin) {
+  updateDirectBuffer((uint8_t)_mod->hal->digitalRead(pin));
 }
 #endif
 
@@ -1953,9 +1955,9 @@ int16_t SX126x::config(uint8_t modem) {
   RADIOLIB_ASSERT(state);
 
   // wait for calibration completion
-  _mod->delay(5);
-  while(_mod->digitalRead(_mod->getGpio())) {
-    _mod->yield();
+  _mod->hal->delay(5);
+  while(_mod->hal->digitalRead(_mod->getGpio())) {
+    _mod->hal->yield();
   }
 
   // check calibration result
@@ -2010,7 +2012,7 @@ bool SX126x::findChip(const char* verStr) {
         _mod->hexdump((uint8_t*)version, 16, RADIOLIB_SX126X_REG_VERSION_STRING);
         RADIOLIB_DEBUG_PRINTLN("Expected string: %s", verStr);
       #endif
-      _mod->delay(10);
+      _mod->hal->delay(10);
       i++;
     }
   }

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -1031,10 +1031,10 @@ class SX126x: public PhysicalLayer {
     int16_t setEncoding(uint8_t encoding) override;
 
     /*! \copydoc Module::setRfSwitchPins */
-    void setRfSwitchPins(uint8_t rxEn, uint8_t txEn);
+    void setRfSwitchPins(uint32_t rxEn, uint32_t txEn);
 
     /*! \copydoc Module::setRfSwitchTable */
-    void setRfSwitchTable(const uint8_t (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]);
+    void setRfSwitchTable(const uint32_t (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]);
 
     /*!
       \brief Forces LoRa low data rate optimization. Only available in LoRa mode. After calling this method, LDRO will always be set to
@@ -1083,7 +1083,7 @@ class SX126x: public PhysicalLayer {
 
       \param pin Pin on which to read.
     */
-    void readBit(uint8_t pin);
+    void readBit(uint32_t pin);
     #endif
 
     /*!

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -1031,10 +1031,10 @@ class SX126x: public PhysicalLayer {
     int16_t setEncoding(uint8_t encoding) override;
 
     /*! \copydoc Module::setRfSwitchPins */
-    void setRfSwitchPins(RADIOLIB_PIN_TYPE rxEn, RADIOLIB_PIN_TYPE txEn);
+    void setRfSwitchPins(uint8_t rxEn, uint8_t txEn);
 
     /*! \copydoc Module::setRfSwitchTable */
-    void setRfSwitchTable(const RADIOLIB_PIN_TYPE (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]);
+    void setRfSwitchTable(const uint8_t (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]);
 
     /*!
       \brief Forces LoRa low data rate optimization. Only available in LoRa mode. After calling this method, LDRO will always be set to
@@ -1083,7 +1083,7 @@ class SX126x: public PhysicalLayer {
 
       \param pin Pin on which to read.
     */
-    void readBit(RADIOLIB_PIN_TYPE pin);
+    void readBit(uint8_t pin);
     #endif
 
     /*!

--- a/src/modules/SX127x/SX1272.cpp
+++ b/src/modules/SX127x/SX1272.cpp
@@ -1,4 +1,5 @@
 #include "SX1272.h"
+#include <math.h>
 #if !defined(RADIOLIB_EXCLUDE_SX127X)
 
 SX1272::SX1272(Module* mod) : SX127x(mod) {
@@ -71,11 +72,11 @@ int16_t SX1272::beginFSK(float freq, float br, float freqDev, float rxBw, int8_t
 }
 
 void SX1272::reset() {
-  _mod->pinMode(_mod->getRst(), OUTPUT);
-  _mod->digitalWrite(_mod->getRst(), HIGH);
-  _mod->delay(1);
-  _mod->digitalWrite(_mod->getRst(), LOW);
-  _mod->delay(5);
+  _mod->hal->pinMode(_mod->getRst(), _mod->hal->GpioModeOutput);
+  _mod->hal->digitalWrite(_mod->getRst(), _mod->hal->GpioLevelHigh);
+  _mod->hal->delay(1);
+  _mod->hal->digitalWrite(_mod->getRst(), _mod->hal->GpioLevelLow);
+  _mod->hal->delay(5);
 }
 
 int16_t SX1272::setFrequency(float freq) {

--- a/src/modules/SX127x/SX1278.cpp
+++ b/src/modules/SX127x/SX1278.cpp
@@ -1,4 +1,5 @@
 #include "SX1278.h"
+#include <math.h>
 #if !defined(RADIOLIB_EXCLUDE_SX127X)
 
 SX1278::SX1278(Module* mod) : SX127x(mod) {
@@ -71,11 +72,11 @@ int16_t SX1278::beginFSK(float freq, float br, float freqDev, float rxBw, int8_t
 }
 
 void SX1278::reset() {
-  _mod->pinMode(_mod->getRst(), OUTPUT);
-  _mod->digitalWrite(_mod->getRst(), LOW);
-  _mod->delay(1);
-  _mod->digitalWrite(_mod->getRst(), HIGH);
-  _mod->delay(5);
+  _mod->hal->pinMode(_mod->getRst(), _mod->hal->GpioModeOutput);
+  _mod->hal->digitalWrite(_mod->getRst(), _mod->hal->GpioLevelLow);
+  _mod->hal->delay(1);
+  _mod->hal->digitalWrite(_mod->getRst(), _mod->hal->GpioLevelHigh);
+  _mod->hal->delay(5);
 }
 
 int16_t SX1278::setFrequency(float freq) {

--- a/src/modules/SX127x/SX127x.cpp
+++ b/src/modules/SX127x/SX127x.cpp
@@ -426,7 +426,7 @@ int16_t SX127x::startReceive(uint32_t mode, uint16_t irqFlags, uint16_t irqMask,
   return(startReceive((uint8_t)len, (uint8_t)mode));
 }
 
-void SX127x::setDio0Action(void (*func)(void), uint8_t dir) {
+void SX127x::setDio0Action(void (*func)(void), uint32_t dir) {
   _mod->hal->attachInterrupt(_mod->hal->pinToInterrupt(_mod->getIrq()), func, dir);
 }
 
@@ -434,7 +434,7 @@ void SX127x::clearDio0Action() {
   _mod->hal->detachInterrupt(_mod->hal->pinToInterrupt(_mod->getIrq()));
 }
 
-void SX127x::setDio1Action(void (*func)(void), uint8_t dir) {
+void SX127x::setDio1Action(void (*func)(void), uint32_t dir) {
   if(_mod->getGpio() == RADIOLIB_NC) {
     return;
   }

--- a/src/modules/SX127x/SX127x.cpp
+++ b/src/modules/SX127x/SX127x.cpp
@@ -1267,11 +1267,11 @@ uint8_t SX127x::getModemStatus() {
   return(_mod->SPIreadRegister(RADIOLIB_SX127X_REG_MODEM_STAT));
 }
 
-void SX127x::setRfSwitchPins(uint8_t rxEn, uint8_t txEn) {
+void SX127x::setRfSwitchPins(uint32_t rxEn, uint32_t txEn) {
   _mod->setRfSwitchPins(rxEn, txEn);
 }
 
-void SX127x::setRfSwitchTable(const uint8_t (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]) {
+void SX127x::setRfSwitchTable(const uint32_t (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]) {
   _mod->setRfSwitchTable(pins, table);
 }
 
@@ -1508,7 +1508,7 @@ void SX127x::setDirectAction(void (*func)(void)) {
   setDio1Action(func, _mod->hal->GpioInterruptRising);
 }
 
-void SX127x::readBit(uint8_t pin) {
+void SX127x::readBit(uint32_t pin) {
   updateDirectBuffer((uint8_t)_mod->hal->digitalRead(pin));
 }
 #endif
@@ -1534,7 +1534,7 @@ void SX127x::clearFHSSInt(void) {
   }
 }
 
-int16_t SX127x::setDIOMapping(uint8_t pin, uint8_t value) {
+int16_t SX127x::setDIOMapping(uint32_t pin, uint32_t value) {
   if (pin > 5)
     return RADIOLIB_ERR_INVALID_DIO_PIN;
 

--- a/src/modules/SX127x/SX127x.cpp
+++ b/src/modules/SX127x/SX127x.cpp
@@ -1,4 +1,5 @@
 #include "SX127x.h"
+#include <math.h>
 #if !defined(RADIOLIB_EXCLUDE_SX127X)
 
 SX127x::SX127x(Module* mod) : PhysicalLayer(RADIOLIB_SX127X_FREQUENCY_STEP_SIZE, RADIOLIB_SX127X_MAX_PACKET_LENGTH) {
@@ -12,8 +13,8 @@ Module* SX127x::getMod() {
 int16_t SX127x::begin(uint8_t chipVersion, uint8_t syncWord, uint16_t preambleLength) {
   // set module properties
   _mod->init();
-  _mod->pinMode(_mod->getIrq(), INPUT);
-  _mod->pinMode(_mod->getGpio(), INPUT);
+  _mod->hal->pinMode(_mod->getIrq(), _mod->hal->GpioModeInput);
+  _mod->hal->pinMode(_mod->getGpio(), _mod->hal->GpioModeInput);
 
   // try to find the SX127x chip
   if(!SX127x::findChip(chipVersion)) {
@@ -59,8 +60,8 @@ int16_t SX127x::begin(uint8_t chipVersion, uint8_t syncWord, uint16_t preambleLe
 int16_t SX127x::beginFSK(uint8_t chipVersion, float freqDev, float rxBw, uint16_t preambleLength, bool enableOOK) {
   // set module properties
   _mod->init();
-  _mod->pinMode(_mod->getIrq(), INPUT);
-  _mod->pinMode(_mod->getGpio(), INPUT);
+  _mod->hal->pinMode(_mod->getIrq(), _mod->hal->GpioModeInput);
+  _mod->hal->pinMode(_mod->getGpio(), _mod->hal->GpioModeInput);
 
   // try to find the SX127x chip
   if(!SX127x::findChip(chipVersion)) {
@@ -152,10 +153,10 @@ int16_t SX127x::transmit(uint8_t* data, size_t len, uint8_t addr) {
     RADIOLIB_ASSERT(state);
 
     // wait for packet transmission or timeout
-    start = _mod->micros();
-    while(!_mod->digitalRead(_mod->getIrq())) {
-      _mod->yield();
-      if(_mod->micros() - start > timeout) {
+    start = _mod->hal->micros();
+    while(!_mod->hal->digitalRead(_mod->getIrq())) {
+      _mod->hal->yield();
+      if(_mod->hal->micros() - start > timeout) {
         finishTransmit();
         return(RADIOLIB_ERR_TX_TIMEOUT);
       }
@@ -170,10 +171,10 @@ int16_t SX127x::transmit(uint8_t* data, size_t len, uint8_t addr) {
     RADIOLIB_ASSERT(state);
 
     // wait for transmission end or timeout
-    start = _mod->micros();
-    while(!_mod->digitalRead(_mod->getIrq())) {
-      _mod->yield();
-      if(_mod->micros() - start > timeout) {
+    start = _mod->hal->micros();
+    while(!_mod->hal->digitalRead(_mod->getIrq())) {
+      _mod->hal->yield();
+      if(_mod->hal->micros() - start > timeout) {
         finishTransmit();
         return(RADIOLIB_ERR_TX_TIMEOUT);
       }
@@ -183,7 +184,7 @@ int16_t SX127x::transmit(uint8_t* data, size_t len, uint8_t addr) {
   }
 
   // update data rate
-  uint32_t elapsed = _mod->micros() - start;
+  uint32_t elapsed = _mod->hal->micros() - start;
   _dataRate = (len*8.0)/((float)elapsed/1000000.0);
 
   return(finishTransmit());
@@ -208,19 +209,19 @@ int16_t SX127x::receive(uint8_t* data, size_t len) {
     }
 
     // wait for packet reception or timeout
-    uint32_t start = _mod->micros();
-    while(!_mod->digitalRead(_mod->getIrq())) {
-      _mod->yield();
+    uint32_t start = _mod->hal->micros();
+    while(!_mod->hal->digitalRead(_mod->getIrq())) {
+      _mod->hal->yield();
 
       if(_mod->getGpio() == RADIOLIB_NC) {
         // no GPIO pin provided, use software timeout
-        if(_mod->micros() - start > timeout) {
+        if(_mod->hal->micros() - start > timeout) {
           clearIRQFlags();
           return(RADIOLIB_ERR_RX_TIMEOUT);
         }
       } else {
         // GPIO provided, use that
-        if(_mod->digitalRead(_mod->getGpio())) {
+        if(_mod->hal->digitalRead(_mod->getGpio())) {
           clearIRQFlags();
           return(RADIOLIB_ERR_RX_TIMEOUT);
         }
@@ -237,10 +238,10 @@ int16_t SX127x::receive(uint8_t* data, size_t len) {
     RADIOLIB_ASSERT(state);
 
     // wait for packet reception or timeout
-    uint32_t start = _mod->micros();
-    while(!_mod->digitalRead(_mod->getIrq())) {
-      _mod->yield();
-      if(_mod->micros() - start > timeout) {
+    uint32_t start = _mod->hal->micros();
+    while(!_mod->hal->digitalRead(_mod->getIrq())) {
+      _mod->hal->yield();
+      if(_mod->hal->micros() - start > timeout) {
         clearIRQFlags();
         return(RADIOLIB_ERR_RX_TIMEOUT);
       }
@@ -259,9 +260,9 @@ int16_t SX127x::scanChannel() {
   RADIOLIB_ASSERT(state);
 
   // wait for channel activity detected or timeout
-  while(!_mod->digitalRead(_mod->getIrq())) {
-    _mod->yield();
-    if(_mod->digitalRead(_mod->getGpio())) {
+  while(!_mod->hal->digitalRead(_mod->getIrq())) {
+    _mod->hal->yield();
+    if(_mod->hal->digitalRead(_mod->getGpio())) {
       return(RADIOLIB_PREAMBLE_DETECTED);
     }
   }
@@ -425,31 +426,31 @@ int16_t SX127x::startReceive(uint32_t mode, uint16_t irqFlags, uint16_t irqMask,
   return(startReceive((uint8_t)len, (uint8_t)mode));
 }
 
-void SX127x::setDio0Action(void (*func)(void), RADIOLIB_INTERRUPT_STATUS dir) {
-  _mod->attachInterrupt(RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(_mod->getIrq()), func, dir);
+void SX127x::setDio0Action(void (*func)(void), uint8_t dir) {
+  _mod->hal->attachInterrupt(_mod->hal->pinToInterrupt(_mod->getIrq()), func, dir);
 }
 
 void SX127x::clearDio0Action() {
-  _mod->detachInterrupt(RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(_mod->getIrq()));
+  _mod->hal->detachInterrupt(_mod->hal->pinToInterrupt(_mod->getIrq()));
 }
 
-void SX127x::setDio1Action(void (*func)(void), RADIOLIB_INTERRUPT_STATUS dir) {
+void SX127x::setDio1Action(void (*func)(void), uint8_t dir) {
   if(_mod->getGpio() == RADIOLIB_NC) {
     return;
   }
-  _mod->attachInterrupt(RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(_mod->getGpio()), func, dir);
+  _mod->hal->attachInterrupt(_mod->hal->pinToInterrupt(_mod->getGpio()), func, dir);
 }
 
 void SX127x::clearDio1Action() {
   if(_mod->getGpio() == RADIOLIB_NC) {
     return;
   }
-  _mod->detachInterrupt(RADIOLIB_DIGITAL_PIN_TO_INTERRUPT(_mod->getGpio()));
+  _mod->hal->detachInterrupt(_mod->hal->pinToInterrupt(_mod->getGpio()));
 }
 
 void SX127x::setFifoEmptyAction(void (*func)(void)) {
   // set DIO1 to the FIFO empty event (the register setting is done in startTransmit)
-  setDio1Action(func);
+  setDio1Action(func, _mod->hal->GpioInterruptRising);
 }
 
 void SX127x::clearFifoEmptyAction() {
@@ -462,7 +463,7 @@ void SX127x::setFifoFullAction(void (*func)(void)) {
   _mod->SPIsetRegValue(RADIOLIB_SX127X_REG_DIO_MAPPING_1, RADIOLIB_SX127X_DIO1_PACK_FIFO_LEVEL, 5, 4);
 
   // set DIO1 to the FIFO full event
-  setDio1Action(func);
+  setDio1Action(func, _mod->hal->GpioInterruptRising);
 }
 
 void SX127x::clearFifoFullAction() {
@@ -1266,11 +1267,11 @@ uint8_t SX127x::getModemStatus() {
   return(_mod->SPIreadRegister(RADIOLIB_SX127X_REG_MODEM_STAT));
 }
 
-void SX127x::setRfSwitchPins(RADIOLIB_PIN_TYPE rxEn, RADIOLIB_PIN_TYPE txEn) {
+void SX127x::setRfSwitchPins(uint8_t rxEn, uint8_t txEn) {
   _mod->setRfSwitchPins(rxEn, txEn);
 }
 
-void SX127x::setRfSwitchTable(const RADIOLIB_PIN_TYPE (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]) {
+void SX127x::setRfSwitchTable(const uint8_t (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]) {
   _mod->setRfSwitchTable(pins, table);
 }
 
@@ -1285,7 +1286,7 @@ uint8_t SX127x::randomByte() {
   setMode(RADIOLIB_SX127X_RX);
 
   // wait a bit for the RSSI reading to stabilise
-  _mod->delay(10);
+  _mod->hal->delay(10);
 
   // read RSSI value 8 times, always keep just the least significant bit
   uint8_t randByte = 0x00;
@@ -1326,7 +1327,7 @@ int8_t SX127x::getTempRaw() {
   _mod->SPIsetRegValue(RADIOLIB_SX127X_REG_IMAGE_CAL, RADIOLIB_SX127X_TEMP_MONITOR_ON, 0, 0);
 
   // wait
-  _mod->delayMicroseconds(200);
+  _mod->hal->delayMicroseconds(200);
 
   // disable temperature reading
   _mod->SPIsetRegValue(RADIOLIB_SX127X_REG_IMAGE_CAL, RADIOLIB_SX127X_TEMP_MONITOR_OFF, 0, 0);
@@ -1432,7 +1433,7 @@ bool SX127x::findChip(uint8_t ver) {
       flagFound = true;
     } else {
       RADIOLIB_DEBUG_PRINTLN("SX127x not found! (%d of 10 tries) RADIOLIB_SX127X_REG_VERSION == 0x%04X, expected 0x00%X", i + 1, version, ver);
-      _mod->delay(10);
+      _mod->hal->delay(10);
       i++;
     }
   }
@@ -1504,11 +1505,11 @@ int16_t SX127x::invertIQ(bool invertIQ) {
 
 #if !defined(RADIOLIB_EXCLUDE_DIRECT_RECEIVE)
 void SX127x::setDirectAction(void (*func)(void)) {
-  setDio1Action(func);
+  setDio1Action(func, _mod->hal->GpioInterruptRising);
 }
 
-void SX127x::readBit(RADIOLIB_PIN_TYPE pin) {
-  updateDirectBuffer((uint8_t)_mod->digitalRead(pin));
+void SX127x::readBit(uint8_t pin) {
+  updateDirectBuffer((uint8_t)_mod->hal->digitalRead(pin));
 }
 #endif
 
@@ -1533,7 +1534,7 @@ void SX127x::clearFHSSInt(void) {
   }
 }
 
-int16_t SX127x::setDIOMapping(RADIOLIB_PIN_TYPE pin, uint8_t value) {
+int16_t SX127x::setDIOMapping(uint8_t pin, uint8_t value) {
   if (pin > 5)
     return RADIOLIB_ERR_INVALID_DIO_PIN;
 

--- a/src/modules/SX127x/SX127x.h
+++ b/src/modules/SX127x/SX127x.h
@@ -727,7 +727,7 @@ class SX127x: public PhysicalLayer {
 
       \param dir Signal change direction.
     */
-    void setDio0Action(void (*func)(void), uint8_t dir);
+    void setDio0Action(void (*func)(void), uint32_t dir);
 
     /*!
       \brief Clears interrupt service routine to call when DIO0 activates.
@@ -741,7 +741,7 @@ class SX127x: public PhysicalLayer {
 
       \param dir Signal change direction.
     */
-    void setDio1Action(void (*func)(void), uint8_t dir);
+    void setDio1Action(void (*func)(void), uint32_t dir);
 
     /*!
       \brief Clears interrupt service routine to call when DIO1 activates.

--- a/src/modules/SX127x/SX127x.h
+++ b/src/modules/SX127x/SX127x.h
@@ -1155,10 +1155,10 @@ class SX127x: public PhysicalLayer {
     int8_t getTempRaw();
 
     /*! \copydoc Module::setRfSwitchPins */
-    void setRfSwitchPins(uint8_t rxEn, uint8_t txEn);
+    void setRfSwitchPins(uint32_t rxEn, uint32_t txEn);
 
     /*! \copydoc Module::setRfSwitchTable */
-    void setRfSwitchTable(const uint8_t (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]);
+    void setRfSwitchTable(const uint32_t (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]);
 
     /*!
      \brief Get one truly random byte from RSSI noise.
@@ -1196,7 +1196,7 @@ class SX127x: public PhysicalLayer {
 
       \param pin Pin on which to read.
     */
-    void readBit(uint8_t pin);
+    void readBit(uint32_t pin);
     #endif
 
     /*!
@@ -1236,7 +1236,7 @@ class SX127x: public PhysicalLayer {
 
       \returns \ref status_codes
     */
-    int16_t setDIOMapping(uint8_t pin, uint8_t value);
+    int16_t setDIOMapping(uint32_t pin, uint32_t value);
 
     /*!
       \brief Configure DIO mapping to use RSSI or Preamble Detect for pins that support it.

--- a/src/modules/SX127x/SX127x.h
+++ b/src/modules/SX127x/SX127x.h
@@ -725,9 +725,9 @@ class SX127x: public PhysicalLayer {
 
       \param func Pointer to interrupt service routine.
 
-      \param dir Signal change direction. Defaults to RISING.
+      \param dir Signal change direction.
     */
-    void setDio0Action(void (*func)(void), RADIOLIB_INTERRUPT_STATUS dir = RISING);
+    void setDio0Action(void (*func)(void), uint8_t dir);
 
     /*!
       \brief Clears interrupt service routine to call when DIO0 activates.
@@ -739,9 +739,9 @@ class SX127x: public PhysicalLayer {
 
       \param func Pointer to interrupt service routine.
 
-      \param dir Signal change direction. Defaults to RISING.
+      \param dir Signal change direction.
     */
-    void setDio1Action(void (*func)(void), RADIOLIB_INTERRUPT_STATUS dir = RISING);
+    void setDio1Action(void (*func)(void), uint8_t dir);
 
     /*!
       \brief Clears interrupt service routine to call when DIO1 activates.
@@ -1155,10 +1155,10 @@ class SX127x: public PhysicalLayer {
     int8_t getTempRaw();
 
     /*! \copydoc Module::setRfSwitchPins */
-    void setRfSwitchPins(RADIOLIB_PIN_TYPE rxEn, RADIOLIB_PIN_TYPE txEn);
+    void setRfSwitchPins(uint8_t rxEn, uint8_t txEn);
 
     /*! \copydoc Module::setRfSwitchTable */
-    void setRfSwitchTable(const RADIOLIB_PIN_TYPE (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]);
+    void setRfSwitchTable(const uint8_t (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]);
 
     /*!
      \brief Get one truly random byte from RSSI noise.
@@ -1196,7 +1196,7 @@ class SX127x: public PhysicalLayer {
 
       \param pin Pin on which to read.
     */
-    void readBit(RADIOLIB_PIN_TYPE pin);
+    void readBit(uint8_t pin);
     #endif
 
     /*!
@@ -1236,7 +1236,7 @@ class SX127x: public PhysicalLayer {
 
       \returns \ref status_codes
     */
-    int16_t setDIOMapping(RADIOLIB_PIN_TYPE pin, uint8_t value);
+    int16_t setDIOMapping(uint8_t pin, uint8_t value);
 
     /*!
       \brief Configure DIO mapping to use RSSI or Preamble Detect for pins that support it.

--- a/src/modules/SX128x/SX1280.cpp
+++ b/src/modules/SX128x/SX1280.cpp
@@ -1,4 +1,5 @@
 #include "SX1280.h"
+#include <string.h>
 #if !defined(RADIOLIB_EXCLUDE_SX128X)
 
 SX1280::SX1280(Module* mod) : SX1281(mod) {
@@ -11,10 +12,10 @@ int16_t SX1280::range(bool master, uint32_t addr, uint16_t calTable[3][6]) {
   RADIOLIB_ASSERT(state);
 
   // wait until ranging is finished
-  uint32_t start = _mod->millis();
-  while(!_mod->digitalRead(_mod->getIrq())) {
-    _mod->yield();
-    if(_mod->millis() - start > 10000) {
+  uint32_t start = _mod->hal->millis();
+  while(!_mod->hal->digitalRead(_mod->getIrq())) {
+    _mod->hal->yield();
+    if(_mod->hal->millis() - start > 10000) {
       clearIrqStatus();
       standby();
       return(RADIOLIB_ERR_RANGING_TIMEOUT);

--- a/src/modules/SX128x/SX128x.cpp
+++ b/src/modules/SX128x/SX128x.cpp
@@ -1266,11 +1266,11 @@ int16_t SX128x::setEncoding(uint8_t encoding) {
   return(setWhitening(encoding));
 }
 
-void SX128x::setRfSwitchPins(uint8_t rxEn, uint8_t txEn) {
+void SX128x::setRfSwitchPins(uint32_t rxEn, uint32_t txEn) {
   _mod->setRfSwitchPins(rxEn, txEn);
 }
 
-void SX128x::setRfSwitchTable(const uint8_t (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]) {
+void SX128x::setRfSwitchTable(const uint32_t (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]) {
   _mod->setRfSwitchTable(pins, table);
 }
 
@@ -1300,7 +1300,7 @@ void SX128x::setDirectAction(void (*func)(void)) {
   (void)func;
 }
 
-void SX128x::readBit(uint8_t pin) {
+void SX128x::readBit(uint32_t pin) {
   // SX128x is unable to perform direct mode reception
   // this method is implemented only for PhysicalLayer compatibility
   (void)pin;

--- a/src/modules/SX128x/SX128x.h
+++ b/src/modules/SX128x/SX128x.h
@@ -817,10 +817,10 @@ class SX128x: public PhysicalLayer {
     int16_t setEncoding(uint8_t encoding) override;
 
     /*! \copydoc Module::setRfSwitchPins */
-    void setRfSwitchPins(uint8_t rxEn, uint8_t txEn);
+    void setRfSwitchPins(uint32_t rxEn, uint32_t txEn);
 
     /*! \copydoc Module::setRfSwitchTable */
-    void setRfSwitchTable(const uint8_t (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]);
+    void setRfSwitchTable(const uint32_t (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]);
 
     /*!
      \brief Dummy random method, to ensure PhysicalLayer compatibility.
@@ -851,7 +851,7 @@ class SX128x: public PhysicalLayer {
 
       \param pin Ignored.
     */
-    void readBit(uint8_t pin);
+    void readBit(uint32_t pin);
     #endif
 
 #if !defined(RADIOLIB_GODMODE) && !defined(RADIOLIB_LOW_LEVEL)

--- a/src/modules/SX128x/SX128x.h
+++ b/src/modules/SX128x/SX128x.h
@@ -817,10 +817,10 @@ class SX128x: public PhysicalLayer {
     int16_t setEncoding(uint8_t encoding) override;
 
     /*! \copydoc Module::setRfSwitchPins */
-    void setRfSwitchPins(RADIOLIB_PIN_TYPE rxEn, RADIOLIB_PIN_TYPE txEn);
+    void setRfSwitchPins(uint8_t rxEn, uint8_t txEn);
 
     /*! \copydoc Module::setRfSwitchTable */
-    void setRfSwitchTable(const RADIOLIB_PIN_TYPE (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]);
+    void setRfSwitchTable(const uint8_t (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]);
 
     /*!
      \brief Dummy random method, to ensure PhysicalLayer compatibility.
@@ -851,7 +851,7 @@ class SX128x: public PhysicalLayer {
 
       \param pin Ignored.
     */
-    void readBit(RADIOLIB_PIN_TYPE pin);
+    void readBit(uint8_t pin);
     #endif
 
 #if !defined(RADIOLIB_GODMODE) && !defined(RADIOLIB_LOW_LEVEL)

--- a/src/modules/Si443x/Si443x.cpp
+++ b/src/modules/Si443x/Si443x.cpp
@@ -576,11 +576,11 @@ int16_t Si443x::setDataShaping(uint8_t sh) {
   }
 }
 
-void Si443x::setRfSwitchPins(uint8_t rxEn, uint8_t txEn) {
+void Si443x::setRfSwitchPins(uint32_t rxEn, uint32_t txEn) {
   _mod->setRfSwitchPins(rxEn, txEn);
 }
 
-void Si443x::setRfSwitchTable(const uint8_t (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]) {
+void Si443x::setRfSwitchTable(const uint32_t (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]) {
   _mod->setRfSwitchTable(pins, table);
 }
 
@@ -612,7 +612,7 @@ void Si443x::setDirectAction(void (*func)(void)) {
   setIrqAction(func);
 }
 
-void Si443x::readBit(uint8_t pin) {
+void Si443x::readBit(uint32_t pin) {
   updateDirectBuffer((uint8_t)_mod->hal->digitalRead(pin));
 }
 #endif

--- a/src/modules/Si443x/Si443x.h
+++ b/src/modules/Si443x/Si443x.h
@@ -810,10 +810,10 @@ class Si443x: public PhysicalLayer {
     int16_t setDataShaping(uint8_t sh) override;
 
     /*! \copydoc Module::setRfSwitchPins */
-    void setRfSwitchPins(uint8_t rxEn, uint8_t txEn);
+    void setRfSwitchPins(uint32_t rxEn, uint32_t txEn);
 
     /*! \copydoc Module::setRfSwitchTable */
-    void setRfSwitchTable(const uint8_t (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]);
+    void setRfSwitchTable(const uint32_t (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]);
 
     /*!
      \brief Get one truly random byte from RSSI noise.
@@ -842,7 +842,7 @@ class Si443x: public PhysicalLayer {
 
       \param pin Pin on which to read.
     */
-    void readBit(uint8_t pin);
+    void readBit(uint32_t pin);
     #endif
 
     /*!

--- a/src/modules/Si443x/Si443x.h
+++ b/src/modules/Si443x/Si443x.h
@@ -810,10 +810,10 @@ class Si443x: public PhysicalLayer {
     int16_t setDataShaping(uint8_t sh) override;
 
     /*! \copydoc Module::setRfSwitchPins */
-    void setRfSwitchPins(RADIOLIB_PIN_TYPE rxEn, RADIOLIB_PIN_TYPE txEn);
+    void setRfSwitchPins(uint8_t rxEn, uint8_t txEn);
 
     /*! \copydoc Module::setRfSwitchTable */
-    void setRfSwitchTable(const RADIOLIB_PIN_TYPE (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]);
+    void setRfSwitchTable(const uint8_t (&pins)[Module::RFSWITCH_MAX_PINS], const Module::RfSwitchMode_t table[]);
 
     /*!
      \brief Get one truly random byte from RSSI noise.
@@ -842,7 +842,7 @@ class Si443x: public PhysicalLayer {
 
       \param pin Pin on which to read.
     */
-    void readBit(RADIOLIB_PIN_TYPE pin);
+    void readBit(uint8_t pin);
     #endif
 
     /*!

--- a/src/modules/nRF24/nRF24.cpp
+++ b/src/modules/nRF24/nRF24.cpp
@@ -559,7 +559,7 @@ void nRF24::setDirectAction(void (*func)(void)) {
   (void)func;
 }
 
-void nRF24::readBit(uint8_t pin) {
+void nRF24::readBit(uint32_t pin) {
   // nRF24 is unable to perform direct mode actions
   // this method is implemented only for PhysicalLayer compatibility
   (void)pin;

--- a/src/modules/nRF24/nRF24.h
+++ b/src/modules/nRF24/nRF24.h
@@ -528,7 +528,7 @@ class nRF24: public PhysicalLayer {
 
       \param pin Ignored.
     */
-    void readBit(RADIOLIB_PIN_TYPE pin);
+    void readBit(uint8_t pin);
     #endif
 
 #if !defined(RADIOLIB_GODMODE) && !defined(RADIOLIB_LOW_LEVEL)

--- a/src/modules/nRF24/nRF24.h
+++ b/src/modules/nRF24/nRF24.h
@@ -528,7 +528,7 @@ class nRF24: public PhysicalLayer {
 
       \param pin Ignored.
     */
-    void readBit(uint8_t pin);
+    void readBit(uint32_t pin);
     #endif
 
 #if !defined(RADIOLIB_GODMODE) && !defined(RADIOLIB_LOW_LEVEL)

--- a/src/protocols/AFSK/AFSK.cpp
+++ b/src/protocols/AFSK/AFSK.cpp
@@ -1,7 +1,7 @@
 #include "AFSK.h"
 #if !defined(RADIOLIB_EXCLUDE_AFSK)
 
-AFSKClient::AFSKClient(PhysicalLayer* phy, uint8_t pin): _pin(pin) {
+AFSKClient::AFSKClient(PhysicalLayer* phy, uint32_t pin): _pin(pin) {
   _phy = phy;
 }
 

--- a/src/protocols/AFSK/AFSK.cpp
+++ b/src/protocols/AFSK/AFSK.cpp
@@ -1,7 +1,7 @@
 #include "AFSK.h"
 #if !defined(RADIOLIB_EXCLUDE_AFSK)
 
-AFSKClient::AFSKClient(PhysicalLayer* phy, RADIOLIB_PIN_TYPE pin): _pin(pin) {
+AFSKClient::AFSKClient(PhysicalLayer* phy, uint8_t pin): _pin(pin) {
   _phy = phy;
 }
 
@@ -20,13 +20,13 @@ int16_t AFSKClient::tone(uint16_t freq, bool autoStart) {
   }
 
   Module* mod = _phy->getMod();
-  mod->tone(_pin, freq);
+  mod->hal->tone(_pin, freq);
   return(RADIOLIB_ERR_NONE);
 }
 
 int16_t AFSKClient::noTone(bool keepOn) {
   Module* mod = _phy->getMod();
-  mod->noTone(_pin);
+  mod->hal->noTone(_pin);
   if(keepOn) {
     return(0);
   }

--- a/src/protocols/AFSK/AFSK.h
+++ b/src/protocols/AFSK/AFSK.h
@@ -23,7 +23,7 @@ class AFSKClient  {
 
       \param pin The pin that will be used for audio output.
     */
-    AFSKClient(PhysicalLayer* phy, uint8_t pin);
+    AFSKClient(PhysicalLayer* phy, uint32_t pin);
 
     /*!
       \brief Initialization method.
@@ -56,7 +56,7 @@ class AFSKClient  {
   private:
 #endif
     PhysicalLayer* _phy;
-    uint8_t _pin;
+    uint32_t _pin;
 
     // allow specific classes access the private PhysicalLayer pointer
     friend class RTTYClient;

--- a/src/protocols/AFSK/AFSK.h
+++ b/src/protocols/AFSK/AFSK.h
@@ -23,7 +23,7 @@ class AFSKClient  {
 
       \param pin The pin that will be used for audio output.
     */
-    AFSKClient(PhysicalLayer* phy, RADIOLIB_PIN_TYPE pin);
+    AFSKClient(PhysicalLayer* phy, uint8_t pin);
 
     /*!
       \brief Initialization method.
@@ -56,7 +56,7 @@ class AFSKClient  {
   private:
 #endif
     PhysicalLayer* _phy;
-    RADIOLIB_PIN_TYPE _pin;
+    uint8_t _pin;
 
     // allow specific classes access the private PhysicalLayer pointer
     friend class RTTYClient;

--- a/src/protocols/APRS/APRS.cpp
+++ b/src/protocols/APRS/APRS.cpp
@@ -1,4 +1,7 @@
 #include "APRS.h"
+#include <string.h>
+#include <stdio.h>
+#include <ctype.h>
 #if !defined(RADIOLIB_EXCLUDE_APRS)
 
 APRSClient::APRSClient(AX25Client* ax) {

--- a/src/protocols/AX25/AX25.cpp
+++ b/src/protocols/AX25/AX25.cpp
@@ -1,4 +1,5 @@
 #include "AX25.h"
+#include <string.h>
 #if !defined(RADIOLIB_EXCLUDE_AX25)
 
 AX25Frame::AX25Frame(const char* destCallsign, uint8_t destSSID, const char* srcCallsign, uint8_t srcSSID, uint8_t control)
@@ -409,7 +410,7 @@ int16_t AX25Client::sendFrame(AX25Frame* frame) {
 
       // check each bit
       for(uint16_t mask = 0x80; mask >= 0x01; mask >>= 1) {
-        uint32_t start = mod->micros();
+        uint32_t start = mod->hal->micros();
         if(stuffedFrameBuff[i] & mask) {
           _audio->tone(_afskMark, false);
         } else {

--- a/src/protocols/ExternalRadio/ExternalRadio.cpp
+++ b/src/protocols/ExternalRadio/ExternalRadio.cpp
@@ -1,7 +1,13 @@
 #include "ExternalRadio.h"
 
+#if defined(RADIOLIB_BUILD_ARDUINO)
 ExternalRadio::ExternalRadio() : PhysicalLayer(1, 0) {
   mod = new Module(RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC);
+}
+#endif
+
+ExternalRadio::ExternalRadio(Hal *hal) : PhysicalLayer(1, 0) {
+  mod = new Module(hal, RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC);
 }
 
 Module* ExternalRadio::getMod() {

--- a/src/protocols/ExternalRadio/ExternalRadio.h
+++ b/src/protocols/ExternalRadio/ExternalRadio.h
@@ -3,7 +3,9 @@
 
 #include "../../TypeDef.h"
 #include "../../Module.h"
+#if defined(RADIOLIB_BUILD_ARDUINO)
 #include "../../ArduinoHal.h"
+#endif
 
 #include "../PhysicalLayer/PhysicalLayer.h"
 

--- a/src/protocols/ExternalRadio/ExternalRadio.h
+++ b/src/protocols/ExternalRadio/ExternalRadio.h
@@ -3,12 +3,17 @@
 
 #include "../../TypeDef.h"
 #include "../../Module.h"
+#include "../../ArduinoHal.h"
 
 #include "../PhysicalLayer/PhysicalLayer.h"
 
 class ExternalRadio: public PhysicalLayer {
   public:
+    #if defined(RADIOLIB_BUILD_ARDUINO)
     ExternalRadio();
+    #endif
+    ExternalRadio(Hal *hal);
+
     Module* getMod();
   private:
     Module* mod;

--- a/src/protocols/FSK4/FSK4.cpp
+++ b/src/protocols/FSK4/FSK4.cpp
@@ -1,4 +1,5 @@
 #include "FSK4.h"
+#include <math.h>
 #if !defined(RADIOLIB_EXCLUDE_FSK4)
 
 FSK4Client::FSK4Client(PhysicalLayer* phy) {
@@ -80,7 +81,7 @@ size_t FSK4Client::write(uint8_t b) {
 
 void FSK4Client::tone(uint8_t i) {
   Module* mod = _phy->getMod();
-  uint32_t start = mod->micros();
+  uint32_t start = mod->hal->micros();
   transmitDirect(_base + _tones[i], _baseHz + _tonesHz[i]);
   mod->waitForMicroseconds(start, _bitDuration);
 }

--- a/src/protocols/Hellschreiber/Hellschreiber.cpp
+++ b/src/protocols/Hellschreiber/Hellschreiber.cpp
@@ -1,4 +1,6 @@
 #include "Hellschreiber.h"
+#include <string.h>
+#include <math.h>
 #if !defined(RADIOLIB_EXCLUDE_HELLSCHREIBER)
 
 HellClient::HellClient(PhysicalLayer* phy) {
@@ -34,7 +36,7 @@ size_t HellClient::printGlyph(uint8_t* buff) {
   bool transmitting = false;
   for(uint8_t mask = 0x40; mask >= 0x01; mask >>= 1) {
     for(int8_t i = RADIOLIB_HELL_FONT_HEIGHT - 1; i >= 0; i--) {
-        uint32_t start = mod->micros();
+        uint32_t start = mod->hal->micros();
         if((buff[i] & mask) && (!transmitting)) {
           transmitting = true;
           transmitDirect(_base, _baseHz);

--- a/src/protocols/Morse/Morse.cpp
+++ b/src/protocols/Morse/Morse.cpp
@@ -58,7 +58,7 @@ char MorseClient::decode(uint8_t symbol, uint8_t len) {
 }
 
 #if !defined(RADIOLIB_EXCLUDE_AFSK)
-int MorseClient::read(byte* symbol, byte* len, float low, float high) {
+int MorseClient::read(uint8_t* symbol, uint8_t* len, float low, float high) {
   Module* mod = _phy->getMod();
 
   // measure pulse duration in us

--- a/src/protocols/Morse/Morse.h
+++ b/src/protocols/Morse/Morse.h
@@ -153,7 +153,7 @@ class MorseClient {
       \returns 0 if not enough symbols were decoded, 1 if inter-character space was detected, 2 if inter-word space was detected.
     */
     #if !defined(RADIOLIB_EXCLUDE_AFSK)
-    int read(byte* symbol, byte* len, float low = 0.75f, float high = 1.25f);
+    int read(uint8_t* symbol, uint8_t* len, float low = 0.75f, float high = 1.25f);
     #endif
 
     size_t write(const char* str);

--- a/src/protocols/Pager/Pager.cpp
+++ b/src/protocols/Pager/Pager.cpp
@@ -7,7 +7,7 @@
 // this is a massive hack, but we need a global-scope ISR to manage the bit reading
 // let's hope nobody ever tries running two POCSAG receivers at the same time
 static PhysicalLayer* _readBitInstance = NULL;
-static uint8_t _readBitPin = RADIOLIB_NC;
+static uint32_t _readBitPin = RADIOLIB_NC;
 
 #if defined(ESP8266) || defined(ESP32)
   ICACHE_RAM_ATTR
@@ -223,7 +223,7 @@ int16_t PagerClient::transmit(uint8_t* data, size_t len, uint32_t addr, uint8_t 
 }
 
 #if !defined(RADIOLIB_EXCLUDE_DIRECT_RECEIVE)
-int16_t PagerClient::startReceive(uint8_t pin, uint32_t addr, uint32_t mask) {
+int16_t PagerClient::startReceive(uint32_t pin, uint32_t addr, uint32_t mask) {
   // save the variables
   _readBitPin = pin;
   _filterAddr = addr;

--- a/src/protocols/Pager/Pager.h
+++ b/src/protocols/Pager/Pager.h
@@ -157,7 +157,7 @@ class PagerClient {
 
       \returns \ref status_codes
     */
-    int16_t startReceive(uint8_t pin, uint32_t addr, uint32_t mask = 0xFFFFF);
+    int16_t startReceive(uint32_t pin, uint32_t addr, uint32_t mask = 0xFFFFF);
 
     /*!
       \brief Get the number of POCSAG batches available in buffer. Limited by the size of direct mode buffer!

--- a/src/protocols/Pager/Pager.h
+++ b/src/protocols/Pager/Pager.h
@@ -157,7 +157,7 @@ class PagerClient {
 
       \returns \ref status_codes
     */
-    int16_t startReceive(RADIOLIB_PIN_TYPE pin, uint32_t addr, uint32_t mask = 0xFFFFF);
+    int16_t startReceive(uint8_t pin, uint32_t addr, uint32_t mask = 0xFFFFF);
 
     /*!
       \brief Get the number of POCSAG batches available in buffer. Limited by the size of direct mode buffer!

--- a/src/protocols/PhysicalLayer/PhysicalLayer.cpp
+++ b/src/protocols/PhysicalLayer/PhysicalLayer.cpp
@@ -380,13 +380,13 @@ void PhysicalLayer::setDirectAction(void (*func)(void)) {
   (void)func;
 }
 
-void PhysicalLayer::readBit(uint8_t pin) {
+void PhysicalLayer::readBit(uint32_t pin) {
   (void)pin;
 }
 
 #endif
 
-int16_t PhysicalLayer::setDIOMapping(uint8_t pin, uint8_t value) {
+int16_t PhysicalLayer::setDIOMapping(uint32_t pin, uint32_t value) {
   (void)pin;
   (void)value;
   return(RADIOLIB_ERR_UNSUPPORTED);

--- a/src/protocols/PhysicalLayer/PhysicalLayer.cpp
+++ b/src/protocols/PhysicalLayer/PhysicalLayer.cpp
@@ -1,4 +1,5 @@
 #include "PhysicalLayer.h"
+#include <string.h>
 
 PhysicalLayer::PhysicalLayer(float freqStep, size_t maxPacketLength) {
   _freqStep = freqStep;
@@ -379,13 +380,13 @@ void PhysicalLayer::setDirectAction(void (*func)(void)) {
   (void)func;
 }
 
-void PhysicalLayer::readBit(RADIOLIB_PIN_TYPE pin) {
+void PhysicalLayer::readBit(uint8_t pin) {
   (void)pin;
 }
 
 #endif
 
-int16_t PhysicalLayer::setDIOMapping(RADIOLIB_PIN_TYPE pin, uint8_t value) {
+int16_t PhysicalLayer::setDIOMapping(uint8_t pin, uint8_t value) {
   (void)pin;
   (void)value;
   return(RADIOLIB_ERR_UNSUPPORTED);

--- a/src/protocols/PhysicalLayer/PhysicalLayer.h
+++ b/src/protocols/PhysicalLayer/PhysicalLayer.h
@@ -360,7 +360,7 @@ class PhysicalLayer {
 
       \param pin Pin on which to read.
     */
-    virtual void readBit(uint8_t pin);
+    virtual void readBit(uint32_t pin);
 
     /*!
       \brief Get the number of direct mode bytes currently available in buffer.
@@ -393,7 +393,7 @@ class PhysicalLayer {
 
       \returns \ref status_codes
     */
-    virtual int16_t setDIOMapping(uint8_t pin, uint8_t value);
+    virtual int16_t setDIOMapping(uint32_t pin, uint32_t value);
 
     /*!
       \brief Sets interrupt service routine to call when DIO1 activates.

--- a/src/protocols/PhysicalLayer/PhysicalLayer.h
+++ b/src/protocols/PhysicalLayer/PhysicalLayer.h
@@ -360,7 +360,7 @@ class PhysicalLayer {
 
       \param pin Pin on which to read.
     */
-    virtual void readBit(RADIOLIB_PIN_TYPE pin);
+    virtual void readBit(uint8_t pin);
 
     /*!
       \brief Get the number of direct mode bytes currently available in buffer.
@@ -393,7 +393,7 @@ class PhysicalLayer {
 
       \returns \ref status_codes
     */
-    virtual int16_t setDIOMapping(RADIOLIB_PIN_TYPE pin, uint8_t value);
+    virtual int16_t setDIOMapping(uint8_t pin, uint8_t value);
 
     /*!
       \brief Sets interrupt service routine to call when DIO1 activates.

--- a/src/protocols/RTTY/RTTY.cpp
+++ b/src/protocols/RTTY/RTTY.cpp
@@ -1,4 +1,6 @@
 #include "RTTY.h"
+#include <string.h>
+#include <math.h>
 #if !defined(RADIOLIB_EXCLUDE_RTTY)
 
 ITA2String::ITA2String(char c) {
@@ -409,14 +411,14 @@ size_t RTTYClient::println(double d, int digits) {
 
 void RTTYClient::mark() {
   Module* mod = _phy->getMod();
-  uint32_t start = mod->micros();
+  uint32_t start = mod->hal->micros();
   transmitDirect(_base + _shift, _baseHz + _shiftHz);
   mod->waitForMicroseconds(start, _bitDuration);
 }
 
 void RTTYClient::space() {
   Module* mod = _phy->getMod();
-  uint32_t start = mod->micros();
+  uint32_t start = mod->hal->micros();
   transmitDirect(_base, _baseHz);
   mod->waitForMicroseconds(start, _bitDuration);
 }

--- a/src/protocols/SSTV/SSTV.cpp
+++ b/src/protocols/SSTV/SSTV.cpp
@@ -291,7 +291,7 @@ uint16_t SSTVClient::getPictureHeight() const {
 
 void SSTVClient::tone(float freq, uint32_t len) {
   Module* mod = _phy->getMod();
-  uint32_t start = mod->micros();
+  uint32_t start = mod->hal->micros();
   #if !defined(RADIOLIB_EXCLUDE_AFSK)
   if(_audio != nullptr) {
     _audio->tone(freq, false);


### PR DESCRIPTION
This PR completly refactor the hardware abstraction layer. I think it's ready to be reviewed and I'm really sorry because it's a big PR and I didn't split the commits to ease the review. 
It compiled successfully on arduino cores (https://github.com/Mesteery/RadioLib/actions/runs/4680264029 and https://github.com/Mesteery/RadioLib/actions/runs/4681321278/jobs/8293761734 after stm32wlx fix)

- I was forced to remove `dir` default in methods like `setGdo0Action` because of the use of `this` (to access eg. `hal->GpioInterruptRising`)
- I'm not too happy with the RADIOLIB_NC check in the HAL because I don't think it's normal that the user has to check this kind of thing (in case he provides his own HAL). But this is the simplest and cleanest way, so it doesn't bother me more than that

*This is a breaking change.*
