### PR TITLE
[SX1272] Correct LoRa mode CRC register values

### DIFF
--- a/src/modules/SX127x/SX1272.cpp
+++ b/src/modules/SX127x/SX1272.cpp
@@ -365,9 +365,9 @@ int16_t SX1272::setCRC(bool enable, bool mode) {
     // set LoRa CRC
     SX127x::crcEnabled = enable;
     if(enable) {
-      return(this->mod->SPIsetRegValue(RADIOLIB_SX127X_REG_MODEM_CONFIG_2, RADIOLIB_SX1272_RX_CRC_MODE_ON, 2, 2));
+      return(this->mod->SPIsetRegValue(RADIOLIB_SX127X_REG_MODEM_CONFIG_1, RADIOLIB_SX1272_RX_CRC_MODE_ON, 1, 1));
     } else {
-      return(this->mod->SPIsetRegValue(RADIOLIB_SX127X_REG_MODEM_CONFIG_2, RADIOLIB_SX1272_RX_CRC_MODE_OFF, 2, 2));
+      return(this->mod->SPIsetRegValue(RADIOLIB_SX127X_REG_MODEM_CONFIG_1, RADIOLIB_SX1272_RX_CRC_MODE_OFF, 1, 1));
     }
   } else {
     // set FSK CRC


### PR DESCRIPTION
Using LoRa mode, an error in the assignment of the CRC enable bit in the `setCRC` method causes CRC to not be actually enabled. The result is RadioLibs SX1272 object *thinking* it has CRC enabled, even though the actual hardware module does not. In doing so, it also accidentally disables automatic LNA gain. According to the datasheet:

![image](https://github.com/jgromes/RadioLib/assets/22843298/351e207f-ce71-4d7f-8dce-38050f699aea)
![image](https://github.com/jgromes/RadioLib/assets/22843298/4fe91c24-4cfd-464e-a580-a32bfb6d1772)

Because CRC is supposed to be enabled by default for this module, it results in the `RADIOLIB_ERR_LORA_HEADER_DAMAGED` error upon attempting to read a received packet sent by a module configured in the same way, even though the read data is fully intact. This is because packets are sent and received without any CRC generation / checking just fine, but the [`readData` method](https://github.com/jgromes/RadioLib/blob/0c40aa7f85950cb60c39cbea31d04e17a4fd7cab/src/modules/SX127x/SX127x.cpp#LL617C3-L623C6) checks the CRC flag of the header (always 0, considering the wrong register/bit is written) with `crcEnabled` (always `1`, considering CRC is on by default), thus always evaluating to an error.

This commit fixes said error and properly enables CRC checking/generation for the SX1272. Tested with an ESP32.