### PR TITLE
Bug in waitForMicroseconds prevTimingLen in V6.0.0

### DIFF
--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -366,7 +366,7 @@ void Module::waitForMicroseconds(uint32_t start, uint32_t len) {
   #if defined(RADIOLIB_INTERRUPT_TIMING)
   (void)start;
   if((this->TimerSetupCb != nullptr) && (len != this->prevTimingLen)) {
-    _prevTimingLen = len;
+    prevTimingLen = len;
     this->TimerSetupCb(len);
   }
   this->TimerFlag = false;


### PR DESCRIPTION
In Module::waitForMicroseconds if RADIOLIB_INTERRUPT_TIMING is defined the variable prevTimingLen has been incorrectly upated in v6.0.0 introducing a bug that stops compilation.

Fix: renamed _prevTimingLen to prevTimingLen to match other updates in 6.0.0