### PR TITLE
Module: Mark some functions as virtual

### DIFF
--- a/src/Module.h
+++ b/src/Module.h
@@ -326,7 +326,7 @@ class Module {
       \param timeout GPIO wait period timeout in milliseconds.
       \returns \ref status_codes
     */
-    int16_t SPItransferStream(uint8_t* cmd, uint8_t cmdLen, bool write, uint8_t* dataOut, uint8_t* dataIn, size_t numBytes, bool waitForGpio, uint32_t timeout);
+    virtual int16_t SPItransferStream(uint8_t* cmd, uint8_t cmdLen, bool write, uint8_t* dataOut, uint8_t* dataIn, size_t numBytes, bool waitForGpio, uint32_t timeout);
 
     // pin number access methods
 


### PR DESCRIPTION
In an effort to support RadioLib on Tock (github.com/tock/tock) we want to replace some of the Module tranfer functions. This is because we want to replace the entire read/write command with an operating system call, instead of performing individual options. For example we don't want to manually control the CS line, but instead want to just specify a read buffer, write buffer and length and have Tock perform the operation for us.

The current Hal abstraction isn't powerful enough for this, so we need to override some Module functions instead.