### PR TITLE
modules: Don't read excess status data

### DIFF
--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -240,7 +240,7 @@ int16_t Module::SPIcheckStream() {
   // get the status
   uint8_t spiStatus = 0;
   uint8_t cmd = this->SPIstatusCommand;
-  state = this->SPItransferStream(&cmd, 1, false, NULL, &spiStatus, 1, true, RADIOLIB_MODULE_SPI_TIMEOUT);
+  state = this->SPItransferStream(&cmd, 1, false, NULL, &spiStatus, 0, true, RADIOLIB_MODULE_SPI_TIMEOUT);
   RADIOLIB_ASSERT(state);
 
   // translate to RadioLib status code

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -1852,7 +1852,7 @@ int16_t SX126x::setRegulatorMode(uint8_t mode) {
 
 uint8_t SX126x::getStatus() {
   uint8_t data = 0;
-  this->mod->SPIreadStream(RADIOLIB_SX126X_CMD_GET_STATUS, &data, 1);
+  this->mod->SPIreadStream(RADIOLIB_SX126X_CMD_GET_STATUS, &data, 0);
   return(data);
 }
 


### PR DESCRIPTION
The SX126x get status command returns a single status byte. The status byte is automatically read in the `Module::SPItransferStream()` function when we increment buffLen (see
https://github.com/jgromes/RadioLib/blob/master/src/Module.cpp#L259).

By setting numBytes we incorrectly end up reading 2 bytes. Instead set numBytes to zero so we only read the single status byte.