### PR TITLE
modules: SX126x: Remove SPIparseStatus error checking

### DIFF
--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -2022,10 +2022,6 @@ int16_t SX126x::config(uint8_t modem) {
 int16_t SX126x::SPIparseStatus(uint8_t in) {
   if((in & 0b00001110) == RADIOLIB_SX126X_STATUS_CMD_TIMEOUT) {
     return(RADIOLIB_ERR_SPI_CMD_TIMEOUT);
-  } else if((in & 0b00001110) == RADIOLIB_SX126X_STATUS_CMD_INVALID) {
-    return(RADIOLIB_ERR_SPI_CMD_INVALID);
-  } else if((in & 0b00001110) == RADIOLIB_SX126X_STATUS_CMD_FAILED) {
-    return(RADIOLIB_ERR_SPI_CMD_FAILED);
   } else if((in == 0x00) || (in == 0xFF)) {
     return(RADIOLIB_ERR_CHIP_NOT_FOUND);
   }


### PR DESCRIPTION
The SX126x status is an unreliable way to detect errors. It is reported in forums online that it reports errors even when operations are succssful [1]. The Semtech reference implementation never checks the status value [2].

So let's remove some of the error checking on the status byte. In my testing it incorrectly reports errors. If we want to perform error checking we can use the GET_DEVICE_ERRORS command instead.

1: https://forum.lora-developers.semtech.com/t/sx1262-failure-to-execute-command/269/11
2: https://github.com/search?q=repo%3ALora-net%2FLoRaMac-node+SX126xGetStatus&type=code