### PR TITLE
Module: Get status from first byte after the command

### DIFF
--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -328,7 +328,7 @@ int16_t Module::SPItransferStream(uint8_t* cmd, uint8_t cmdLen, bool write, uint
   // parse status
   int16_t state = RADIOLIB_ERR_NONE;
   if(this->SPIparseStatusCb != nullptr) {
-    state = this->SPIparseStatusCb(buffIn[0]);
+    state = this->SPIparseStatusCb(buffIn[cmdLen]);
   }
   
   // copy the data


### PR DESCRIPTION
Instead of getting the status from the very first byte in the input buffer, which will be what we read when we send the first byte. Let's instead get the status from the first byte after the command. This provides a more accurate status value.