### PR TITLE
Add parenthesis for compatibility

### DIFF
--- a/src/protocols/LoRaWAN/LoRaWAN.cpp
+++ b/src/protocols/LoRaWAN/LoRaWAN.cpp
@@ -122,7 +122,7 @@ int16_t LoRaWANNode::beginOTAA(uint64_t appEUI, uint64_t devEUI, uint8_t* nwkKey
   RADIOLIB_ASSERT(state);
 
   // check reply message type
-  if(joinAcceptMsgEnc[0] & RADIOLIB_LORAWAN_MHDR_MTYPE_MASK != RADIOLIB_LORAWAN_MHDR_MTYPE_JOIN_ACCEPT) {
+  if((joinAcceptMsgEnc[0] & RADIOLIB_LORAWAN_MHDR_MTYPE_MASK) != RADIOLIB_LORAWAN_MHDR_MTYPE_JOIN_ACCEPT) {
     RADIOLIB_DEBUG_PRINTLN("joinAccept reply message type invalid, expected 0x%02x got 0x%02x", RADIOLIB_LORAWAN_MHDR_MTYPE_JOIN_ACCEPT, joinAcceptMsgEnc[0]);
     return(RADIOLIB_ERR_RX_TIMEOUT);
   }


### PR DESCRIPTION
Hi,
I am getting a compile error on ESP-IDF/Platformio:
```
managed_components/RadioLib/src/protocols/LoRaWAN/LoRaWAN.cpp: In member function 'int16_t LoRaWANNode::beginOTAA(uint64_t, uint64_t, uint8_t*, uint8_t*, bool)':
managed_components/RadioLib/src/protocols/LoRaWAN/LoRaWAN.cpp:125:61: error: suggest parentheses around comparison in operand of '&' [-Werror=parentheses]
  125 |   if(joinAcceptMsgEnc[0] & RADIOLIB_LORAWAN_MHDR_MTYPE_MASK != RADIOLIB_LORAWAN_MHDR_MTYPE_JOIN_ACCEPT) {
cc1plus: some warnings being treated as errors
*** [.pio/build/TTGO-LoRa32-v1/managed_components/RadioLib/src/protocols/LoRaWAN/LoRaWAN.o] Error 1

I propose adding a parenthesis, for clarity and compatibility.