### PR TITLE
Remove unnecessary condition

### DIFF
--- a/src/protocols/APRS/APRS.cpp
+++ b/src/protocols/APRS/APRS.cpp
@@ -24,7 +24,7 @@ int16_t APRSClient::begin(char sym, char* callsign, uint8_t ssid, bool alt) {
     table = '/';
   }
 
-  if((!src) && (this->phyLayer != nullptr)) {
+  if(this->phyLayer != nullptr) {
     return(RADIOLIB_ERR_INVALID_CALLSIGN);
   }
 


### PR DESCRIPTION
This will never be NULL and thus causes an error in ESP-IDF

```
managed_components/RadioLib/src/protocols/APRS/APRS.cpp: In member function 'int16_t APRSClient::begin(char, char*, uint8_t, bool)':

managed_components/RadioLib/src/protocols/APRS/APRS.cpp:27:8: error: the address of 'APRSClient::src' will never be NULL [-Werror=address]
   27 |   if((!src) && (this->phyLayer != nullptr)) {
```