### PR TITLE
Incorrectly checking sx128x command status

### DIFF
--- a/src/modules/SX128x/SX128x.cpp
+++ b/src/modules/SX128x/SX128x.cpp
@@ -1499,11 +1499,11 @@ int16_t SX128x::config(uint8_t modem) {
 }
 
 int16_t SX128x::SPIparseStatus(uint8_t in) {
-  if((in & 0b00001110) == RADIOLIB_SX128X_STATUS_CMD_TIMEOUT) {
+  if((in & 0b00011100) == RADIOLIB_SX128X_STATUS_CMD_TIMEOUT) {
     return(RADIOLIB_ERR_SPI_CMD_TIMEOUT);
-  } else if((in & 0b00001110) == RADIOLIB_SX128X_STATUS_CMD_ERROR) {
+  } else if((in & 0b00011100) == RADIOLIB_SX128X_STATUS_CMD_ERROR) {
     return(RADIOLIB_ERR_SPI_CMD_INVALID);
-  } else if((in & 0b00001110) == RADIOLIB_SX128X_STATUS_CMD_FAILED) {
+  } else if((in & 0b00011100) == RADIOLIB_SX128X_STATUS_CMD_FAILED) {
     return(RADIOLIB_ERR_SPI_CMD_FAILED);
   } else if((in == 0x00) || (in == 0xFF)) {
     return(RADIOLIB_ERR_CHIP_NOT_FOUND);


### PR DESCRIPTION
In `SX128x::SPIparseStatus` the bit mask to check the command status is incorrect, it's checking bits 3:1 when the documentation says that are 4:2
![image](https://github.com/jgromes/RadioLib/assets/1191573/026132dd-4646-4517-ba75-eb7f6bfe0404)

You can replace the constants and clearly see that they don't make sense
```c++
if((status & 0b00001110) == RADIOLIB_SX128X_STATUS_CMD_TIMEOUT)
if((status & 0b00001110) == RADIOLIB_SX128X_STATUS_CMD_ERROR)
if((status & 0b00001110) == RADIOLIB_SX128X_STATUS_CMD_FAILED)
// replacing the constant becomes
if((status & 0b00001110) == 0b00001100)
if((status & 0b00001110) == 0b00010000)
if((status & 0b00001110) == 0b00010100)
```