### PR TITLE
Enabling ACK support for LoRaWAN frames.

### DIFF
--- a/src/protocols/LoRaWAN/LoRaWAN.cpp
+++ b/src/protocols/LoRaWAN/LoRaWAN.cpp
@@ -499,16 +499,16 @@ int16_t LoRaWANNode::beginABP(uint32_t addr, uint8_t* nwkSKey, uint8_t* appSKey,
 }
 
 #if defined(RADIOLIB_BUILD_ARDUINO)
-int16_t LoRaWANNode::uplink(String& str, uint8_t port) {
-  return(this->uplink(str.c_str(), port));
+int16_t LoRaWANNode::uplink(String& str, uint8_t port, bool confirm) {
+  return(this->uplink(str.c_str(), port, confirm));
 }
 #endif
 
-int16_t LoRaWANNode::uplink(const char* str, uint8_t port) {
-  return(this->uplink((uint8_t*)str, strlen(str), port));
+int16_t LoRaWANNode::uplink(const char* str, uint8_t port, bool confirm) {
+  return(this->uplink((uint8_t*)str, strlen(str), port, confirm));
 }
 
-int16_t LoRaWANNode::uplink(uint8_t* data, size_t len, uint8_t port) {
+int16_t LoRaWANNode::uplink(uint8_t* data, size_t len, uint8_t port, bool confirm) {
   // check destination port
   if(port > 0xDF) {
     return(RADIOLIB_ERR_INVALID_PORT);
@@ -559,7 +559,7 @@ int16_t LoRaWANNode::uplink(uint8_t* data, size_t len, uint8_t port) {
   #endif
   
   // set the packet fields
-  uplinkMsg[RADIOLIB_LORAWAN_FHDR_LEN_START_OFFS] = RADIOLIB_LORAWAN_MHDR_MTYPE_UNCONF_DATA_UP | RADIOLIB_LORAWAN_MHDR_MAJOR_R1;
+  uplinkMsg[RADIOLIB_LORAWAN_FHDR_LEN_START_OFFS] = (confirm ? RADIOLIB_LORAWAN_MHDR_MTYPE_CONF_DATA_UP : RADIOLIB_LORAWAN_MHDR_MTYPE_UNCONF_DATA_UP) | RADIOLIB_LORAWAN_MHDR_MAJOR_R1;
   LoRaWANNode::hton<uint32_t>(&uplinkMsg[RADIOLIB_LORAWAN_FHDR_DEV_ADDR_POS], this->devAddr);
 
   // TODO implement adaptive data rate

--- a/src/protocols/LoRaWAN/LoRaWAN.h
+++ b/src/protocols/LoRaWAN/LoRaWAN.h
@@ -363,27 +363,30 @@ class LoRaWANNode {
       \brief Send a message to the server.
       \param str Address of Arduino String that will be transmitted.
       \param port Port number to send the message to.
+      \param confirm Whether or not an ACK is requested for the message.
       \returns \ref status_codes
     */
-    int16_t uplink(String& str, uint8_t port);
+    int16_t uplink(String& str, uint8_t port, bool confirm=false);
     #endif
 
     /*!
       \brief Send a message to the server.
       \param str C-string that will be transmitted.
       \param port Port number to send the message to.
+      \param confirm Whether or not an ACK is requested for the message.
       \returns \ref status_codes
     */
-    int16_t uplink(const char* str, uint8_t port);
+    int16_t uplink(const char* str, uint8_t port, bool confirm=false);
 
     /*!
       \brief Send a message to the server.
       \param data Data to send.
       \param len Length of the data.
       \param port Port number to send the message to.
+      \param confirm Whether or not an ACK is requested for the message.
       \returns \ref status_codes
     */
-    int16_t uplink(uint8_t* data, size_t len, uint8_t port);
+    int16_t uplink(uint8_t* data, size_t len, uint8_t port, bool confirm=false);
 
     #if defined(RADIOLIB_BUILD_ARDUINO)
     /*!


### PR DESCRIPTION
To the best of my knowledge, there isn't yet support to send frames with a request for ACK from the network server. This pull request makes an effort to enable an ACK request per frame by calling `node.uplink(strUp, 10, true);` from user space. This does not break existing functionality. I have tested this using the SX1262 radio and the Actility Thingpark Network server. The functionality seems to be working well.

Acknowledgement: I thank Jansen Christian Liando for his advice on how to enable this. 

As always, I welcome feedback.