### PR TITLE
LoRaWAN OTAA example fix

### DIFF
--- a/examples/LoRaWAN/LoRaWAN_End_Device/LoRaWAN_End_Device.ino
+++ b/examples/LoRaWAN/LoRaWAN_End_Device/LoRaWAN_End_Device.ino
@@ -111,7 +111,7 @@ void setup() {
   // by calling "begin"
   /*
     Serial.print(F("[LoRaWAN] Resuming previous session ... "));
-    state = node.begin();
+    state = node.restoreOTAA();
     if(state == RADIOLIB_ERR_NONE) {
       Serial.println(F("success!"));
     } else {


### PR DESCRIPTION
node.begin(); does not exist anymore, in OTAA speech, this should be node.restoreOTAA();. However, I am unsure what should be the correct way to fix the ABP example.