### PR TITLE
Fixed Persistent Storage Issue for RP2040 with Arduino Pico Framework

### DIFF
--- a/src/ArduinoHal.cpp
+++ b/src/ArduinoHal.cpp
@@ -104,7 +104,7 @@ void inline ArduinoHal::spiEnd() {
 
 void ArduinoHal::readPersistentStorage(uint32_t addr, uint8_t* buff, size_t len) {
   #if !defined(RADIOLIB_EEPROM_UNSUPPORTED)
-    #if defined(RADIOLIB_ESP32)
+    #if defined(RADIOLIB_ESP32) || defined(ARDUINO_ARCH_RP2040)
       EEPROM.begin(RADIOLIB_HAL_PERSISTENT_STORAGE_SIZE);
     #elif defined(ARDUINO_ARCH_APOLLO3)
       EEPROM.init();
@@ -112,7 +112,7 @@ void ArduinoHal::readPersistentStorage(uint32_t addr, uint8_t* buff, size_t len)
     for(size_t i = 0; i < len; i++) {
       buff[i] = EEPROM.read(addr + i);
     }
-    #if defined(RADIOLIB_ESP32)
+    #if defined(RADIOLIB_ESP32) || defined(ARDUINO_ARCH_RP2040)
       EEPROM.end();
     #endif
   #endif
@@ -120,7 +120,7 @@ void ArduinoHal::readPersistentStorage(uint32_t addr, uint8_t* buff, size_t len)
 
 void ArduinoHal::writePersistentStorage(uint32_t addr, uint8_t* buff, size_t len) {
   #if !defined(RADIOLIB_EEPROM_UNSUPPORTED)
-    #if defined(RADIOLIB_ESP32)
+    #if defined(RADIOLIB_ESP32) || defined(ARDUINO_ARCH_RP2040)
       EEPROM.begin(RADIOLIB_HAL_PERSISTENT_STORAGE_SIZE);
     #elif defined(ARDUINO_ARCH_APOLLO3)
       EEPROM.init();
@@ -128,7 +128,7 @@ void ArduinoHal::writePersistentStorage(uint32_t addr, uint8_t* buff, size_t len
     for(size_t i = 0; i < len; i++) {
       EEPROM.write(addr + i, buff[i]);
     }
-    #if defined(RADIOLIB_ESP32)
+    #if defined(RADIOLIB_ESP32) || defined(ARDUINO_ARCH_RP2040)
       EEPROM.commit();
       EEPROM.end();
     #endif


### PR DESCRIPTION
RP2040 does not have an EEPROM but always reserves the last 4K chunk of the flash for a software EEPROM - given the Arduino Pico framework is in use. It is exactly handled as ESP32 "SoftEEPROMs", meaning it does copy the "flashEEPROM" to memory on .begin(); and does need to .commit(); to write it back. We saw in the past that a node could successfully get an OTAA on a RP2040, but could never re-join - due to the missing commit and wrong init - which is with that fixed. As the "SoftEEPROM" is always written at the end of the flash, it also survives an Arduino Sketch reflash if not wiped afterwards by node.wipe(); More info and documentation here: https://arduino-pico.readthedocs.io/en/latest/eeprom.html