### PR TITLE
[LoRaWAN] Add datarate into event structure

### DIFF
--- a/examples/LoRaWAN/LoRaWAN_End_Device_Reference/LoRaWAN_End_Device_Reference.ino
+++ b/examples/LoRaWAN/LoRaWAN_End_Device_Reference/LoRaWAN_End_Device_Reference.ino
@@ -214,6 +214,8 @@ void loop() {
     Serial.println(event.confirmed);
     Serial.print(F("[LoRaWAN] Confirming:\t"));
     Serial.println(event.confirming);
+    Serial.print(F("[LoRaWAN] Datarate:\t"));
+    Serial.print(event.datarate);
     Serial.print(F("[LoRaWAN] Frequency:\t"));
     Serial.print(event.freq, 3);
     Serial.println(F(" MHz"));

--- a/keywords.txt
+++ b/keywords.txt
@@ -300,6 +300,7 @@ sendReceive	KEYWORD2
 setDeviceStatus	KEYWORD2
 setDatarate	KEYWORD2
 setADR	KEYWORD2
+setTxPower	KEYWORD2
 selectSubband	KEYWORD2
 setCSMA	KEYWORD2
 

--- a/src/protocols/LoRaWAN/LoRaWAN.cpp
+++ b/src/protocols/LoRaWAN/LoRaWAN.cpp
@@ -904,6 +904,7 @@ int16_t LoRaWANNode::uplink(uint8_t* data, size_t len, uint8_t port, bool isConf
     event->dir = RADIOLIB_LORAWAN_CHANNEL_DIR_UPLINK;
     event->confirmed = isConfirmed;
     event->confirming = isConfirmingDown;
+    event->datarate = this->dataRates[RADIOLIB_LORAWAN_CHANNEL_DIR_UPLINK];
     event->freq = currentChannels[event->dir].freq;
     event->power = this->txPwrCur;
     event->fcnt = this->fcntUp;
@@ -1262,6 +1263,7 @@ int16_t LoRaWANNode::downlink(uint8_t* data, size_t* len, LoRaWANEvent_t* event)
     event->dir = RADIOLIB_LORAWAN_CHANNEL_DIR_DOWNLINK;
     event->confirmed = isConfirmedDown;
     event->confirming = isConfirmingUp;
+    event->datarate = this->dataRates[RADIOLIB_LORAWAN_CHANNEL_DIR_DOWNLINK];
     event->freq = currentChannels[event->dir].freq;
     event->power = this->txPwrCur;
     event->fcnt = isAppDownlink ? this->aFcntDown : this->nFcntDown;

--- a/src/protocols/LoRaWAN/LoRaWAN.h
+++ b/src/protocols/LoRaWAN/LoRaWAN.h
@@ -325,6 +325,9 @@ struct LoRaWANEvent_t {
   /*! \brief Whether the event is confirming a previous request
   (e.g., server downlink reply to confirmed uplink sent by user application)*/
   bool confirming;
+
+  /*! \brief Datarate */
+  uint8_t datarate;
   
   /*! \brief Frequency in MHz */
   float freq;

--- a/src/protocols/LoRaWAN/LoRaWAN.h
+++ b/src/protocols/LoRaWAN/LoRaWAN.h
@@ -532,10 +532,17 @@ class LoRaWANNode {
     int16_t setDatarate(uint8_t drUp);
 
     /*!
-      \brief Toggle ADR to on or off
-      \param enable Whether to disable ADR or not
+      \brief Toggle ADR to on or off.
+      \param enable Whether to disable ADR or not.
     */
     void setADR(bool enable = true);
+
+    /*!
+      \brief Configure TX power of the radio module.
+      \param txPower Output power during TX mode to be set in dBm.
+      \returns \ref status_codes
+    */
+    int16_t setTxPower(int8_t txPower);
 
     /*!
       \brief Select a single subband (8 channels) for fixed bands such as US915.


### PR DESCRIPTION
As ADR can change the configured datarate, and for some bands the uplink datarate can be different to the downlink datarate, I think it is useful to be able to retrieve this using the event structure.

Yeah I'm not much of a Git expert so I messed up something with the commits while synchronizing the forks - it's now mislabelled previous commits as part of this PR but actually it's just one.