### PR TITLE
Maintain consistency across SX126x and SX128x with macro rename

### DIFF
--- a/src/modules/SX128x/SX128x.h
+++ b/src/modules/SX128x/SX128x.h
@@ -310,7 +310,7 @@
 #define RADIOLIB_SX128X_PACKET_STATUS_SYNC_DET_3                0b00000100  //  2     0                            detected sync word 3
 
 //RADIOLIB_SX128X_CMD_SET_DIO_IRQ_PARAMS
-#define RADIOLIB_SX128X_IRQ_RADIOLIB_PREAMBLE_DETECTED          0x8000      //  15    15  interrupt source: preamble detected
+#define RADIOLIB_SX128X_IRQ_PREAMBLE_DETECTED                   0x8000      //  15    15  interrupt source: preamble detected
 #define RADIOLIB_SX128X_IRQ_ADVANCED_RANGING_DONE               0x8000      //  15    15                    advanced ranging done
 #define RADIOLIB_SX128X_IRQ_RX_TX_TIMEOUT                       0x4000      //  14    14                    Rx or Tx timeout
 #define RADIOLIB_SX128X_IRQ_CAD_DETECTED                        0x2000      //  13    13                    channel activity detected


### PR DESCRIPTION
See https://github.com/jgromes/RadioLib/commit/82258105b798bc3e2a57a3de42d8a44e370f16a1#r133872034