### PR TITLE
LoRaWAN: Fix broken node when memory is dynamically allocated

### DIFF
--- a/src/protocols/LoRaWAN/LoRaWAN.h
+++ b/src/protocols/LoRaWAN/LoRaWAN.h
@@ -350,7 +350,7 @@ class LoRaWANNode {
   public:
 
     // Offset between TX and RX1 (such that RX1 has equal or lower DR)
-    uint8_t rx1DrOffset;
+    uint8_t rx1DrOffset = 0;
 
     // RX2 channel properties - may be changed by MAC command
     LoRaWANChannel_t rx2;
@@ -616,7 +616,7 @@ class LoRaWANNode {
     uint32_t adrFcnt = 0;
 
     // whether the current configured channel is in FSK mode
-    bool FSK;
+    bool FSK = false;
 
     // flag that shows whether the device is joined and there is an ongoing session
     bool isJoinedFlag = false;


### PR DESCRIPTION
Hi!

I observed that two variables are not initialized correctly during LoRaWAN object creation.
Basic example does work because object is precreated during firmware startup so memory is zeroed.
When I create LoRaWAN object during program runtime node either fails to init or fails during OTAA. My changes fixed this behavior. 