### PR TITLE
[LoRaWAN] Fix ABP initialization, support MAC in payload

### DIFF
--- a/src/protocols/LoRaWAN/LoRaWAN.cpp
+++ b/src/protocols/LoRaWAN/LoRaWAN.cpp
@@ -1194,7 +1194,7 @@ int16_t LoRaWANNode::downlink(uint8_t* data, size_t* len, LoRaWANEvent_t* event)
   // process FOpts (if there are any)
   if(foptsLen > 0) {
     // there are some Fopts, decrypt them
-    uint8_t fopts[max(RADIOLIB_LORAWAN_FHDR_FOPTS_LEN_MASK, (int)foptsLen)];
+    uint8_t fopts[RADIOLIB_MAX(RADIOLIB_LORAWAN_FHDR_FOPTS_LEN_MASK, (int)foptsLen)];
 
     // TODO it COULD be the case that the assumed FCnt rollover is incorrect, if possible figure out a way to catch this and retry with just fcnt16
     // if there are <= 15 bytes of FOpts, they are in the FHDR, otherwise they are in the payload
@@ -1216,7 +1216,7 @@ int16_t LoRaWANNode::downlink(uint8_t* data, size_t* len, LoRaWANEvent_t* event)
       LoRaWANMacCommand_t cmd = {
         .cid = *foptsPtr,
         .payload = { 0 },
-        .len = (uint8_t)min((remLen - 1), 5),
+        .len = (uint8_t)RADIOLIB_MIN((remLen - 1), 5),
         .repeat = 0,
       };
       memcpy(cmd.payload, foptsPtr + 1, cmd.len);


### PR DESCRIPTION
* ABP initialization was not working, but is now fixed and tested working.
* When there are more than 15 bytes of MAC payload, this was not handled as MAC payload but as application payload. Now, this is recognized by looking at the FPort and handled accordingly. This fix is very relevant for ABP devices, which cause a very fat downlink (of 43 MAC bytes in my case).

This fat downlink of 9 MAC commands causes a response of 18 MAC bytes which is currently not processed correctly (it should trigger a MAC-only uplink at FPort 0); currently, it just fills the available 15 bytes of FOpts, which causes a second downlink that will request the remaining MAC payload. I will work on a fix, but this is quite workable for now. 

**_Please make sure that you are in good reach of a gateway when you initialize an ABP device to prevent endless downlinks_**.

Fixes #912 and by extent #904 