### PR TITLE
fix warning/error: compound assignment with 'volatile'-qualified left operand is deprecated

### DIFF
--- a/src/modules/RF69/RF69.cpp
+++ b/src/modules/RF69/RF69.cpp
@@ -375,7 +375,7 @@ bool RF69::fifoGet(volatile uint8_t* data, int totalLen, volatile int* rcvLen) {
 
   // get the data
   this->mod->SPIreadRegisterBurst(RADIOLIB_RF69_REG_FIFO, len, dataPtr);
-  (*rcvLen) += (len);
+  *rcvLen = *rcvLen + len;
 
   // check if we're done
   if(*rcvLen >= totalLen) {

--- a/src/modules/SX127x/SX127x.cpp
+++ b/src/modules/SX127x/SX127x.cpp
@@ -542,7 +542,7 @@ bool SX127x::fifoGet(volatile uint8_t* data, int totalLen, volatile int* rcvLen)
 
   // get the data
   this->mod->SPIreadRegisterBurst(RADIOLIB_SX127X_REG_FIFO, len, dataPtr);
-  (*rcvLen) += (len);
+  *rcvLen = *rcvLen + len;
 
   // check if we're done
   if(*rcvLen >= totalLen) {


### PR DESCRIPTION
I am compiling my projects with `build_flags = -Werror -Wall` and I just found this error on the two places:

```
error: compound assignment with 'volatile'-qualified left operand is deprecated [-Werror=volatile]
```

this PR is to fix this warning/error.