### PR TITLE
[LoRaWAN] Fix session restore throwing unnecessary error

### DIFF
--- a/examples/LoRaWAN/LoRaWAN_End_Device/LoRaWAN_End_Device.ino
+++ b/examples/LoRaWAN/LoRaWAN_End_Device/LoRaWAN_End_Device.ino
@@ -102,7 +102,7 @@ void setup() {
   Serial.print(F("[LoRaWAN] Attempting over-the-air activation ... "));
   state = node.beginOTAA(joinEUI, devEUI, nwkKey, appKey);
 
-  if(state == RADIOLIB_ERR_NONE) {
+  if(state >= RADIOLIB_ERR_NONE) {
     Serial.println(F("success!"));
   } else {
     Serial.print(F("failed, code "));

--- a/examples/LoRaWAN/LoRaWAN_End_Device_ABP/LoRaWAN_End_Device_ABP.ino
+++ b/examples/LoRaWAN/LoRaWAN_End_Device_ABP/LoRaWAN_End_Device_ABP.ino
@@ -110,7 +110,7 @@ void setup() {
   // start the device by directly providing the encryption keys and device address
   Serial.print(F("[LoRaWAN] Attempting over-the-air activation ... "));
   state = node.beginABP(devAddr, nwkSKey, appSKey, fNwkSIntKey, sNwkSIntKey);
-  if(state == RADIOLIB_ERR_NONE) {
+  if(state >= RADIOLIB_ERR_NONE) {
     Serial.println(F("success!"));
   } else {
     Serial.print(F("failed, code "));

--- a/examples/LoRaWAN/LoRaWAN_End_Device_Reference/LoRaWAN_End_Device_Reference.ino
+++ b/examples/LoRaWAN/LoRaWAN_End_Device_Reference/LoRaWAN_End_Device_Reference.ino
@@ -100,7 +100,7 @@ void setup() {
   Serial.print(F("[LoRaWAN] Attempting over-the-air activation ... "));
   state = node.beginOTAA(joinEUI, devEUI, nwkKey, appKey);
 
-  if(state == RADIOLIB_ERR_NONE) {
+  if(state >= RADIOLIB_ERR_NONE) {
     Serial.println(F("success!"));
   } else {
     Serial.print(F("failed, code "));

--- a/src/protocols/LoRaWAN/LoRaWAN.cpp
+++ b/src/protocols/LoRaWAN/LoRaWAN.cpp
@@ -65,17 +65,17 @@ int16_t LoRaWANNode::restore() {
   // }
   (void)nvm_table_version;
 
-  // check the magic value
-  uint8_t lwMode = mod->hal->getPersistentParameter<uint8_t>(RADIOLIB_EEPROM_LORAWAN_MODE_ID);
+  // check the mode value
+  uint16_t lwMode = mod->hal->getPersistentParameter<uint16_t>(RADIOLIB_EEPROM_LORAWAN_MODE_ID);
   if(lwMode == RADIOLIB_LORAWAN_MODE_NONE) {
     #if RADIOLIB_DEBUG
-      RADIOLIB_DEBUG_PRINTLN("magic id not set (no saved session)");
+      RADIOLIB_DEBUG_PRINTLN("mode value not set (no saved session)");
       RADIOLIB_DEBUG_PRINTLN("first 16 bytes of NVM:");
       uint8_t nvmBuff[16];
       mod->hal->readPersistentStorage(mod->hal->getPersistentAddr(0), nvmBuff, 16);
       RADIOLIB_DEBUG_HEXDUMP(nvmBuff, 16);
     #endif
-    // the magic value is not set, user will have to do perform the join procedure
+    // the mode value is not set, user will have to do perform the join procedure
     return(RADIOLIB_ERR_NETWORK_NOT_JOINED);
   }
   
@@ -396,7 +396,7 @@ int16_t LoRaWANNode::beginOTAA(uint64_t joinEUI, uint64_t devEUI, uint8_t* nwkKe
     return(this->restore());
   } else {
     #if RADIOLIB_DEBUG
-      RADIOLIB_DEBUG_PRINTLN("Failed to restore session (checksum: %d, mode: %d)", validCheckSum, validMode);
+      RADIOLIB_DEBUG_PRINTLN("Didn't restore session (checksum: %d, mode: %d)", validCheckSum, validMode);
       RADIOLIB_DEBUG_PRINTLN("First 16 bytes of NVM:");
       uint8_t nvmBuff[16];
       mod->hal->readPersistentStorage(mod->hal->getPersistentAddr(0), nvmBuff, 16);
@@ -683,7 +683,7 @@ int16_t LoRaWANNode::beginABP(uint32_t addr, uint8_t* nwkSKey, uint8_t* appSKey,
     return(this->restore());
   } else {
     #if RADIOLIB_DEBUG
-      RADIOLIB_DEBUG_PRINTLN("Failed to restore session (checksum: %d, mode: %d)", validCheckSum, validMode);
+      RADIOLIB_DEBUG_PRINTLN("Didn't restore session (checksum: %d, mode: %d)", validCheckSum, validMode);
       RADIOLIB_DEBUG_PRINTLN("First 16 bytes of NVM:");
       uint8_t nvmBuff[16];
       mod->hal->readPersistentStorage(mod->hal->getPersistentAddr(0), nvmBuff, 16);


### PR DESCRIPTION
If a session is stored, the value returned by `beginOTAA()`, `beginABP()` and `restore()` is positive, returning the active mode (OTAA / ABP). This was not handled correctly. Plus reading this mode value from NVM was done in only 1 byte width. From #935 it appears this was accidentally not a relevant bug, fortunately.