### PR TITLE
[LoRaWAN] Fix channel logic: for fixed bands, persistence of dynamic bands, rejoining during active session

### DIFF
--- a/src/protocols/LoRaWAN/LoRaWAN.cpp
+++ b/src/protocols/LoRaWAN/LoRaWAN.cpp
@@ -1849,13 +1849,11 @@ int16_t LoRaWANNode::processCFList(uint8_t* cfList) {
     for(size_t chMaskCntl = 0; chMaskCntl < numChMasks; chMaskCntl++) {
       cmd.len = MacTable[RADIOLIB_LORAWAN_MAC_LINK_ADR].lenDn;
       cmd.payload[3] = chMaskCntl << 4;               // NbTrans = 0 -> keep the same
+      cmd.repeat = (chMaskCntl + 1);
       memcpy(&cmd.payload[1], &cfList[chMaskCntl*2], 2);
       (void)execMacCommand(&cmd);
-      // save the response as a MAC answer, as this signals execMacCommand() to store the masks contiguously
-      pushMacCommand(&cmd, &this->commandsUp);
     }
     // delete the ADR response
-    (void)deleteMacCommand(RADIOLIB_LORAWAN_MAC_LINK_ADR, &this->commandsUp);
   }
 
   return(RADIOLIB_ERR_NONE);
@@ -2246,11 +2244,11 @@ bool LoRaWANNode::execMacCommand(LoRaWANMacCommand_t* cmd, bool saveToEeprom) {
             // if this is the first ADR command in the queue, clear all saved channels
             // so we can apply the new channel mask
             clearChannels = true;
+            RADIOLIB_DEBUG_PRINTLN("ADR mask: clearing channels");
           } else {
             // if this is not the first ADR command, clear the ADR response that was in the queue
             (void)deleteMacCommand(RADIOLIB_LORAWAN_MAC_LINK_ADR, &this->commandsUp);
           }
-          RADIOLIB_DEBUG_PRINTLN("ADR mask: clearing channels");
           chMaskAck = (uint8_t)this->applyChannelMaskFix(chMaskCntl, chMask, clearChannels);
 
         }

--- a/src/protocols/LoRaWAN/LoRaWAN.cpp
+++ b/src/protocols/LoRaWAN/LoRaWAN.cpp
@@ -2278,6 +2278,10 @@ bool LoRaWANNode::execMacCommand(LoRaWANMacCommand_t* cmd, bool saveToEeprom) {
         if((cmd->payload[3] >> 7) == 1) {
           mod->hal->readPersistentStorage(mod->hal->getPersistentAddr(RADIOLIB_EEPROM_LORAWAN_LINK_ADR_ID) + 1, &(cmd->payload[1]), 3);
         }
+        // if there was no channel mask (all zeroes), we should never apply that channel mask, so set RFU bit again
+        if(cmd->payload[1] == 0 && cmd->payload[2] == 0) {
+          cmd->payload[3] |= (1 << 7);
+        }
 
         // save to the single ADR MAC location
         mod->hal->writePersistentStorage(mod->hal->getPersistentAddr(RADIOLIB_EEPROM_LORAWAN_LINK_ADR_ID), &(cmd->payload[0]), payLen);

--- a/src/protocols/LoRaWAN/LoRaWAN.cpp
+++ b/src/protocols/LoRaWAN/LoRaWAN.cpp
@@ -277,6 +277,11 @@ int16_t LoRaWANNode::restoreChannels() {
 #endif
 
 void LoRaWANNode::beginCommon(uint8_t joinDr) {
+  // in case a new session is started while there is an ongoing session
+  // clear the MAC queues completely
+  memset(&(this->commandsUp), 0, sizeof(LoRaWANMacCommandQueue_t));
+  memset(&(this->commandsDown), 0, sizeof(LoRaWANMacCommandQueue_t));
+
   LoRaWANMacCommand_t cmd = {
     .cid = RADIOLIB_LORAWAN_MAC_LINK_ADR,
     .payload = { 0 }, 
@@ -1732,6 +1737,11 @@ int16_t LoRaWANNode::setupChannelsDyn(bool joinRequest) {
       this->availableChannels[RADIOLIB_LORAWAN_CHANNEL_DIR_DOWNLINK][num] = this->band->txFreqs[num];
       RADIOLIB_DEBUG_PRINTLN("Channel UL/DL %d frequency = %f MHz", this->availableChannels[RADIOLIB_LORAWAN_CHANNEL_DIR_UPLINK][num].idx, this->availableChannels[RADIOLIB_LORAWAN_CHANNEL_DIR_UPLINK][num].freq);
     }
+  }
+
+  // clear all remaining channels
+  for(; num < RADIOLIB_LORAWAN_NUM_AVAILABLE_CHANNELS; num++) {
+    this->availableChannels[RADIOLIB_LORAWAN_CHANNEL_DIR_UPLINK][num] = RADIOLIB_LORAWAN_CHANNEL_NONE;
   }
   
   return(RADIOLIB_ERR_NONE);

--- a/src/protocols/LoRaWAN/LoRaWAN.cpp
+++ b/src/protocols/LoRaWAN/LoRaWAN.cpp
@@ -1918,7 +1918,7 @@ int16_t LoRaWANNode::setDatarate(uint8_t drUp, bool saveToEeprom) {
   for(size_t i = 0; i < RADIOLIB_LORAWAN_NUM_AVAILABLE_CHANNELS; i++) {
     LoRaWANChannel_t *chnl = &(this->availableChannels[RADIOLIB_LORAWAN_CHANNEL_DIR_UPLINK][i]);
     if(chnl->enabled) {
-      if(drUp > chnl->drMin && drUp < chnl->drMax) {
+      if(drUp >= chnl->drMin && drUp <= chnl->drMax) {
         isValidDR = true;
         break;
       }

--- a/src/protocols/LoRaWAN/LoRaWAN.cpp
+++ b/src/protocols/LoRaWAN/LoRaWAN.cpp
@@ -2026,7 +2026,7 @@ int16_t LoRaWANNode::setTxPower(int8_t txPower, bool saveToEeprom) {
   // Tx Power is set in steps of two
   // the selected value is rounded down to nearest multiple of two away from txPowerMax
   // e.g. on EU868, max is 16; if 13 is selected then we set to 12
-  uint8_t txPowerNew = (this->txPowerMax - txPower) / 2 + 1;
+  uint8_t numSteps = (this->txPowerMax - txPower + 1) / (-RADIOLIB_LORAWAN_POWER_STEP_SIZE_DBM);
 
   LoRaWANMacCommand_t cmd = {
     .cid = RADIOLIB_LORAWAN_MAC_LINK_ADR,
@@ -2035,7 +2035,7 @@ int16_t LoRaWANNode::setTxPower(int8_t txPower, bool saveToEeprom) {
     .repeat = 0,
   };
   cmd.payload[0]  = 0xF0;               // keep datarate the same
-  cmd.payload[0] |= txPowerNew;         // set the Tx Power
+  cmd.payload[0] |= numSteps;           // set the Tx Power
   cmd.payload[3]  = (1 << 7);           // set the RFU bit, which means that the channel mask gets ignored
   cmd.payload[3] |= 0;                  // keep NbTrans the same
   (void)execMacCommand(&cmd, saveToEeprom);


### PR DESCRIPTION
Under various situations the channel logic was not completely tight. Thanks to @jerryneedell for verifying and debugging fixed-band behavior in #935. This PR also fixes bugs on sessions with ADR disabled, as after restore, all channels were masked away. Moreover, rejoining on OTAA during an active session didn't clear the MAC command queue (they piled up) and remained stored channels in the availableChannels structure.

As of 6.4.0, only specific sessions work well (with ADR enabled _or_ without restoring the session, without rejoining during active session). I would suggest a bugfix release to 6.4.1, although that's completely up to you. I have no idea what your policy is around this sort of stuff :)