### PR TITLE
include esp_attr.h where IRAM_ATTR is used

### DIFF
--- a/src/protocols/LoRaWAN/LoRaWAN.cpp
+++ b/src/protocols/LoRaWAN/LoRaWAN.cpp
@@ -1,5 +1,8 @@
 #include "LoRaWAN.h"
 #include <string.h>
+#if defined(ESP8266) || defined(ESP32)
+#include "esp_attr.h"
+#endif
 
 #if !RADIOLIB_EXCLUDE_LORAWAN
 

--- a/src/protocols/Pager/Pager.cpp
+++ b/src/protocols/Pager/Pager.cpp
@@ -1,6 +1,10 @@
 #include "Pager.h"
 #include <string.h>
 #include <math.h>
+#if defined(ESP8266) || defined(ESP32)
+#include "esp_attr.h"
+#endif
+
 #if !RADIOLIB_EXCLUDE_PAGER
 
 #if !RADIOLIB_EXCLUDE_DIRECT_RECEIVE


### PR DESCRIPTION
These two commits contain a small fix in two files that allowed my PlatformIO project to build.

They reference `IRAM_ATTR` attribute, but do not not include esp_attr.h; now they do, with the same ifdef guard as the attributes themselves.

If this issue is not apparent for other people and only my system is wrong, feel free to close this request.