### PR TITLE
IDF Component Registry manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ extras/SX126x_Spectrum_Scan/out/*
 
 # cmake
 build/
+
+# Compote build output
+dist

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,0 +1,11 @@
+version: "6.4.2"
+description: "Universal wireless communication library. User-friendly library for sub-GHz radio modules (SX1278, RF69, CC1101, SX1268, and many others), as well as ham radio digital modes (RTTY, SSTV, AX.25 etc.) and other protocols (Pagers, LoRaWAN)."
+tags: "radio, communication, morse, cc1101, aprs, sx1276, sx1278, sx1272, rtty, ax25, afsk, nrf24, rfm96, sx1231, rfm96, rfm98, sstv, sx1278, sx1272, sx1276, sx1280, sx1281, sx1282, sx1261, sx1262, sx1268, si4432, rfm22, llcc68, pager, pocsag, lorawan"
+url: "https://github.com/jgromes/RadioLib"
+repository: "https://github.com/jgromes/RadioLib.git"""
+license: "MIT"
+dependencies:
+  # Required IDF version
+  idf: ">=4.1"
+maintainers:
+  "Jan Gromeš <gromes.jan@gmail.com>"

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -2,7 +2,7 @@ version: "6.4.2"
 description: "Universal wireless communication library. User-friendly library for sub-GHz radio modules (SX1278, RF69, CC1101, SX1268, and many others), as well as ham radio digital modes (RTTY, SSTV, AX.25 etc.) and other protocols (Pagers, LoRaWAN)."
 tags: "radio, communication, morse, cc1101, aprs, sx1276, sx1278, sx1272, rtty, ax25, afsk, nrf24, rfm96, sx1231, rfm96, rfm98, sstv, sx1278, sx1272, sx1276, sx1280, sx1281, sx1282, sx1261, sx1262, sx1268, si4432, rfm22, llcc68, pager, pocsag, lorawan"
 url: "https://github.com/jgromes/RadioLib"
-repository: "https://github.com/jgromes/RadioLib.git"""
+repository: "https://github.com/jgromes/RadioLib.git"
 license: "MIT"
 dependencies:
   # Required IDF version


### PR DESCRIPTION
Ok then. 

I added a idf_components.yml and did a --dry-run using compote, it didn't complain, at least. 

So what is done is:
1. Sign in at [components.espressif.com](https://components.espressif.com/). I use Github.
2. In the profile menu, click tokens and create a token. I gave it all the rights as I way looking around the CLI.
3. Add a `~.espressif/idf_component_manager.yml` or equivalent on your platform. 
4. Make it look like:
```
profiles:
  default:
    api_token: "ADD THE FULL TOKEN HERE"
```
5. Now you are logged in on the command line when you run IDF stuff. 
6. In the repository folder, run: `compote component upload --name Radiolib`

If you haven't gotten any errors, you should be able to search for find Radiolib at https://components.espressif.com/ .
I hope I haven't forgotten any steps, is really tired today, but seeing that you seem to work with getting stuff up in space, I am sure you can get stuff up on Espressif as well if I have made some mistake. :-)

Good luck!