### PR TITLE
Added ESP32_RTC_EEPROM and LoraWAN_ESP32_Deep_Sleep example

### DIFF
--- a/examples/LoRaWAN/LoRaWAN_ESP32_Deep_Sleep/LoRaWAN_ESP32_Deep_Sleep.ino
+++ b/examples/LoRaWAN/LoRaWAN_ESP32_Deep_Sleep/LoRaWAN_ESP32_Deep_Sleep.ino
@@ -1,0 +1,196 @@
+/*
+  RadioLib ESP32 Deep Sleep LoRaWAN example
+
+  THIS EXAMPLE ONLY WORKS ON ESP32. It assumes the ESP32 stays powered, but puts
+  it in a very low-power "deep sleep" mode between sends to the network.
+
+  This example joins a LoRaWAN network and will send uplink packets. Before you
+  start, you will have to register your device at
+  https://www.thethingsnetwork.org/ After your device is registered, you can run
+  this example. The device will join the network and start uploading data.
+
+  LoRaWAN v1.1 requires storing parameters persistently. RadioLib does this by
+  using the Arduino EEPROM storage. The ESP32 does not have EEPROM memory, so
+  the Arduino code from Espressif has code that emulates EEPROM in its "NVS"
+  flash key-value storage. This unfortunately means that every change of a
+  single but re- writes the entire emulated "EEPROM" to flash again. 
+
+  That would be great for the occasional configuration change, but we need to
+  keep state after every single interaction with the LoRaWAN network. Flash
+  memory can only be erased and written to a limited number of times. This is
+  why on ESP32 RadioLib stores data using ESP32_RTC_EEPROM, which writes to the
+  memory of the ESP32's onboard Real-Time Clock which is kept powered during the
+  chip's "deep sleep", which uses almost no power.
+
+  This example then backs up that RTC RAM memory to flash
+    a) every time it is woken up with a wiped RTC RAM,
+    b) whenever it receives a downlink packet, or 
+    c) every so many times as set by BACKUP_EVERY.
+
+  This backup is then automatically loaded when the RTC RAM is empty (after a
+  reset or power failure) so that we hang on to enough state information to
+  rejoin the network in a secure manner. 
+
+  For default module settings, see the wiki page
+  https://github.com/jgromes/RadioLib/wiki/Default-configuration
+
+  For full API reference, see the GitHub Pages
+  https://jgromes.github.io/RadioLib/
+
+  For LoRaWAN details, see the wiki page
+  https://github.com/jgromes/RadioLib/wiki/LoRaWAN
+
+
+  Last updated March 2024 for RadioLib 6.4.2
+*/
+
+// Create a backup copy of the RTC RAM to flash every so many times
+#define BACKUP_EVERY 100
+
+// include the library
+#include <RadioLib.h>
+
+// SX1262 has the following pin order:
+// Module(NSS/CS, DIO1, RESET, BUSY)
+SX1262 radio = new Module(8, 14, 12, 13);
+
+// SX1278 has the following pin order:
+// Module(NSS/CS, DIO0, RESET, DIO1)
+// SX1278 radio = new Module(10, 2, 9, 3);
+
+// create the node instance on the EU-868 band
+// using the radio module and the encryption key
+// make sure you are using the correct band
+// based on your geographical location!
+LoRaWANNode node(&radio, &EU868);
+
+// for fixed bands with subband selection
+// such as US915 and AU915, you must specify
+// the subband that matches the Frequency Plan
+// that you selected on your LoRaWAN console
+// LoRaWANNode node(&radio, &US915, 2);
+
+// Variables that are placed in RTC RAM survive deep sleep. This counter tells
+// us how many times we've booted since the last reset or power loss.
+RTC_DATA_ATTR int count = 1;
+
+void setup() {
+  Serial.begin(115200);
+  
+  // initialize radio (SX1262 / SX1278 / ... ) with default settings
+  Serial.print("[Radio] Initializing ... ");
+  int state = radio.begin();
+  if(state == RADIOLIB_ERR_NONE) {
+    Serial.println("success!");
+  } else {
+    Serial.printf("failed, code %i\n", state);
+    while(true);
+  }
+
+  // JoinEUI - previous versions of LoRaWAN called this AppEUI
+  // for development purposes you can use all zeros - see wiki for details
+  uint64_t joinEUI = 0x0000000000000000;
+
+  // DevEUI - The device's Extended Unique Identifier
+  // TTN will generate one for you
+  uint64_t devEUI =  0x----------------;
+
+  // encryption keys used to secure the communication
+  // TTN will generate them for you
+  // see wiki for details on copying & pasting them
+  uint8_t appKey[] = { 0x--, 0x--, 0x--, 0x--, 0x--, 0x--, 0x--, 0x--,   
+                       0x--, 0x--, 0x--, 0x--, 0x--, 0x--, 0x--, 0x-- };
+  uint8_t nwkKey[] = { 0x--, 0x--, 0x--, 0x--, 0x--, 0x--, 0x--, 0x--,   
+                       0x--, 0x--, 0x--, 0x--, 0x--, 0x--, 0x--, 0x-- };
+
+  // Manages uplink intervals to the TTN Fair Use Policy
+  node.setDutyCycle(true, 1250);
+
+  bool gotDownlink = false;
+
+  String strUp;
+  String strDown;
+
+  // Begin the join to the network
+  Serial.print("[LoRaWAN] Attempting over-the-air activation ... ");
+  if (count == 1) {
+    Serial.print(" (forcing join) ");
+    // We're forcing a new join message when we wake up with wiped RTC RAM to
+    // make sure there is no outdated information sent and cmmunications are
+    // restored promptly.
+    state = node.beginOTAA(joinEUI, devEUI, nwkKey, appKey, RADIOLIB_LORAWAN_DATA_RATE_UNUSED, true);
+  } else {
+    state = node.beginOTAA(joinEUI, devEUI, nwkKey, appKey);
+  }
+  if(state >= RADIOLIB_ERR_NONE) {
+    Serial.println("success!");
+    delay(2000);	// small delay between joining and uplink
+  } else if (state == RADIOLIB_LORAWAN_MODE_OTAA){
+    Serial.println("success! (resumed session)");
+  } else {
+    Serial.printf("failed, code %i\n", state);
+    goto sleep;
+  }
+
+  // send uplink to port 10
+  Serial.print("[LoRaWAN] Sending uplink packet ... ");
+  strUp = "Hello! " + String(count);
+  state = node.sendReceive(strUp, 10, strDown);
+  if(state == RADIOLIB_ERR_NONE) {
+    gotDownlink = true;
+    Serial.println("received a downlink!");
+    // print data of the packet (if there are any)
+    Serial.print("[LoRaWAN] Data:\t\t");
+    if(strDown.length() > 0) {
+      Serial.println(strDown);
+    } else {
+      Serial.println("<MAC commands only>");
+    }
+    // print RSSI (Received Signal Strength Indicator)
+    Serial.printf("[LoRaWAN] RSSI:\t%.2f dBm\n", radio.getRSSI());
+    // print SNR (Signal-to-Noise Ratio)
+    Serial.printf("[LoRaWAN] SNR:\t%.2f dB\n", radio.getSNR());
+    // print frequency error
+    Serial.printf("[LoRaWAN] Freq. err.:\t%.2f Hz\n", radio.getFrequencyError());
+  
+  } else if(state == RADIOLIB_ERR_RX_TIMEOUT) {
+    Serial.println();
+
+  } else {
+    Serial.printf("failed, code %i\n", state);
+  }
+
+  // This saves to RTC RAM only, so it will survive deep sleep, but will be lost
+  // on powercycle or reset.
+  node.saveSession();
+
+  // If we woke up with wiped RTC RAM, or received a message, we back it up to
+  // flash.
+  if (count == 1 || gotDownlink == true || count % BACKUP_EVERY == 0) {
+    Serial.println("Saving RTC RAM to NVS flash.");
+    EEPROM.toNVS();
+  }
+  
+  count++;
+
+  // Label to jump to from failed beginOTAA, so we try again later
+  sleep:
+
+  // Determine wait time before sending another packet
+  uint32_t minimumDelay = 300000;                 // try to send once every 5 minutes
+  uint32_t interval = node.timeUntilUplink();     // calculate minimum duty cycle delay (per FUP & law!)
+  uint32_t delayMs = max(interval, minimumDelay); // cannot send faster than duty cycle allows
+  Serial.printf("[LoRaWAN] Next uplink in %i s.\n", Serial.print(delayMs/1000));
+ 
+  // Print message and give it time to get printed
+  Serial.println("Entering deep sleep");
+  delay(100);
+  // Wakeup in microseconds from now
+  esp_sleep_enable_timer_wakeup(delayMs * 1000);
+  // Go to sleep
+  esp_deep_sleep_start();
+}
+
+void loop() {
+  // this code will never be reached
+}

--- a/src/ArduinoHal.cpp
+++ b/src/ArduinoHal.cpp
@@ -2,10 +2,6 @@
 
 #if defined(RADIOLIB_BUILD_ARDUINO)
 
-#if !defined(RADIOLIB_EEPROM_UNSUPPORTED)
-#include <EEPROM.h>
-#endif
-
 ArduinoHal::ArduinoHal(): RadioLibHal(INPUT, OUTPUT, LOW, HIGH, RISING, FALLING), spi(&RADIOLIB_DEFAULT_SPI), initInterface(true) {}
 
 ArduinoHal::ArduinoHal(SPIClass& spi, SPISettings spiSettings): RadioLibHal(INPUT, OUTPUT, LOW, HIGH, RISING, FALLING), spi(&spi), spiSettings(spiSettings) {}

--- a/src/ArduinoHal.h
+++ b/src/ArduinoHal.h
@@ -15,6 +15,14 @@
 
 #include <SPI.h>
 
+#if !defined(RADIOLIB_EEPROM_UNSUPPORTED)
+  #if defined(RADIOLIB_ESP32)
+    #include "utils/ESP32_RTC_EEPROM.h"
+  #else
+    #include <EEPROM.h>
+  #endif
+#endif
+
 /*!
   \class ArduinoHal
   \brief Arduino default hardware abstraction library implementation.

--- a/src/utils/ESP32_RTC_EEPROM.cpp
+++ b/src/utils/ESP32_RTC_EEPROM.cpp
@@ -1,0 +1,430 @@
+/*
+  EEPROM.cpp -originally written by Ivan Grokhotkov as part of the esp8266 
+              core for Arduino environment.
+             -ported by Paolo Becchi to Esp32 from esp8266 EEPROM
+             -Modified by Elochukwu Ifediora <ifedioraelochukwuc@gmail.com>
+             -Converted to nvs lbernstone@gmail.com
+             -Adapted for ESP32_RTC_EEPROM.cpp by Rop Gonggrijp
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "ESP32_RTC_EEPROM.h"
+#include <nvs.h>
+#include <esp_partition.h>
+#include <esp_log.h>
+
+// Wake up with a magic word in there that lets us detect that we're starting from reset or power-down. 
+uint8_t RTC_DATA_ATTR EEPROMClass::_data[EEPROM_SIZE] = { 0x23, 0x42, 0x23, 0x42, 0x23, 0x42, 0x23, 0x42 };
+
+size_t EEPROMClass::_size = EEPROM_SIZE;
+
+bool EEPROMClass::_restored = false;
+
+
+EEPROMClass::EEPROMClass(void)
+{
+}
+
+EEPROMClass::EEPROMClass(uint32_t sector)
+// Only for compatiility, no sectors in RTC RAM!
+{
+}
+
+EEPROMClass::~EEPROMClass() {
+}
+
+bool EEPROMClass::fromNVS() {
+  nvs_handle _handle;
+  char _name[] = EEPROM_FLASH_PARTITION_NAME;
+
+  esp_err_t res = nvs_open(_name, NVS_READWRITE, &_handle);
+  if (res != ESP_OK) {
+      log_e("Unable to open NVS namespace: %d", res);
+      return false;
+  }
+
+  size_t key_size = 0;
+  res = nvs_get_blob(_handle, _name, NULL, &key_size);
+  if(res != ESP_OK && res != ESP_ERR_NVS_NOT_FOUND) {
+      log_e("Unable to read NVS key: %d", res);
+      return false;
+  }
+  if (key_size != _size) {
+      log_e("EEPROM in NVS not same size as EEPROM in RTC RAM");
+      return false;
+  }
+  nvs_get_blob(_handle, _name, _data, &key_size);
+  return true;
+}
+
+bool EEPROMClass::toNVS() {
+  nvs_handle _handle;
+  char _name[] = EEPROM_FLASH_PARTITION_NAME;
+
+  esp_err_t res = nvs_open(_name, NVS_READWRITE, &_handle);
+  if (res != ESP_OK) {
+      log_e("Unable to open NVS namespace: %d", res);
+      return false;
+  }
+
+  res = nvs_set_blob(_handle, _name, _data, _size);
+  if (res != ESP_OK) {
+      log_e("Unable to write NVS key: %d", res);
+      return false;
+  }
+  res = nvs_commit(_handle);
+  if (res != ESP_OK) {
+      log_e("Unable to commit NVS key: %d", res);
+      return false;
+  }
+  nvs_close(_handle);
+  return true;
+}
+
+bool EEPROMClass::wasRestored() {
+  return _restored;
+}
+
+bool EEPROMClass::begin(size_t size) {
+  if (!size || size > EEPROM_SIZE) {
+    return false;
+  }
+  _size = size;
+  // See if we just woke up from reset or power-off
+  uint64_t* magic_word = (uint64_t*) _data;
+  // magic_word reversed because ESP32 is little-endian
+  if (*magic_word == 0x4223422342234223) {
+    log_w("Woke up cold, trying recover RTC EEPROM contents from NVS backup.");
+    // if we did, see if we have a saved copy in NVS (flash)
+    if (!fromNVS()) {
+      log_w("No backup copy found, EEPROM starts with clean slate.");
+      // If not, delete the magic word and start with a clean slate
+      *magic_word = 0;
+    } else {
+      log_w("RTC EEPROM contents recovered from NVS backup.");
+      _restored = true;
+    }
+  }
+  return true;
+}
+
+void EEPROMClass::end()
+{
+}
+
+uint8_t EEPROMClass::read(int address) {
+  if (address < 0 || (size_t)address >= _size) {
+    return 0;
+  }
+  return _data[address];
+}
+
+void EEPROMClass::write(int address, uint8_t value) {
+  if (address < 0 || (size_t)address >= _size)
+    return;
+  _data[address] = value;
+}
+
+bool EEPROMClass::commit() {
+  return true;
+}
+
+uint8_t * EEPROMClass::getDataPtr() {
+  return &_data[0];
+}
+
+/*
+   Get EEPROM total size in byte defined by the user
+*/
+uint16_t EEPROMClass::length () {
+  return _size;
+}
+
+/*
+   Read 'value' from 'address'
+*/
+uint8_t EEPROMClass::readByte (int address)
+{
+  uint8_t value = 0;
+  return EEPROMClass::readAll (address, value);
+}
+
+int8_t EEPROMClass::readChar (int address)
+{
+  int8_t value = 0;
+  return EEPROMClass::readAll (address, value);
+}
+
+uint8_t EEPROMClass::readUChar (int address)
+{
+  uint8_t value = 0;
+  return EEPROMClass::readAll (address, value);
+}
+
+int16_t EEPROMClass::readShort (int address)
+{
+  int16_t value = 0;
+  return EEPROMClass::readAll (address, value);
+}
+
+uint16_t EEPROMClass::readUShort (int address)
+{
+  uint16_t value = 0;
+  return EEPROMClass::readAll (address, value);
+}
+
+int32_t EEPROMClass::readInt (int address)
+{
+  int32_t value = 0;
+  return EEPROMClass::readAll (address, value);
+}
+
+uint32_t EEPROMClass::readUInt (int address)
+{
+  uint32_t value = 0;
+  return EEPROMClass::readAll (address, value);
+}
+
+int32_t EEPROMClass::readLong (int address)
+{
+  int32_t value = 0;
+  return EEPROMClass::readAll (address, value);
+}
+
+uint32_t EEPROMClass::readULong (int address)
+{
+  uint32_t value = 0;
+  return EEPROMClass::readAll (address, value);
+}
+
+int64_t EEPROMClass::readLong64 (int address)
+{
+  int64_t value = 0;
+  return EEPROMClass::readAll (address, value);
+}
+
+uint64_t EEPROMClass::readULong64 (int address)
+{
+  uint64_t value = 0;
+  return EEPROMClass::readAll (address, value);
+}
+
+float_t EEPROMClass::readFloat (int address)
+{
+  float_t value = 0;
+  return EEPROMClass::readAll (address, value);
+}
+
+double_t EEPROMClass::readDouble (int address)
+{
+  double_t value = 0;
+  return EEPROMClass::readAll (address, value);
+}
+
+bool EEPROMClass::readBool (int address)
+{
+  int8_t value = 0;
+  return EEPROMClass::readAll (address, value) ? 1 : 0;
+}
+
+size_t EEPROMClass::readString (int address, char* value, size_t maxLen)
+{
+  if (!value)
+    return 0;
+
+  if (address < 0 || address + maxLen > _size)
+    return 0;
+
+  uint16_t len;
+  for (len = 0; len <= _size; len++)
+    if (_data[address + len] == 0)
+      break;
+
+  if (address + len > _size)
+    return 0;
+
+  if (len > maxLen)
+    return 0; //Maybe return part of the string instead?
+
+  memcpy((uint8_t*) value, _data + address, len);
+  value[len] = 0;
+  return len;
+}
+
+String EEPROMClass::readString (int address)
+{
+  if (address < 0 || address > _size)
+    return String();
+
+  uint16_t len;
+  for (len = 0; len <= _size; len++)
+    if (_data[address + len] == 0)
+      break;
+
+  if (address + len > _size)
+    return String();
+
+  char value[len+1];
+  memcpy((uint8_t*) value, _data + address, len);
+  value[len] = 0;
+  return String(value);
+}
+
+size_t EEPROMClass::readBytes (int address, void* value, size_t maxLen)
+{
+  if (!value || !maxLen)
+    return 0;
+
+  if (address < 0 || address + maxLen > _size)
+    return 0;
+
+  memcpy((void*) value, _data + address, maxLen);
+  return maxLen;
+}
+
+template <class T> T EEPROMClass::readAll (int address, T &value)
+{
+  if (address < 0 || address + sizeof(T) > _size)
+    return value;
+
+  memcpy((uint8_t*) &value, _data + address, sizeof(T));
+  return value;
+}
+
+/*
+   Write 'value' to 'address'
+*/
+size_t EEPROMClass::writeByte (int address, uint8_t value)
+{
+  return EEPROMClass::writeAll (address, value);
+}
+
+size_t EEPROMClass::writeChar (int address, int8_t value)
+{
+  return EEPROMClass::writeAll (address, value);
+}
+
+size_t EEPROMClass::writeUChar (int address, uint8_t value)
+{
+  return EEPROMClass::writeAll (address, value);
+}
+
+size_t EEPROMClass::writeShort (int address, int16_t value)
+{
+  return EEPROMClass::writeAll (address, value);
+}
+
+size_t EEPROMClass::writeUShort (int address, uint16_t value)
+{
+  return EEPROMClass::writeAll (address, value);
+}
+
+size_t EEPROMClass::writeInt (int address, int32_t value)
+{
+  return EEPROMClass::writeAll (address, value);
+}
+
+size_t EEPROMClass::writeUInt (int address, uint32_t value)
+{
+  return EEPROMClass::writeAll (address, value);
+}
+
+size_t EEPROMClass::writeLong (int address, int32_t value)
+{
+  return EEPROMClass::writeAll (address, value);
+}
+
+size_t EEPROMClass::writeULong (int address, uint32_t value)
+{
+  return EEPROMClass::writeAll (address, value);
+}
+
+size_t EEPROMClass::writeLong64 (int address, int64_t value)
+{
+  return EEPROMClass::writeAll (address, value);
+}
+
+size_t EEPROMClass::writeULong64 (int address, uint64_t value)
+{
+  return EEPROMClass::writeAll (address, value);
+}
+
+size_t EEPROMClass::writeFloat (int address, float_t value)
+{
+  return EEPROMClass::writeAll (address, value);
+}
+
+size_t EEPROMClass::writeDouble (int address, double_t value)
+{
+  return EEPROMClass::writeAll (address, value);
+}
+
+size_t EEPROMClass::writeBool (int address, bool value)
+{
+  int8_t Bool;
+  value ? Bool = 1 : Bool = 0;
+  return EEPROMClass::writeAll (address, Bool);
+}
+
+size_t EEPROMClass::writeString (int address, const char* value)
+{
+  if (!value)
+    return 0;
+
+  if (address < 0 || address > _size)
+    return 0;
+
+  uint16_t len;
+  for (len = 0; len <= _size; len++)
+    if (value[len] == 0)
+      break;
+
+  if (address + len > _size)
+    return 0;
+
+  memcpy(_data + address, (const uint8_t*) value, len + 1);
+  return strlen(value);
+}
+
+size_t EEPROMClass::writeString (int address, String value)
+{
+  return EEPROMClass::writeString (address, value.c_str());
+}
+
+size_t EEPROMClass::writeBytes (int address, const void* value, size_t len)
+{
+  if (!value || !len)
+    return 0;
+
+  if (address < 0 || address + len > _size)
+    return 0;
+
+  memcpy(_data + address, (const void*) value, len);
+  return len;
+}
+
+template <class T> T EEPROMClass::writeAll (int address, const T &value)
+{
+  if (address < 0 || address + sizeof(T) > _size)
+    return value;
+
+  memcpy(_data + address, (const uint8_t*) &value, sizeof(T));
+  return sizeof (value);
+}
+
+#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_EEPROM)
+EEPROMClass EEPROM;
+#endif

--- a/src/utils/ESP32_RTC_EEPROM.h
+++ b/src/utils/ESP32_RTC_EEPROM.h
@@ -1,0 +1,119 @@
+/*
+  EEPROM.h -originally written by Ivan Grokhotkov as part of the esp8266 
+            core for Arduino environment.
+           -ported by Paolo Becchi to Esp32 from esp8266 EEPROM
+           -Modified by Elochukwu Ifediora <ifedioraelochukwuc@gmail.com>
+           -Converted to nvs lbernstone@gmail.com
+           -Adapted for ESP32_RTC_EEPROM.cpp by Rop Gonggrijp
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef ESP32_RTC_EEPROM_h
+#define ESP32_RTC_EEPROM_h
+
+#define EEPROM_SIZE 2048
+
+#ifndef EEPROM_FLASH_PARTITION_NAME
+  #define EEPROM_FLASH_PARTITION_NAME "eeprom"
+#endif
+
+#include <Arduino.h>
+
+class EEPROMClass {
+  public:
+    EEPROMClass(uint32_t sector);
+    EEPROMClass(void);
+    ~EEPROMClass(void);
+
+    static bool begin(size_t size);
+    static bool fromNVS();
+    static bool toNVS();
+    static bool wasRestored();
+    static uint8_t read(int address);
+    static void write(int address, uint8_t val);
+    static uint16_t length();
+    static bool commit();
+    static void end();
+
+    static uint8_t * getDataPtr();
+
+    template<typename T>
+    static T &get(int address, T &t) {
+      if (address < 0 || address + sizeof(T) > _size)
+        return t;
+
+      memcpy((uint8_t*) &t, _data + address, sizeof(T));
+      return t;
+    }
+
+    template<typename T>
+    static const T &put(int address, const T &t) {
+      if (address < 0 || address + sizeof(T) > _size)
+        return t;
+
+      memcpy(_data + address, (const uint8_t*) &t, sizeof(T));
+      return t;
+    }
+
+    static uint8_t readByte(int address);
+    static int8_t readChar(int address);
+    static uint8_t readUChar(int address);
+    static int16_t readShort(int address);
+    static uint16_t readUShort(int address);
+    static int32_t readInt(int address);
+    static uint32_t readUInt(int address);
+    static int32_t readLong(int address);
+    static uint32_t readULong(int address);
+    static int64_t readLong64(int address);
+    static uint64_t readULong64(int address);
+    static float_t readFloat(int address);
+    static double_t readDouble(int address);
+    static bool readBool(int address);
+    static size_t readString(int address, char* value, size_t maxLen);
+    static String readString(int address);
+    static size_t readBytes(int address, void * value, size_t maxLen);
+    template <class T> static T readAll (int address, T &);
+
+    static size_t writeByte(int address, uint8_t value);
+    static size_t writeChar(int address, int8_t value);
+    static size_t writeUChar(int address, uint8_t value);
+    static size_t writeShort(int address, int16_t value);
+    static size_t writeUShort(int address, uint16_t value);
+    static size_t writeInt(int address, int32_t value);
+    static size_t writeUInt(int address, uint32_t value);
+    static size_t writeLong(int address, int32_t value);
+    static size_t writeULong(int address, uint32_t value);
+    static size_t writeLong64(int address, int64_t value);
+    static size_t writeULong64(int address, uint64_t value);
+    static size_t writeFloat(int address, float_t value);
+    static size_t writeDouble(int address, double_t value);
+    static size_t writeBool(int address, bool value);
+    static size_t writeString(int address, const char* value);
+    static size_t writeString(int address, String value);
+    static size_t writeBytes(int address, const void* value, size_t len);
+    template <class T> static T writeAll (int address, const T &);
+
+  protected:
+    static size_t _size;
+    static uint8_t RTC_DATA_ATTR _data[EEPROM_SIZE];
+    static bool _restored;  
+};
+
+#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_EEPROM)
+extern EEPROMClass EEPROM;
+#endif
+
+#endif


### PR DESCRIPTION
Allows ESP32 to run LoRaWAN from deep sleep mode without writing a significant chunk of flash every send.

Includes new files `ESP32_RTC_EEPROM.[cpp|h]` in src/utils/, which provide the mechanism to use ESP32's RTC RAM as the backend storage for simulated EEPROM instead of flash. These provide `toNVS()` and `fromNVS()` to backup and restore from flash, as well as automatically restoring from last flash backup if RTC memory was found empty.

The included new example `LoRaWAN_ESP32_Deep_Sleep` and the code comments therein should explain how to use the RTC RAM persistence while still being resilient against reset, power failure, code reflashes, battery changes, etc.

The only proposed change to existing code in this PR involves `#include`ing [ESP32_RTC_EEPROM](https://github.com/ropg/ESP32_RTC_EEPROM) in the case of ESP32 and moving that include from the .cpp to the .h file so that the EEPROM object is exposed to users of the library. This has the added advantage that (both on the RTC RAM version as on the strictly NVS flash one), users are then free to load and save contents to and from 8" floppies or other external sources by just putting and getting `EEPROM.length()` bytes of data from `EEPROM.getDataPtr()`