### PR TITLE
Arduino string fixes

### DIFF
--- a/src/protocols/LoRaWAN/LoRaWAN.cpp
+++ b/src/protocols/LoRaWAN/LoRaWAN.cpp
@@ -1690,6 +1690,16 @@ int16_t LoRaWANNode::sendReceive(String& strUp, uint8_t port, String& strDown, b
   state = this->downlink(strDown, eventDown);
   return(state);
 }
+
+int16_t LoRaWANNode::sendReceive(String& strUp, uint8_t port, bool isConfirmed, LoRaWANEvent_t* eventUp, LoRaWANEvent_t* eventDown) {
+  // send the uplink
+  int16_t state = this->uplink(strUp, port, isConfirmed, eventUp);
+  RADIOLIB_ASSERT(state);
+
+  // wait for the downlink
+  state = this->downlink(eventDown);
+  return(state);
+}
 #endif
 
 int16_t LoRaWANNode::sendReceive(uint8_t* dataUp, size_t lenUp, uint8_t port, bool isConfirmed, LoRaWANEvent_t* eventUp, LoRaWANEvent_t* eventDown) {

--- a/src/protocols/LoRaWAN/LoRaWAN.cpp
+++ b/src/protocols/LoRaWAN/LoRaWAN.cpp
@@ -1335,6 +1335,7 @@ int16_t LoRaWANNode::downlink(String& str, LoRaWANEvent_t* event) {
 
     // Copy data by appending so char(0) not lost. 
     str = ""; // Empty the String that was passed in
+    str.reserve(length);
     for (int i = 0; i < length; i++) {
       str += (char)data[i]; // Append each byte as a char
     }

--- a/src/protocols/LoRaWAN/LoRaWAN.cpp
+++ b/src/protocols/LoRaWAN/LoRaWAN.cpp
@@ -926,8 +926,8 @@ void LoRaWANNode::saveFcntUp() {
 #endif  // RADIOLIB_EEPROM_UNSUPPORTED
 
 #if defined(RADIOLIB_BUILD_ARDUINO)
-int16_t LoRaWANNode::uplink(String& str, uint8_t port, bool isConfirmed, LoRaWANEvent_t* event) {
-  return(this->uplink(str.c_str(), port, isConfirmed, event));
+int16_t LoRaWANNode::uplink(String& str, uint8_t port, bool isConfirmed, LoRaWANEvent_t* event) {  
+  return(this->uplink((uint8_t*)str.c_str(), str.length(), port, isConfirmed, event));
 }
 #endif
 
@@ -1325,18 +1325,20 @@ int16_t LoRaWANNode::downlink(String& str, LoRaWANEvent_t* event) {
   int16_t state = RADIOLIB_ERR_NONE;
 
   // build a temporary buffer
-  // LoRaWAN downlinks can have 250 bytes at most with 1 extra byte for NULL
+  // LoRaWAN downlinks can have 250 bytes
   size_t length = 0;
-  uint8_t data[251];
+  uint8_t data[250];
 
   // wait for downlink
   state = this->downlink(data, &length, event);
   if(state == RADIOLIB_ERR_NONE) {
-    // add null terminator
-    data[length] = '\0';
 
-    // initialize Arduino String class
-    str = String((char*)data);
+    // Copy data by appending so char(0) not lost. 
+    str = ""; // Empty the String that was passed in
+    for (int i = 0; i < length; i++) {
+      str += (char)data[i]; // Append each byte as a char
+    }
+
   }
 
   return(state);

--- a/src/protocols/LoRaWAN/LoRaWAN.h
+++ b/src/protocols/LoRaWAN/LoRaWAN.h
@@ -555,6 +555,20 @@ class LoRaWANNode {
       \returns \ref status_codes
     */
     int16_t sendReceive(String& strUp, uint8_t port, String& strDown, bool isConfirmed = false, LoRaWANEvent_t* eventUp = NULL, LoRaWANEvent_t* eventDown = NULL);
+
+    /*!
+      \brief Send a message to the server and wait for a downlink during Rx1 and/or Rx2 window
+      but don't bother the user with downlink contents
+      \param strUp Address of Arduino String that will be transmitted.
+      \param port Port number to send the message to.
+      \param isConfirmed Whether to send a confirmed uplink or not.
+      \param eventUp Pointer to a structure to store extra information about the uplink event
+      (port, frame counter, etc.). If set to NULL, no extra information will be passed to the user.
+      \param eventDown Pointer to a structure to store extra information about the downlink event
+      (port, frame counter, etc.). If set to NULL, no extra information will be passed to the user.
+      \returns \ref status_codes
+    */
+    int16_t sendReceive(String& strUp, uint8_t port, bool isConfirmed = false, LoRaWANEvent_t* eventUp = NULL, LoRaWANEvent_t* eventDown = NULL);
     #endif
 
     /*!


### PR DESCRIPTION
* Arduino Strings can contain null chars, but Strings provided to uplink() were truncated at first null, and downlink messages were only copied into the provided String until the first null. This fixes that.
* A sendReceive function is provided for when the user doesn't care about user downlink messages. This provides the fitting Arduino String equivalent.