### PR TITLE
Added array of supported bands

### DIFF
--- a/src/protocols/LoRaWAN/LoRaWAN.h
+++ b/src/protocols/LoRaWAN/LoRaWAN.h
@@ -393,6 +393,29 @@ extern const LoRaWANBand_t KR920;
 extern const LoRaWANBand_t IN865;
 
 /*!
+  \struct LoRaWANBandNum_t
+  \brief IDs of all currently supported bands
+*/
+enum LoRaWANBandNum_t {
+  BandEU868,
+  BandUS915,
+  BandCN780,
+  BandEU433,
+  BandAU915,
+  BandCN500,
+  BandAS923,
+  BandKR920,
+  BandIN865,
+  BandLast
+};
+
+// provide easy access to the number of currently supported bands
+#define RADIOLIB_LORAWAN_NUM_SUPPORTED_BANDS      (BandLast - BandEU868)
+
+// array of currently supported bands
+extern const LoRaWANBand_t* LoRaWANBands[];
+
+/*!
   \struct LoRaWANMacCommand_t
   \brief Structure to save information about MAC command
 */

--- a/src/protocols/LoRaWAN/LoRaWANBands.cpp
+++ b/src/protocols/LoRaWAN/LoRaWANBands.cpp
@@ -2,17 +2,17 @@
 
 #if !RADIOLIB_EXCLUDE_LORAWAN
 
-enum LoRaWANBandNum_t {
-  BandNone,
-  BandEU868,
-  BandUS915,
-  BandCN780,
-  BandEU433,
-  BandAU915,
-  BandCN500,
-  BandAS923,
-  BandKR920,
-  BandIN865
+// array of pointers to currently supported LoRaWAN bands
+const LoRaWANBand_t* LoRaWANBands[RADIOLIB_LORAWAN_NUM_SUPPORTED_BANDS] = {
+  &EU868,
+  &US915,
+  &CN780,
+  &EU433,
+  &AU915,
+  &CN500,
+  &AS923,
+  &KR920,
+  &IN865,
 };
 
 const LoRaWANBand_t EU868 = {


### PR DESCRIPTION
Discussed in #1029.

In the end I just added an array of currently implemented bands without an additional `LoraWANNode` constructor. This can be used pretty easily like this:

```c++
LoRaWANNode node(&radio, LoRaWANBands[BandEU868]);
```

Since most users will likely set a fixed band at compile time, this was intentionally not propagated to examples.

To be merged after #995