### PR TITLE
Update ArduinoHal.h to make spi and friends protected

### DIFF
--- a/src/ArduinoHal.h
+++ b/src/ArduinoHal.h
@@ -60,7 +60,7 @@ class ArduinoHal : public RadioLibHal {
     uint32_t pinToInterrupt(uint32_t pin) override;
 
 #if !RADIOLIB_GODMODE
-  private:
+  protected:
 #endif
     SPIClass* spi = NULL;
     SPISettings spiSettings = RADIOLIB_DEFAULT_SPI_SETTINGS;


### PR DESCRIPTION
Most of the "override" functions here can't actually be overridden in a useful way when spi, spiSettings, and everything else is marked private. If everything is override, then nothing should be private.