### PR TITLE
Make PA ramp up time configurable for SX1262

### DIFF
--- a/src/modules/LLCC68/LLCC68.cpp
+++ b/src/modules/LLCC68/LLCC68.cpp
@@ -6,7 +6,7 @@ LLCC68::LLCC68(Module* mod) : SX1262(mod) {
   this->XTAL = true;
 }
 
-int16_t LLCC68::begin(float freq, float bw, uint8_t sf, uint8_t cr, uint8_t syncWord, int8_t pwr, uint16_t preambleLength, float tcxoVoltage, bool useRegulatorLDO) {
+int16_t LLCC68::begin(float freq, float bw, uint8_t sf, uint8_t cr, uint8_t syncWord, int8_t pwr, uint16_t preambleLength, float tcxoVoltage, bool useRegulatorLDO, uint8_t rampTime) {
   // execute common part
   int16_t state = SX126x::begin(cr, syncWord, preambleLength, tcxoVoltage, useRegulatorLDO);
   RADIOLIB_ASSERT(state);
@@ -21,7 +21,7 @@ int16_t LLCC68::begin(float freq, float bw, uint8_t sf, uint8_t cr, uint8_t sync
   state = setSpreadingFactor(sf);
   RADIOLIB_ASSERT(state);
 
-  state = setOutputPower(pwr);
+  state = setOutputPower(pwr, rampTime);
   RADIOLIB_ASSERT(state);
 
   state = SX126x::fixPaClamping();

--- a/src/modules/LLCC68/LLCC68.h
+++ b/src/modules/LLCC68/LLCC68.h
@@ -36,9 +36,10 @@ class LLCC68: public SX1262 {
       If you are seeing -706/-707 error codes, it likely means you are using a module with TCXO.
       To use TCXO, either set this value to its reference voltage, or set SX126x::XTAL to false.
       \param useRegulatorLDO Whether to use only LDO regulator (true) or DC-DC regulator (false). Defaults to false.
+      \param rampTime The time delayed to allow the PA to ramp up. Defaults to 200 us.
       \returns \ref status_codes
     */
-    int16_t begin(float freq = 434.0, float bw = 125.0, uint8_t sf = 9, uint8_t cr = 7, uint8_t syncWord = RADIOLIB_SX126X_SYNC_WORD_PRIVATE, int8_t pwr = 10, uint16_t preambleLength = 8, float tcxoVoltage = 0, bool useRegulatorLDO = false);
+    int16_t begin(float freq = 434.0, float bw = 125.0, uint8_t sf = 9, uint8_t cr = 7, uint8_t syncWord = RADIOLIB_SX126X_SYNC_WORD_PRIVATE, int8_t pwr = 10, uint16_t preambleLength = 8, float tcxoVoltage = 0, bool useRegulatorLDO = false, uint8_t rampTime = RADIOLIB_SX126X_PA_RAMP_200U);
 
     // configuration methods
 

--- a/src/modules/SX126x/SX1262.cpp
+++ b/src/modules/SX126x/SX1262.cpp
@@ -23,7 +23,7 @@ int16_t SX1262::begin(float freq, float bw, uint8_t sf, uint8_t cr, uint8_t sync
   state = SX126x::fixPaClamping();
   RADIOLIB_ASSERT(state);
 
-  state = setOutputPower(power);
+  state = setOutputPower(power, rampTime);
   RADIOLIB_ASSERT(state);
 
   return(state);
@@ -97,7 +97,7 @@ int16_t SX1262::setFrequency(float freq, bool calibrate) {
   return(SX126x::setFrequencyRaw(freq));
 }
 
-int16_t SX1262::setOutputPower(int8_t power) {
+int16_t SX1262::setOutputPower(int8_t power, uint8_t rampTime) {
   RADIOLIB_CHECK_RANGE(power, -9, 22, RADIOLIB_ERR_INVALID_OUTPUT_POWER);
 
   // get current OCP configuration
@@ -109,9 +109,8 @@ int16_t SX1262::setOutputPower(int8_t power) {
   state = SX126x::setPaConfig(0x04, RADIOLIB_SX126X_PA_CONFIG_SX1262);
   RADIOLIB_ASSERT(state);
 
-  // set output power
-  /// \todo power ramp time configuration
-  state = SX126x::setTxParams(power);
+  // set output power and PA ramp time
+  state = SX126x::setTxParams(power, rampTime);
   RADIOLIB_ASSERT(state);
 
   // restore OCP configuration

--- a/src/modules/SX126x/SX1262.cpp
+++ b/src/modules/SX126x/SX1262.cpp
@@ -5,9 +5,9 @@ SX1262::SX1262(Module* mod) : SX126x(mod) {
   chipType = RADIOLIB_SX1262_CHIP_TYPE;
 }
 
-int16_t SX1262::begin(float freq, float bw, uint8_t sf, uint8_t cr, uint8_t syncWord, int8_t power, uint16_t preambleLength, float tcxoVoltage, bool useRegulatorLDO) {
+int16_t SX1262::begin(float freq, float bw, uint8_t sf, uint8_t cr, uint8_t syncWord, int8_t power, uint16_t preambleLength, float tcxoVoltage, bool useRegulatorLDO, int8_t rampTime) {
   // execute common part
-  int16_t state = SX126x::begin(cr, syncWord, preambleLength, tcxoVoltage, useRegulatorLDO);
+  int16_t state = SX126x::begin(cr, syncWord, preambleLength, tcxoVoltage, useRegulatorLDO, rampTime);
   RADIOLIB_ASSERT(state);
 
   // configure publicly accessible settings

--- a/src/modules/SX126x/SX1262.cpp
+++ b/src/modules/SX126x/SX1262.cpp
@@ -5,9 +5,9 @@ SX1262::SX1262(Module* mod) : SX126x(mod) {
   chipType = RADIOLIB_SX1262_CHIP_TYPE;
 }
 
-int16_t SX1262::begin(float freq, float bw, uint8_t sf, uint8_t cr, uint8_t syncWord, int8_t power, uint16_t preambleLength, float tcxoVoltage, bool useRegulatorLDO, int8_t rampTime) {
+int16_t SX1262::begin(float freq, float bw, uint8_t sf, uint8_t cr, uint8_t syncWord, int8_t power, uint16_t preambleLength, float tcxoVoltage, bool useRegulatorLDO, uint8_t rampTime) {
   // execute common part
-  int16_t state = SX126x::begin(cr, syncWord, preambleLength, tcxoVoltage, useRegulatorLDO, rampTime);
+  int16_t state = SX126x::begin(cr, syncWord, preambleLength, tcxoVoltage, useRegulatorLDO);
   RADIOLIB_ASSERT(state);
 
   // configure publicly accessible settings
@@ -29,7 +29,7 @@ int16_t SX1262::begin(float freq, float bw, uint8_t sf, uint8_t cr, uint8_t sync
   return(state);
 }
 
-int16_t SX1262::beginFSK(float freq, float br, float freqDev, float rxBw, int8_t power, uint16_t preambleLength, float tcxoVoltage, bool useRegulatorLDO) {
+int16_t SX1262::beginFSK(float freq, float br, float freqDev, float rxBw, int8_t power, uint16_t preambleLength, float tcxoVoltage, bool useRegulatorLDO, uint8_t rampTime)) {
   // execute common part
   int16_t state = SX126x::beginFSK(br, freqDev, rxBw, preambleLength, tcxoVoltage, useRegulatorLDO);
   RADIOLIB_ASSERT(state);
@@ -41,7 +41,7 @@ int16_t SX1262::beginFSK(float freq, float br, float freqDev, float rxBw, int8_t
   state = SX126x::fixPaClamping();
   RADIOLIB_ASSERT(state);
 
-  state = setOutputPower(power);
+  state = setOutputPower(power, rampTime);
   RADIOLIB_ASSERT(state);
 
   return(state);
@@ -110,6 +110,7 @@ int16_t SX1262::setOutputPower(int8_t power, uint8_t rampTime) {
   RADIOLIB_ASSERT(state);
 
   // set output power and PA ramp time
+  // fixme: perform check to see if rampTime is in valid range?
   state = SX126x::setTxParams(power, rampTime);
   RADIOLIB_ASSERT(state);
 

--- a/src/modules/SX126x/SX1262.cpp
+++ b/src/modules/SX126x/SX1262.cpp
@@ -29,7 +29,7 @@ int16_t SX1262::begin(float freq, float bw, uint8_t sf, uint8_t cr, uint8_t sync
   return(state);
 }
 
-int16_t SX1262::beginFSK(float freq, float br, float freqDev, float rxBw, int8_t power, uint16_t preambleLength, float tcxoVoltage, bool useRegulatorLDO, uint8_t rampTime)) {
+int16_t SX1262::beginFSK(float freq, float br, float freqDev, float rxBw, int8_t power, uint16_t preambleLength, float tcxoVoltage, bool useRegulatorLDO, uint8_t rampTime) {
   // execute common part
   int16_t state = SX126x::beginFSK(br, freqDev, rxBw, preambleLength, tcxoVoltage, useRegulatorLDO);
   RADIOLIB_ASSERT(state);

--- a/src/modules/SX126x/SX1262.h
+++ b/src/modules/SX126x/SX1262.h
@@ -59,6 +59,7 @@ class SX1262: public SX126x {
       If you are seeing -706/-707 error codes, it likely means you are using non-0 value for module with XTAL.
       To use XTAL, either set this value to 0, or set SX126x::XTAL to true.
       \param useRegulatorLDO Whether to use only LDO regulator (true) or DC-DC regulator (false). Defaults to false.
+      \param rampTime The time delayed to allow the PA to ramp up. Defaults to 200 us.
       \returns \ref status_codes
     */
     int16_t beginFSK(float freq = 434.0, float br = 4.8, float freqDev = 5.0, float rxBw = 156.2, int8_t power = 10, uint16_t preambleLength = 16, float tcxoVoltage = 1.6, bool useRegulatorLDO = false, uint8_t rampTime = RADIOLIB_SX126X_PA_RAMP_200U));
@@ -84,7 +85,7 @@ class SX1262: public SX126x {
       \brief Sets output power. Allowed values are in range from -9 to 22 dBm.
       This method is virtual to allow override from the SX1261 class.
       \param power Output power to be set in dBm.
-      \param rampTime The time delayed to allow the PA to ramp up.
+      \param rampTime The time delayed to allow the PA to ramp up. Defaults to 200 us.
       \returns \ref status_codes
     */
     virtual int16_t setOutputPower(int8_t power, uint8_t rampTime = RADIOLIB_SX126X_PA_RAMP_200U);

--- a/src/modules/SX126x/SX1262.h
+++ b/src/modules/SX126x/SX1262.h
@@ -61,7 +61,7 @@ class SX1262: public SX126x {
       \param useRegulatorLDO Whether to use only LDO regulator (true) or DC-DC regulator (false). Defaults to false.
       \returns \ref status_codes
     */
-    int16_t beginFSK(float freq = 434.0, float br = 4.8, float freqDev = 5.0, float rxBw = 156.2, int8_t power = 10, uint16_t preambleLength = 16, float tcxoVoltage = 1.6, bool useRegulatorLDO = false);
+    int16_t beginFSK(float freq = 434.0, float br = 4.8, float freqDev = 5.0, float rxBw = 156.2, int8_t power = 10, uint16_t preambleLength = 16, float tcxoVoltage = 1.6, bool useRegulatorLDO = false, uint8_t rampTime = RADIOLIB_SX126X_PA_RAMP_200U));
     
     // configuration methods
 
@@ -84,9 +84,10 @@ class SX1262: public SX126x {
       \brief Sets output power. Allowed values are in range from -9 to 22 dBm.
       This method is virtual to allow override from the SX1261 class.
       \param power Output power to be set in dBm.
+      \param rampTime The time delayed to allow the PA to ramp up.
       \returns \ref status_codes
     */
-    virtual int16_t setOutputPower(int8_t power);
+    virtual int16_t setOutputPower(int8_t power, uint8_t rampTime);
 
 #if !RADIOLIB_GODMODE
   private:

--- a/src/modules/SX126x/SX1262.h
+++ b/src/modules/SX126x/SX1262.h
@@ -87,7 +87,7 @@ class SX1262: public SX126x {
       \param rampTime The time delayed to allow the PA to ramp up.
       \returns \ref status_codes
     */
-    virtual int16_t setOutputPower(int8_t power, uint8_t rampTime);
+    virtual int16_t setOutputPower(int8_t power, uint8_t rampTime = RADIOLIB_SX126X_PA_RAMP_200U);
 
 #if !RADIOLIB_GODMODE
   private:

--- a/src/modules/SX126x/SX1262.h
+++ b/src/modules/SX126x/SX1262.h
@@ -62,7 +62,7 @@ class SX1262: public SX126x {
       \param rampTime The time delayed to allow the PA to ramp up. Defaults to 200 us.
       \returns \ref status_codes
     */
-    int16_t beginFSK(float freq = 434.0, float br = 4.8, float freqDev = 5.0, float rxBw = 156.2, int8_t power = 10, uint16_t preambleLength = 16, float tcxoVoltage = 1.6, bool useRegulatorLDO = false, uint8_t rampTime = RADIOLIB_SX126X_PA_RAMP_200U));
+    int16_t beginFSK(float freq = 434.0, float br = 4.8, float freqDev = 5.0, float rxBw = 156.2, int8_t power = 10, uint16_t preambleLength = 16, float tcxoVoltage = 1.6, bool useRegulatorLDO = false, uint8_t rampTime = RADIOLIB_SX126X_PA_RAMP_200U);
     
     // configuration methods
 

--- a/src/modules/SX126x/SX1262.h
+++ b/src/modules/SX126x/SX1262.h
@@ -42,9 +42,10 @@ class SX1262: public SX126x {
       If you are seeing -706/-707 error codes, it likely means you are using non-0 value for module with XTAL.
       To use XTAL, either set this value to 0, or set SX126x::XTAL to true.
       \param useRegulatorLDO Whether to use only LDO regulator (true) or DC-DC regulator (false). Defaults to false.
+      \param rampTime The time delayed to allow the PA to ramp up. Defaults to 200 us.
       \returns \ref status_codes
     */
-    int16_t begin(float freq = 434.0, float bw = 125.0, uint8_t sf = 9, uint8_t cr = 7, uint8_t syncWord = RADIOLIB_SX126X_SYNC_WORD_PRIVATE, int8_t power = 10, uint16_t preambleLength = 8, float tcxoVoltage = 1.6, bool useRegulatorLDO = false);
+    int16_t begin(float freq = 434.0, float bw = 125.0, uint8_t sf = 9, uint8_t cr = 7, uint8_t syncWord = RADIOLIB_SX126X_SYNC_WORD_PRIVATE, int8_t power = 10, uint16_t preambleLength = 8, float tcxoVoltage = 1.6, bool useRegulatorLDO = false, uint8_t rampTime = RADIOLIB_SX126X_PA_RAMP_200U);
 
     /*!
       \brief Initialization method for FSK modem.

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -475,7 +475,7 @@ class SX126x: public PhysicalLayer {
       \param useRegulatorLDO Whether to use only LDO regulator (true) or DC-DC regulator (false). Defaults to false.
       \returns \ref status_codes
     */
-    int16_t begin(uint8_t cr, uint8_t syncWord, uint16_t preambleLength, float tcxoVoltage, bool useRegulatorLDO = false);
+    int16_t begin(uint8_t cr, uint8_t syncWord, uint16_t preambleLength, float tcxoVoltage, bool useRegulatorLDO = false, uint8_t rampTime = RADIOLIB_SX126X_PA_RAMP_200U);
 
     /*!
       \brief Initialization method for FSK modem.

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -475,7 +475,7 @@ class SX126x: public PhysicalLayer {
       \param useRegulatorLDO Whether to use only LDO regulator (true) or DC-DC regulator (false). Defaults to false.
       \returns \ref status_codes
     */
-    int16_t begin(uint8_t cr, uint8_t syncWord, uint16_t preambleLength, float tcxoVoltage, bool useRegulatorLDO = false, uint8_t rampTime = RADIOLIB_SX126X_PA_RAMP_200U);
+    int16_t begin(uint8_t cr, uint8_t syncWord, uint16_t preambleLength, float tcxoVoltage, bool useRegulatorLDO = false);
 
     /*!
       \brief Initialization method for FSK modem.


### PR DESCRIPTION
Default behaviour should not be changed.
Backwards-compatible (I would have liked to put `rampTime` next to `power` in `begin()` but this would have been breaking)
If you are okay with this, I can makes the same changes to the SX1261 and SX1268.