### PR TITLE
Use RadioLibTime_t (aka unsigned long) when dealing with millis() and micros()

### DIFF
--- a/examples/NonArduino/Raspberry/PiHal.h
+++ b/examples/NonArduino/Raspberry/PiHal.h
@@ -106,23 +106,23 @@ class PiHal : public RadioLibHal {
       gpioSetAlertFuncEx(interruptNum, NULL, NULL);
     }
 
-    void delay(unsigned long ms) override {
+    void delay(RadioLibTime_t ms) override {
       gpioDelay(ms * 1000);
     }
 
-    void delayMicroseconds(unsigned long us) override {
+    void delayMicroseconds(RadioLibTime_t us) override {
       gpioDelay(us);
     }
 
-    unsigned long millis() override {
+    RadioLibTime_t millis() override {
       return(gpioTick() / 1000);
     }
 
-    unsigned long micros() override {
+    RadioLibTime_t micros() override {
       return(gpioTick());
     }
 
-    long pulseIn(uint32_t pin, uint32_t state, unsigned long timeout) override {
+    long pulseIn(uint32_t pin, uint32_t state, RadioLibTime_t timeout) override {
       if(pin == RADIOLIB_NC) {
         return(0);
       }

--- a/extras/test/SX126x/PiHal.h
+++ b/extras/test/SX126x/PiHal.h
@@ -86,30 +86,30 @@ class PiHal : public RadioLibHal {
       gpioSetISRFunc(interruptNum, 0, 0, NULL);
     }
 
-    void delay(unsigned long ms) override {
+    void delay(RadioLibTime_t ms) override {
       gpioDelay(ms * 1000);
     }
 
-    void delayMicroseconds(unsigned long us) override {
+    void delayMicroseconds(RadioLibTime_t us) override {
       gpioDelay(us);
     }
 
-    unsigned long millis() override {
+    RadioLibTime_t millis() override {
       return(gpioTick() / 1000);
     }
 
-    unsigned long micros() override {
+    RadioLibTime_t micros() override {
       return(gpioTick());
     }
 
-    long pulseIn(uint32_t pin, uint32_t state, unsigned long timeout) override {
+    long pulseIn(uint32_t pin, uint32_t state, RadioLibTime_t timeout) override {
       if(pin == RADIOLIB_NC) {
         return(0);
       }
 
       this->pinMode(pin, PI_INPUT);
-      uint32_t start = this->micros();
-      uint32_t curtick = this->micros();
+      RadioLibTime_t start = this->micros();
+      RadioLibTime_t curtick = this->micros();
 
       while(this->digitalRead(pin) == state) {
         if((this->micros() - curtick) > timeout) {

--- a/src/ArduinoHal.cpp
+++ b/src/ArduinoHal.cpp
@@ -53,7 +53,7 @@ void inline ArduinoHal::detachInterrupt(uint32_t interruptNum) {
   ::detachInterrupt(interruptNum);
 }
 
-void inline ArduinoHal::delay(unsigned long ms) {
+void inline ArduinoHal::delay(RadioLibTime_t ms) {
 #if !defined(RADIOLIB_CLOCK_DRIFT_MS)
   ::delay(ms);
 #else
@@ -61,7 +61,7 @@ void inline ArduinoHal::delay(unsigned long ms) {
 #endif
 }
 
-void inline ArduinoHal::delayMicroseconds(unsigned long us) {
+void inline ArduinoHal::delayMicroseconds(RadioLibTime_t us) {
 #if !defined(RADIOLIB_CLOCK_DRIFT_MS)
   ::delayMicroseconds(us);
 #else
@@ -69,7 +69,7 @@ void inline ArduinoHal::delayMicroseconds(unsigned long us) {
 #endif
 }
 
-unsigned long inline ArduinoHal::millis() {
+RadioLibTime_t inline ArduinoHal::millis() {
 #if !defined(RADIOLIB_CLOCK_DRIFT_MS)
   return(::millis());
 #else
@@ -77,7 +77,7 @@ unsigned long inline ArduinoHal::millis() {
 #endif
 }
 
-unsigned long inline ArduinoHal::micros() {
+RadioLibTime_t inline ArduinoHal::micros() {
 #if !defined(RADIOLIB_CLOCK_DRIFT_MS)
   return(::micros());
 #else
@@ -85,7 +85,7 @@ unsigned long inline ArduinoHal::micros() {
 #endif
 }
 
-long inline ArduinoHal::pulseIn(uint32_t pin, uint32_t state, unsigned long timeout) {
+long inline ArduinoHal::pulseIn(uint32_t pin, uint32_t state, RadioLibTime_t timeout) {
   if(pin == RADIOLIB_NC) {
     return 0;
   }
@@ -114,7 +114,7 @@ void inline ArduinoHal::spiEnd() {
   spi->end();
 }
 
-void inline ArduinoHal::tone(uint32_t pin, unsigned int frequency, unsigned long duration) {
+void inline ArduinoHal::tone(uint32_t pin, unsigned int frequency, RadioLibTime_t duration) {
   #if !defined(RADIOLIB_TONE_UNSUPPORTED)
     if(pin == RADIOLIB_NC) {
       return;

--- a/src/ArduinoHal.h
+++ b/src/ArduinoHal.h
@@ -40,11 +40,11 @@ class ArduinoHal : public RadioLibHal {
     uint32_t digitalRead(uint32_t pin) override;
     void attachInterrupt(uint32_t interruptNum, void (*interruptCb)(void), uint32_t mode) override;
     void detachInterrupt(uint32_t interruptNum) override;
-    void delay(unsigned long ms) override;
-    void delayMicroseconds(unsigned long us) override;
-    unsigned long millis() override;
-    unsigned long micros() override;
-    long pulseIn(uint32_t pin, uint32_t state, unsigned long timeout) override;
+    void delay(RadioLibTime_t ms) override;
+    void delayMicroseconds(RadioLibTime_t us) override;
+    RadioLibTime_t millis() override;
+    RadioLibTime_t micros() override;
+    long pulseIn(uint32_t pin, uint32_t state, RadioLibTime_t timeout) override;
     void spiBegin() override;
     void spiBeginTransaction() override;
     void spiTransfer(uint8_t* out, size_t len, uint8_t* in) override;
@@ -54,7 +54,7 @@ class ArduinoHal : public RadioLibHal {
     // implementations of virtual RadioLibHal methods
     void init() override;
     void term() override;
-    void tone(uint32_t pin, unsigned int frequency, unsigned long duration = 0) override;
+    void tone(uint32_t pin, unsigned int frequency, RadioLibTime_t duration = 0) override;
     void noTone(uint32_t pin) override;
     void yield() override;
     uint32_t pinToInterrupt(uint32_t pin) override;

--- a/src/BuildOpt.h
+++ b/src/BuildOpt.h
@@ -1,6 +1,8 @@
 #if !defined(_RADIOLIB_BUILD_OPTIONS_H)
 #define _RADIOLIB_BUILD_OPTIONS_H
 
+#include "TypeDef.h"
+
 /* RadioLib build configuration options */
 
 /*
@@ -350,12 +352,12 @@
   // ... and for the grand finale, we have millis() and micros() DEFINED AS MACROS!
   #if defined(millis)
   #undef millis
-  inline unsigned long millis() { return((unsigned long)(STCV / 1000)); };
+  inline RadioLibTime_t millis() { return((RadioLibTime_t)(STCV / 1000)); };
   #endif
 
   #if defined(micros)
   #undef micros
-  inline unsigned long micros() { return((unsigned long)(STCV)); };
+  inline RadioLibTime_t micros() { return((RadioLibTime_t)(STCV)); };
   #endif
 
 #elif defined(TEENSYDUINO)

--- a/src/Hal.cpp
+++ b/src/Hal.cpp
@@ -16,7 +16,7 @@ void RadioLibHal::term() {
 
 }
 
-void RadioLibHal::tone(uint32_t pin, unsigned int frequency, unsigned long duration) {
+void RadioLibHal::tone(uint32_t pin, unsigned int frequency, RadioLibTime_t duration) {
   (void)pin;
   (void)frequency;
   (void)duration;

--- a/src/Hal.h
+++ b/src/Hal.h
@@ -104,28 +104,28 @@ class RadioLibHal {
       Must be implemented by the platform-specific hardware abstraction!
       \param ms Number of milliseconds to wait.
     */
-    virtual void delay(unsigned long ms) = 0;
+    virtual void delay(RadioLibTime_t ms) = 0;
     
     /*!
       \brief Blocking microsecond wait function.
       Must be implemented by the platform-specific hardware abstraction!
       \param us Number of microseconds to wait.
     */
-    virtual void delayMicroseconds(unsigned long us) = 0;
+    virtual void delayMicroseconds(RadioLibTime_t us) = 0;
     
     /*!
       \brief Get number of milliseconds since start.
       Must be implemented by the platform-specific hardware abstraction!
       \returns Number of milliseconds since start.
     */
-    virtual unsigned long millis() = 0;
+    virtual RadioLibTime_t millis() = 0;
     
     /*!
       \brief Get number of microseconds since start.
       Must be implemented by the platform-specific hardware abstraction!
       \returns Number of microseconds since start.
     */
-    virtual unsigned long micros() = 0;
+    virtual RadioLibTime_t micros() = 0;
     
     /*!
       \brief Measure the length of incoming digital pulse in microseconds.
@@ -135,7 +135,7 @@ class RadioLibHal {
       \param timeout Timeout in microseconds.
       \returns Pulse length in microseconds, or 0 if the pulse did not start before timeout.
     */
-    virtual long pulseIn(uint32_t pin, uint32_t state, unsigned long timeout) = 0;
+    virtual long pulseIn(uint32_t pin, uint32_t state, RadioLibTime_t timeout) = 0;
 
     /*!
       \brief SPI initialization method.
@@ -188,7 +188,7 @@ class RadioLibHal {
       \param frequency Frequency of the square wave.
       \param duration Duration of the tone in ms. When set to 0, the tone will be infinite.
     */
-    virtual void tone(uint32_t pin, unsigned int frequency, unsigned long duration = 0);
+    virtual void tone(uint32_t pin, unsigned int frequency, RadioLibTime_t duration = 0);
 
     /*!
       \brief Method to stop producing a tone.

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -75,7 +75,7 @@ int16_t Module::SPIsetRegValue(uint32_t reg, uint8_t value, uint8_t msb, uint8_t
   #if RADIOLIB_SPI_PARANOID
     // check register value each millisecond until check interval is reached
     // some registers need a bit of time to process the change (e.g. SX127X_REG_OP_MODE)
-    unsigned long start = this->hal->micros();
+    RadioLibTime_t start = this->hal->micros();
     uint8_t readValue = 0x00;
     while(this->hal->micros() - start < (checkInterval * 1000)) {
       readValue = SPIreadRegister(reg);
@@ -308,7 +308,7 @@ int16_t Module::SPIcheckStream() {
   return(state);
 }
 
-int16_t Module::SPItransferStream(uint8_t* cmd, uint8_t cmdLen, bool write, uint8_t* dataOut, uint8_t* dataIn, size_t numBytes, bool waitForGpio, uint32_t timeout) {
+int16_t Module::SPItransferStream(uint8_t* cmd, uint8_t cmdLen, bool write, uint8_t* dataOut, uint8_t* dataIn, size_t numBytes, bool waitForGpio, RadioLibTime_t timeout) {
   // prepare the buffers
   size_t buffLen = cmdLen + numBytes;
   if(!write) {
@@ -339,7 +339,7 @@ int16_t Module::SPItransferStream(uint8_t* cmd, uint8_t cmdLen, bool write, uint
   if(this->gpioPin == RADIOLIB_NC) {
     this->hal->delay(50);
   } else {
-    unsigned long start = this->hal->millis();
+    RadioLibTime_t start = this->hal->millis();
     while(this->hal->digitalRead(this->gpioPin)) {
       this->hal->yield();
       if(this->hal->millis() - start >= timeout) {
@@ -366,7 +366,7 @@ int16_t Module::SPItransferStream(uint8_t* cmd, uint8_t cmdLen, bool write, uint
       this->hal->delay(1);
     } else {
       this->hal->delayMicroseconds(1);
-      unsigned long start = this->hal->millis();
+      RadioLibTime_t start = this->hal->millis();
       while(this->hal->digitalRead(this->gpioPin)) {
         this->hal->yield();
         if(this->hal->millis() - start >= timeout) {
@@ -432,7 +432,7 @@ int16_t Module::SPItransferStream(uint8_t* cmd, uint8_t cmdLen, bool write, uint
   return(state);
 }
 
-void Module::waitForMicroseconds(unsigned long start, unsigned long len) {
+void Module::waitForMicroseconds(RadioLibTime_t start, RadioLibTime_t len) {
   #if RADIOLIB_INTERRUPT_TIMING
   (void)start;
   if((this->TimerSetupCb != nullptr) && (len != this->prevTimingLen)) {

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -75,7 +75,7 @@ int16_t Module::SPIsetRegValue(uint32_t reg, uint8_t value, uint8_t msb, uint8_t
   #if RADIOLIB_SPI_PARANOID
     // check register value each millisecond until check interval is reached
     // some registers need a bit of time to process the change (e.g. SX127X_REG_OP_MODE)
-    uint32_t start = this->hal->micros();
+    unsigned long start = this->hal->micros();
     uint8_t readValue = 0x00;
     while(this->hal->micros() - start < (checkInterval * 1000)) {
       readValue = SPIreadRegister(reg);
@@ -339,7 +339,7 @@ int16_t Module::SPItransferStream(uint8_t* cmd, uint8_t cmdLen, bool write, uint
   if(this->gpioPin == RADIOLIB_NC) {
     this->hal->delay(50);
   } else {
-    uint32_t start = this->hal->millis();
+    unsigned long start = this->hal->millis();
     while(this->hal->digitalRead(this->gpioPin)) {
       this->hal->yield();
       if(this->hal->millis() - start >= timeout) {
@@ -366,7 +366,7 @@ int16_t Module::SPItransferStream(uint8_t* cmd, uint8_t cmdLen, bool write, uint
       this->hal->delay(1);
     } else {
       this->hal->delayMicroseconds(1);
-      uint32_t start = this->hal->millis();
+      unsigned long start = this->hal->millis();
       while(this->hal->digitalRead(this->gpioPin)) {
         this->hal->yield();
         if(this->hal->millis() - start >= timeout) {
@@ -432,7 +432,7 @@ int16_t Module::SPItransferStream(uint8_t* cmd, uint8_t cmdLen, bool write, uint
   return(state);
 }
 
-void Module::waitForMicroseconds(uint32_t start, uint32_t len) {
+void Module::waitForMicroseconds(unsigned long start, unsigned long len) {
   #if RADIOLIB_INTERRUPT_TIMING
   (void)start;
   if((this->TimerSetupCb != nullptr) && (len != this->prevTimingLen)) {

--- a/src/Module.h
+++ b/src/Module.h
@@ -371,7 +371,7 @@ class Module {
       \param timeout GPIO wait period timeout in milliseconds.
       \returns \ref status_codes
     */
-    int16_t SPItransferStream(uint8_t* cmd, uint8_t cmdLen, bool write, uint8_t* dataOut, uint8_t* dataIn, size_t numBytes, bool waitForGpio, uint32_t timeout);
+    int16_t SPItransferStream(uint8_t* cmd, uint8_t cmdLen, bool write, uint8_t* dataOut, uint8_t* dataIn, size_t numBytes, bool waitForGpio, RadioLibTime_t timeout);
 
     // pin number access methods
 
@@ -503,7 +503,7 @@ class Module {
       \param start Waiting start timestamp, in microseconds.
       \param len Waiting duration, in microseconds;
     */
-    void waitForMicroseconds(unsigned long start, unsigned long len);
+    void waitForMicroseconds(RadioLibTime_t start, RadioLibTime_t len);
 
     /*!
       \brief Function to reflect bits within a byte.

--- a/src/Module.h
+++ b/src/Module.h
@@ -503,7 +503,7 @@ class Module {
       \param start Waiting start timestamp, in microseconds.
       \param len Waiting duration, in microseconds;
     */
-    void waitForMicroseconds(uint32_t start, uint32_t len);
+    void waitForMicroseconds(unsigned long start, unsigned long len);
 
     /*!
       \brief Function to reflect bits within a byte.

--- a/src/TypeDef.h
+++ b/src/TypeDef.h
@@ -567,4 +567,19 @@
   \}
 */
 
+/*!
+  \defgroup typedefs Type aliases used by RadioLib.
+
+  \{
+*/
+
+/*!
+  \brief Type used for durations in RadioLib
+*/
+typedef unsigned long RadioLibTime_t;
+
+/*!
+  \}
+*/
+
 #endif

--- a/src/modules/CC1101/CC1101.cpp
+++ b/src/modules/CC1101/CC1101.cpp
@@ -107,7 +107,7 @@ int16_t CC1101::transmit(uint8_t* data, size_t len, uint8_t addr) {
   RADIOLIB_ASSERT(state);
 
   // wait for transmission start or timeout
-  uint32_t start = this->mod->hal->millis();
+  unsigned long start = this->mod->hal->millis();
   while(!this->mod->hal->digitalRead(this->mod->getGpio())) {
     this->mod->hal->yield();
 
@@ -140,7 +140,7 @@ int16_t CC1101::receive(uint8_t* data, size_t len) {
   RADIOLIB_ASSERT(state);
 
   // wait for packet start or timeout
-  uint32_t start = this->mod->hal->millis();
+  unsigned long start = this->mod->hal->millis();
   while(this->mod->hal->digitalRead(this->mod->getIrq())) {
     this->mod->hal->yield();
 
@@ -172,7 +172,7 @@ int16_t CC1101::standby() {
   SPIsendCommand(RADIOLIB_CC1101_CMD_IDLE);
 
   // wait until idle is reached
-  uint32_t start = this->mod->hal->millis();
+  unsigned long start = this->mod->hal->millis();
   while(SPIgetRegValue(RADIOLIB_CC1101_REG_MARCSTATE, 4, 0) != RADIOLIB_CC1101_MARC_STATE_IDLE) {
     mod->hal->yield();
     if(this->mod->hal->millis() - start > 100) {

--- a/src/modules/CC1101/CC1101.cpp
+++ b/src/modules/CC1101/CC1101.cpp
@@ -100,14 +100,14 @@ void CC1101::reset() {
 
 int16_t CC1101::transmit(uint8_t* data, size_t len, uint8_t addr) {
   // calculate timeout (5ms + 500 % of expected time-on-air)
-  uint32_t timeout = 5 + (uint32_t)((((float)(len * 8)) / this->bitRate) * 5);
+  RadioLibTime_t timeout = 5 + (RadioLibTime_t)((((float)(len * 8)) / this->bitRate) * 5);
 
   // start transmission
   int16_t state = startTransmit(data, len, addr);
   RADIOLIB_ASSERT(state);
 
   // wait for transmission start or timeout
-  unsigned long start = this->mod->hal->millis();
+  RadioLibTime_t start = this->mod->hal->millis();
   while(!this->mod->hal->digitalRead(this->mod->getGpio())) {
     this->mod->hal->yield();
 
@@ -133,14 +133,14 @@ int16_t CC1101::transmit(uint8_t* data, size_t len, uint8_t addr) {
 
 int16_t CC1101::receive(uint8_t* data, size_t len) {
   // calculate timeout (500 ms + 400 full max-length packets at current bit rate)
-  uint32_t timeout = 500 + (1.0/(this->bitRate))*(RADIOLIB_CC1101_MAX_PACKET_LENGTH*400.0);
+  RadioLibTime_t timeout = 500 + (1.0/(this->bitRate))*(RADIOLIB_CC1101_MAX_PACKET_LENGTH*400.0);
 
   // start reception
   int16_t state = startReceive();
   RADIOLIB_ASSERT(state);
 
   // wait for packet start or timeout
-  unsigned long start = this->mod->hal->millis();
+  RadioLibTime_t start = this->mod->hal->millis();
   while(this->mod->hal->digitalRead(this->mod->getIrq())) {
     this->mod->hal->yield();
 
@@ -172,7 +172,7 @@ int16_t CC1101::standby() {
   SPIsendCommand(RADIOLIB_CC1101_CMD_IDLE);
 
   // wait until idle is reached
-  unsigned long start = this->mod->hal->millis();
+  RadioLibTime_t start = this->mod->hal->millis();
   while(SPIgetRegValue(RADIOLIB_CC1101_REG_MARCSTATE, 4, 0) != RADIOLIB_CC1101_MARC_STATE_IDLE) {
     mod->hal->yield();
     if(this->mod->hal->millis() - start > 100) {

--- a/src/modules/LR11x0/LR11x0.cpp
+++ b/src/modules/LR11x0/LR11x0.cpp
@@ -1282,13 +1282,13 @@ RadioLibTime_t LR11x0::getTimeOnAir(size_t len) {
     }
 
     // get time-on-air in us
-    return(((RadioLibTime_t(1) << this->spreadingFactor) / this->bandwidthKhz) * N_symbol * 1000.0);
+    return(((uint32_t(1) << this->spreadingFactor) / this->bandwidthKhz) * N_symbol * 1000.0);
 
   } else if(type == RADIOLIB_LR11X0_PACKET_TYPE_GFSK) {
-    return(((RadioLibTime_t)len * 8 * 1000000UL) / this->bitRate);
+    return(((uint32_t)len * 8 * 1000000UL) / this->bitRate);
   
   } else if(type == RADIOLIB_LR11X0_PACKET_TYPE_LR_FHSS) {
-    return(((RadioLibTime_t)len * 8 * 1000000UL) / RADIOLIB_LR11X0_LR_FHSS_BIT_RATE);
+    return(((uint32_t)len * 8 * 1000000UL) / RADIOLIB_LR11X0_LR_FHSS_BIT_RATE);
   }
 
   return(0);

--- a/src/modules/LR11x0/LR11x0.cpp
+++ b/src/modules/LR11x0/LR11x0.cpp
@@ -118,7 +118,7 @@ int16_t LR11x0::reset() {
   this->mod->hal->delay(300);
   
   // wait for BUSY to go low
-  uint32_t start = this->mod->hal->millis();
+  unsigned long start = this->mod->hal->millis();
   while(this->mod->hal->digitalRead(this->mod->getGpio())) {
     this->mod->hal->yield();
     if(this->mod->hal->millis() - start >= 3000) {
@@ -163,7 +163,7 @@ int16_t LR11x0::transmit(uint8_t* data, size_t len, uint8_t addr) {
   RADIOLIB_ASSERT(state);
 
   // wait for packet transmission or timeout
-  uint32_t start = this->mod->hal->micros();
+  unsigned long start = this->mod->hal->micros();
   while(!this->mod->hal->digitalRead(this->mod->getIrq())) {
     this->mod->hal->yield();
     if(this->mod->hal->micros() - start > timeout) {
@@ -171,7 +171,7 @@ int16_t LR11x0::transmit(uint8_t* data, size_t len, uint8_t addr) {
       return(RADIOLIB_ERR_TX_TIMEOUT);
     }
   }
-  uint32_t elapsed = this->mod->hal->micros() - start;
+  unsigned long elapsed = this->mod->hal->micros() - start;
 
   // update data rate
   this->dataRateMeasured = (len*8.0)/((float)elapsed/1000000.0);
@@ -224,7 +224,7 @@ int16_t LR11x0::receive(uint8_t* data, size_t len) {
 
   // wait for packet reception or timeout
   bool softTimeout = false;
-  uint32_t start = this->mod->hal->millis();
+  unsigned long start = this->mod->hal->millis();
   while(!this->mod->hal->digitalRead(this->mod->getIrq())) {
     this->mod->hal->yield();
     // safety check, the timeout should be done by the radio

--- a/src/modules/LR11x0/LR11x0.h
+++ b/src/modules/LR11x0/LR11x0.h
@@ -1017,7 +1017,7 @@ class LR11x0: public PhysicalLayer {
       \param len Payload length in bytes.
       \returns Expected time-on-air in microseconds.
     */
-    uint32_t getTimeOnAir(size_t len) override;
+    RadioLibTime_t getTimeOnAir(size_t len) override;
 
     /*!
       \brief Gets effective data rate for the last transmitted packet. The value is calculated only for payload bytes.

--- a/src/modules/RF69/RF69.cpp
+++ b/src/modules/RF69/RF69.cpp
@@ -100,14 +100,14 @@ void RF69::reset() {
 
 int16_t RF69::transmit(uint8_t* data, size_t len, uint8_t addr) {
   // calculate timeout (5ms + 500 % of expected time-on-air)
-  uint32_t timeout = 5 + (uint32_t)((((float)(len * 8)) / this->bitRate) * 5);
+  RadioLibTime_t timeout = 5 + (RadioLibTime_t)((((float)(len * 8)) / this->bitRate) * 5);
 
   // start transmission
   int16_t state = startTransmit(data, len, addr);
   RADIOLIB_ASSERT(state);
 
   // wait for transmission end or timeout
-  unsigned long start = this->mod->hal->millis();
+  RadioLibTime_t start = this->mod->hal->millis();
   while(!this->mod->hal->digitalRead(this->mod->getIrq())) {
     this->mod->hal->yield();
 
@@ -122,14 +122,14 @@ int16_t RF69::transmit(uint8_t* data, size_t len, uint8_t addr) {
 
 int16_t RF69::receive(uint8_t* data, size_t len) {
   // calculate timeout (500 ms + 400 full 64-byte packets at current bit rate)
-  uint32_t timeout = 500 + (1.0/(this->bitRate))*(RADIOLIB_RF69_MAX_PACKET_LENGTH*400.0);
+  RadioLibTime_t timeout = 500 + (1.0/(this->bitRate))*(RADIOLIB_RF69_MAX_PACKET_LENGTH*400.0);
 
   // start reception
   int16_t state = startReceive();
   RADIOLIB_ASSERT(state);
 
   // wait for packet reception or timeout
-  unsigned long start = this->mod->hal->millis();
+  RadioLibTime_t start = this->mod->hal->millis();
   while(!this->mod->hal->digitalRead(this->mod->getIrq())) {
     this->mod->hal->yield();
 

--- a/src/modules/RF69/RF69.cpp
+++ b/src/modules/RF69/RF69.cpp
@@ -107,7 +107,7 @@ int16_t RF69::transmit(uint8_t* data, size_t len, uint8_t addr) {
   RADIOLIB_ASSERT(state);
 
   // wait for transmission end or timeout
-  uint32_t start = this->mod->hal->millis();
+  unsigned long start = this->mod->hal->millis();
   while(!this->mod->hal->digitalRead(this->mod->getIrq())) {
     this->mod->hal->yield();
 
@@ -129,7 +129,7 @@ int16_t RF69::receive(uint8_t* data, size_t len) {
   RADIOLIB_ASSERT(state);
 
   // wait for packet reception or timeout
-  uint32_t start = this->mod->hal->millis();
+  unsigned long start = this->mod->hal->millis();
   while(!this->mod->hal->digitalRead(this->mod->getIrq())) {
     this->mod->hal->yield();
 

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -1444,7 +1444,7 @@ RadioLibTime_t SX126x::getTimeOnAir(size_t len) {
 
     return((symbolLength_us * nSymbol_x4) / 4);
   } else {
-    return((len * 8 * this->bitRate) / (RADIOLIB_SX126X_CRYSTAL_FREQ * 32));
+    return(((uint32_t)len * 8 * this->bitRate) / (RADIOLIB_SX126X_CRYSTAL_FREQ * 32));
   }
 }
 

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -207,7 +207,7 @@ int16_t SX126x::reset(bool verify) {
   }
 
   // set mode to standby - SX126x often refuses first few commands after reset
-  uint32_t start = this->mod->hal->millis();
+  unsigned long start = this->mod->hal->millis();
   while(true) {
     // try to set mode to standby
     int16_t state = standby();
@@ -246,7 +246,7 @@ int16_t SX126x::transmit(uint8_t* data, size_t len, uint8_t addr) {
   RADIOLIB_ASSERT(state);
 
   // wait for packet transmission or timeout
-  uint32_t start = this->mod->hal->millis();
+  unsigned long start = this->mod->hal->millis();
   while(!this->mod->hal->digitalRead(this->mod->getIrq())) {
     this->mod->hal->yield();
     if(this->mod->hal->millis() - start > timeout) {
@@ -256,7 +256,7 @@ int16_t SX126x::transmit(uint8_t* data, size_t len, uint8_t addr) {
   }
 
   // update data rate
-  uint32_t elapsed = this->mod->hal->millis() - start;
+  unsigned long elapsed = this->mod->hal->millis() - start;
   this->dataRateMeasured = (len*8.0)/((float)elapsed/1000.0);
 
   return(finishTransmit());
@@ -299,7 +299,7 @@ int16_t SX126x::receive(uint8_t* data, size_t len) {
 
   // wait for packet reception or timeout
   bool softTimeout = false;
-  uint32_t start = this->mod->hal->millis();
+  unsigned long start = this->mod->hal->millis();
   while(!this->mod->hal->digitalRead(this->mod->getIrq())) {
     this->mod->hal->yield();
     // safety check, the timeout should be done by the radio

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -957,14 +957,14 @@ class SX126x: public PhysicalLayer {
       \param len Payload length in bytes.
       \returns Expected time-on-air in microseconds.
     */
-    uint32_t getTimeOnAir(size_t len) override;
+    RadioLibTime_t getTimeOnAir(size_t len) override;
 
     /*!
       \brief Calculate the timeout value for this specific module / series (in number of symbols or units of time)
       \param timeoutUs Timeout in microseconds to listen for
       \returns Timeout value in a unit that is specific for the used module
     */
-    uint32_t calculateRxTimeout(uint32_t timeoutUs);
+    RadioLibTime_t calculateRxTimeout(RadioLibTime_t timeoutUs);
 
     /*!
       \brief Create the flags that make up RxDone and RxTimeout used for receiving downlinks

--- a/src/modules/SX127x/SX127x.cpp
+++ b/src/modules/SX127x/SX127x.cpp
@@ -147,7 +147,7 @@ int16_t SX127x::transmit(uint8_t* data, size_t len, uint8_t addr) {
   RADIOLIB_ASSERT(state);
 
   int16_t modem = getActiveModem();
-  uint32_t start = 0;
+  unsigned long start = 0;
   uint32_t timeout = 0;
   uint32_t toa = getTimeOnAir(len);
   if(modem == RADIOLIB_SX127X_LORA) {
@@ -179,7 +179,7 @@ int16_t SX127x::transmit(uint8_t* data, size_t len, uint8_t addr) {
   }
 
   // update data rate
-  uint32_t elapsed = this->mod->hal->millis() - start;
+  unsigned long elapsed = this->mod->hal->millis() - start;
   this->dataRate = (len*8.0)/((float)elapsed/1000.0);
 
   return(finishTransmit());
@@ -204,7 +204,7 @@ int16_t SX127x::receive(uint8_t* data, size_t len) {
     }
 
     // wait for packet reception or timeout
-    uint32_t start = this->mod->hal->millis();
+    unsigned long start = this->mod->hal->millis();
     while(!this->mod->hal->digitalRead(this->mod->getIrq())) {
       this->mod->hal->yield();
 
@@ -233,7 +233,7 @@ int16_t SX127x::receive(uint8_t* data, size_t len) {
     RADIOLIB_ASSERT(state);
 
     // wait for packet reception or timeout
-    uint32_t start = this->mod->hal->millis();
+    unsigned long start = this->mod->hal->millis();
     while(!this->mod->hal->digitalRead(this->mod->getIrq())) {
       this->mod->hal->yield();
       if(this->mod->hal->millis() - start > timeout) {

--- a/src/modules/SX127x/SX127x.cpp
+++ b/src/modules/SX127x/SX127x.cpp
@@ -199,7 +199,7 @@ int16_t SX127x::receive(uint8_t* data, size_t len) {
     // if no DIO1 is provided, use software timeout (100 LoRa symbols, same as hardware timeout)
     RadioLibTime_t timeout = 0;
     if(this->mod->getGpio() == RADIOLIB_NC) {
-      float symbolLength = (float) (RadioLibTime_t(1) << this->spreadingFactor) / (float) this->bandwidth;
+      float symbolLength = (float) (uint32_t(1) << this->spreadingFactor) / (float) this->bandwidth;
       timeout = (RadioLibTime_t)(symbolLength * 100.0);
     }
 
@@ -1249,7 +1249,7 @@ RadioLibTime_t SX127x::getTimeOnAir(size_t len) {
   uint8_t modem = getActiveModem();
   if (modem == RADIOLIB_SX127X_LORA) {
     // get symbol length in us
-    float symbolLength = (float) (RadioLibTime_t(1) << this->spreadingFactor) / (float) this->bandwidth;
+    float symbolLength = (float) (uint32_t(1) << this->spreadingFactor) / (float) this->bandwidth;
 
     // get number of symbols
     float n_sym = getNumSymbols(len);
@@ -1274,7 +1274,7 @@ RadioLibTime_t SX127x::getTimeOnAir(size_t len) {
     }
 
     // calculate time-on-air in us {[(length in bytes) * (8 bits / 1 byte)] / [(Bit Rate in kbps) * (1000 bps / 1 kbps)]} * (1000000 us in 1 sec)
-    return((RadioLibTime_t) (((crc + n_syncWord + n_pre + (float) (len * 8)) / (this->bitRate * 1000.0)) * 1000000.0));
+    return((uint32_t) (((crc + n_syncWord + n_pre + (float) (len * 8)) / (this->bitRate * 1000.0)) * 1000000.0));
   }
   
   return(RADIOLIB_ERR_UNKNOWN);
@@ -1284,7 +1284,7 @@ RadioLibTime_t SX127x::calculateRxTimeout(RadioLibTime_t timeoutUs) {
   // the timeout is given as the number of symbols
   // the calling function should provide some extra width, as this number of symbols is truncated to integer
   // the order of operators is swapped here to decrease the effects of this truncation error
-  float symbolLength = (float) (RadioLibTime_t(1) << this->spreadingFactor) / (float) this->bandwidth;
+  float symbolLength = (float) (uint32_t(1) << this->spreadingFactor) / (float) this->bandwidth;
   RadioLibTime_t numSymbols = (timeoutUs / symbolLength) / 1000; 
   return(numSymbols);
 }

--- a/src/modules/SX127x/SX127x.h
+++ b/src/modules/SX127x/SX127x.h
@@ -1055,14 +1055,14 @@ class SX127x: public PhysicalLayer {
       \param len Payload length in bytes.
       \returns Expected time-on-air in microseconds.
     */
-    uint32_t getTimeOnAir(size_t len) override;
+    RadioLibTime_t getTimeOnAir(size_t len) override;
 
     /*!
       \brief Calculate the timeout value for this specific module / series (in number of symbols or units of time)
       \param timeoutUs Timeout in microseconds to listen for
       \returns Timeout value in a unit that is specific for the used module
     */
-    uint32_t calculateRxTimeout(uint32_t timeoutUs);
+    RadioLibTime_t calculateRxTimeout(RadioLibTime_t timeoutUs);
 
     /*!
       \brief Create the flags that make up RxDone and RxTimeout used for receiving downlinks

--- a/src/modules/SX128x/SX1280.cpp
+++ b/src/modules/SX128x/SX1280.cpp
@@ -13,7 +13,7 @@ int16_t SX1280::range(bool master, uint32_t addr, uint16_t calTable[3][6]) {
 
   // wait until ranging is finished
   Module* mod = this->getMod();
-  unsigned long start = mod->hal->millis();
+  RadioLibTime_t start = mod->hal->millis();
   while(!mod->hal->digitalRead(mod->getIrq())) {
     mod->hal->yield();
     if(mod->hal->millis() - start > 10000) {

--- a/src/modules/SX128x/SX1280.cpp
+++ b/src/modules/SX128x/SX1280.cpp
@@ -13,7 +13,7 @@ int16_t SX1280::range(bool master, uint32_t addr, uint16_t calTable[3][6]) {
 
   // wait until ranging is finished
   Module* mod = this->getMod();
-  uint32_t start = mod->hal->millis();
+  unsigned long start = mod->hal->millis();
   while(!mod->hal->digitalRead(mod->getIrq())) {
     mod->hal->yield();
     if(mod->hal->millis() - start > 10000) {

--- a/src/modules/SX128x/SX128x.cpp
+++ b/src/modules/SX128x/SX128x.cpp
@@ -281,7 +281,7 @@ int16_t SX128x::reset(bool verify) {
   }
 
   // set mode to standby
-  unsigned long start = this->mod->hal->millis();
+  RadioLibTime_t start = this->mod->hal->millis();
   while(true) {
     // try to set mode to standby
     int16_t state = standby();
@@ -318,7 +318,7 @@ int16_t SX128x::transmit(uint8_t* data, size_t len, uint8_t addr) {
   RADIOLIB_ASSERT(state);
 
   // calculate timeout in ms (500% of expected time-on-air)
-  uint32_t timeout = (getTimeOnAir(len) * 5) / 1000;
+  RadioLibTime_t timeout = (getTimeOnAir(len) * 5) / 1000;
   RADIOLIB_DEBUG_BASIC_PRINTLN("Timeout in %lu ms", timeout);
 
   // start transmission
@@ -326,7 +326,7 @@ int16_t SX128x::transmit(uint8_t* data, size_t len, uint8_t addr) {
   RADIOLIB_ASSERT(state);
 
   // wait for packet transmission or timeout
-  unsigned long start = this->mod->hal->millis();
+  RadioLibTime_t start = this->mod->hal->millis();
   while(!this->mod->hal->digitalRead(this->mod->getIrq())) {
     this->mod->hal->yield();
     if(this->mod->hal->millis() - start > timeout) {
@@ -350,7 +350,7 @@ int16_t SX128x::receive(uint8_t* data, size_t len) {
   RADIOLIB_ASSERT(state);
 
   // calculate timeout (1000% of expected time-on-air)
-  uint32_t timeout = getTimeOnAir(len) * 10;
+  RadioLibTime_t timeout = getTimeOnAir(len) * 10;
   RADIOLIB_DEBUG_BASIC_PRINTLN("Timeout in %lu ms", timeout);
 
   // start reception
@@ -360,7 +360,7 @@ int16_t SX128x::receive(uint8_t* data, size_t len) {
 
   // wait for packet reception or timeout
   bool softTimeout = false;
-  unsigned long start = this->mod->hal->millis();
+  RadioLibTime_t start = this->mod->hal->millis();
   while(!this->mod->hal->digitalRead(this->mod->getIrq())) {
     this->mod->hal->yield();
     // safety check, the timeout should be done by the radio
@@ -1235,7 +1235,7 @@ size_t SX128x::getPacketLength(bool update) {
   return((size_t)rxBufStatus[0]);
 }
 
-uint32_t SX128x::getTimeOnAir(size_t len) {
+RadioLibTime_t SX128x::getTimeOnAir(size_t len) {
   // check active modem
   uint8_t modem = getPacketType();
   if(modem == RADIOLIB_SX128X_PACKET_TYPE_LORA) {
@@ -1291,10 +1291,10 @@ uint32_t SX128x::getTimeOnAir(size_t len) {
     }
 
     // get time-on-air in us
-    return(((uint32_t(1) << sf) / this->bandwidthKhz) * N_symbol * 1000.0);
+    return(((RadioLibTime_t(1) << sf) / this->bandwidthKhz) * N_symbol * 1000.0);
 
   } else {
-    return(((uint32_t)len * 8 * 1000) / this->bitRateKbps);
+    return(((RadioLibTime_t)len * 8 * 1000) / this->bitRateKbps);
   }
 
 }

--- a/src/modules/SX128x/SX128x.cpp
+++ b/src/modules/SX128x/SX128x.cpp
@@ -1291,10 +1291,10 @@ RadioLibTime_t SX128x::getTimeOnAir(size_t len) {
     }
 
     // get time-on-air in us
-    return(((RadioLibTime_t(1) << sf) / this->bandwidthKhz) * N_symbol * 1000.0);
+    return(((uint32_t(1) << sf) / this->bandwidthKhz) * N_symbol * 1000.0);
 
   } else {
-    return(((RadioLibTime_t)len * 8 * 1000) / this->bitRateKbps);
+    return(((uint32_t)len * 8 * 1000) / this->bitRateKbps);
   }
 
 }

--- a/src/modules/SX128x/SX128x.cpp
+++ b/src/modules/SX128x/SX128x.cpp
@@ -281,7 +281,7 @@ int16_t SX128x::reset(bool verify) {
   }
 
   // set mode to standby
-  uint32_t start = this->mod->hal->millis();
+  unsigned long start = this->mod->hal->millis();
   while(true) {
     // try to set mode to standby
     int16_t state = standby();
@@ -326,7 +326,7 @@ int16_t SX128x::transmit(uint8_t* data, size_t len, uint8_t addr) {
   RADIOLIB_ASSERT(state);
 
   // wait for packet transmission or timeout
-  uint32_t start = this->mod->hal->millis();
+  unsigned long start = this->mod->hal->millis();
   while(!this->mod->hal->digitalRead(this->mod->getIrq())) {
     this->mod->hal->yield();
     if(this->mod->hal->millis() - start > timeout) {
@@ -360,7 +360,7 @@ int16_t SX128x::receive(uint8_t* data, size_t len) {
 
   // wait for packet reception or timeout
   bool softTimeout = false;
-  uint32_t start = this->mod->hal->millis();
+  unsigned long start = this->mod->hal->millis();
   while(!this->mod->hal->digitalRead(this->mod->getIrq())) {
     this->mod->hal->yield();
     // safety check, the timeout should be done by the radio

--- a/src/modules/SX128x/SX128x.h
+++ b/src/modules/SX128x/SX128x.h
@@ -722,7 +722,7 @@ class SX128x: public PhysicalLayer {
       \param len Payload length in bytes.
       \returns Expected time-on-air in microseconds.
     */
-    uint32_t getTimeOnAir(size_t len);
+    RadioLibTime_t getTimeOnAir(size_t len);
 
     /*!
       \brief Set implicit header mode for future reception/transmission.

--- a/src/modules/Si443x/Si443x.cpp
+++ b/src/modules/Si443x/Si443x.cpp
@@ -73,14 +73,14 @@ void Si443x::reset() {
 
 int16_t Si443x::transmit(uint8_t* data, size_t len, uint8_t addr) {
   // calculate timeout (5ms + 500 % of expected time-on-air)
-  uint32_t timeout = 5 + (uint32_t)((((float)(len * 8)) / this->bitRate) * 5);
+  RadioLibTime_t timeout = 5 + (uint32_t)((((float)(len * 8)) / this->bitRate) * 5);
 
   // start transmission
   int16_t state = startTransmit(data, len, addr);
   RADIOLIB_ASSERT(state);
 
   // wait for transmission end or timeout
-  unsigned long start = this->mod->hal->millis();
+  RadioLibTime_t start = this->mod->hal->millis();
   while(this->mod->hal->digitalRead(this->mod->getIrq())) {
     this->mod->hal->yield();
     if(this->mod->hal->millis() - start > timeout) {
@@ -94,14 +94,14 @@ int16_t Si443x::transmit(uint8_t* data, size_t len, uint8_t addr) {
 
 int16_t Si443x::receive(uint8_t* data, size_t len) {
   // calculate timeout (500 ms + 400 full 64-byte packets at current bit rate)
-  uint32_t timeout = 500 + (1.0/(this->bitRate))*(RADIOLIB_SI443X_MAX_PACKET_LENGTH*400.0);
+  RadioLibTime_t timeout = 500 + (1.0/(this->bitRate))*(RADIOLIB_SI443X_MAX_PACKET_LENGTH*400.0);
 
   // start reception
   int16_t state = startReceive();
   RADIOLIB_ASSERT(state);
 
   // wait for packet reception or timeout
-  unsigned long start = this->mod->hal->millis();
+  RadioLibTime_t start = this->mod->hal->millis();
   while(this->mod->hal->digitalRead(this->mod->getIrq())) {
     if(this->mod->hal->millis() - start > timeout) {
       standby();

--- a/src/modules/Si443x/Si443x.cpp
+++ b/src/modules/Si443x/Si443x.cpp
@@ -80,7 +80,7 @@ int16_t Si443x::transmit(uint8_t* data, size_t len, uint8_t addr) {
   RADIOLIB_ASSERT(state);
 
   // wait for transmission end or timeout
-  uint32_t start = this->mod->hal->millis();
+  unsigned long start = this->mod->hal->millis();
   while(this->mod->hal->digitalRead(this->mod->getIrq())) {
     this->mod->hal->yield();
     if(this->mod->hal->millis() - start > timeout) {
@@ -101,7 +101,7 @@ int16_t Si443x::receive(uint8_t* data, size_t len) {
   RADIOLIB_ASSERT(state);
 
   // wait for packet reception or timeout
-  uint32_t start = this->mod->hal->millis();
+  unsigned long start = this->mod->hal->millis();
   while(this->mod->hal->digitalRead(this->mod->getIrq())) {
     if(this->mod->hal->millis() - start > timeout) {
       standby();

--- a/src/protocols/BellModem/BellModem.cpp
+++ b/src/protocols/BellModem/BellModem.cpp
@@ -70,7 +70,7 @@ size_t BellClient::write(uint8_t b) {
 
   // iterate over the bits and set correct frequencies
   for(uint16_t mask = 0x80; mask >= 0x01; mask >>= 1) {
-    unsigned long start = mod->hal->micros();
+    RadioLibTime_t start = mod->hal->micros();
     if(b & mask) {
       this->tone(toneMark, false);
     } else {

--- a/src/protocols/BellModem/BellModem.cpp
+++ b/src/protocols/BellModem/BellModem.cpp
@@ -70,7 +70,7 @@ size_t BellClient::write(uint8_t b) {
 
   // iterate over the bits and set correct frequencies
   for(uint16_t mask = 0x80; mask >= 0x01; mask >>= 1) {
-    uint32_t start = mod->hal->micros();
+    unsigned long start = mod->hal->micros();
     if(b & mask) {
       this->tone(toneMark, false);
     } else {

--- a/src/protocols/FSK4/FSK4.cpp
+++ b/src/protocols/FSK4/FSK4.cpp
@@ -22,7 +22,7 @@ int16_t FSK4Client::begin(float base, uint32_t shift, uint16_t rate) {
   shiftFreqHz = shift;
 
   // calculate duration of 1 bit
-  bitDuration = (uint32_t)1000000/rate;
+  bitDuration = (RadioLibTime_t)1000000/rate;
 
   // calculate carrier shift
   shiftFreq = getRawShift(shift);
@@ -81,7 +81,7 @@ size_t FSK4Client::write(uint8_t b) {
 
 void FSK4Client::tone(uint8_t i) {
   Module* mod = phyLayer->getMod();
-  unsigned long start = mod->hal->micros();
+  RadioLibTime_t start = mod->hal->micros();
   transmitDirect(baseFreq + tones[i], baseFreqHz + tonesHz[i]);
   mod->waitForMicroseconds(start, bitDuration);
 }

--- a/src/protocols/FSK4/FSK4.cpp
+++ b/src/protocols/FSK4/FSK4.cpp
@@ -81,7 +81,7 @@ size_t FSK4Client::write(uint8_t b) {
 
 void FSK4Client::tone(uint8_t i) {
   Module* mod = phyLayer->getMod();
-  uint32_t start = mod->hal->micros();
+  unsigned long start = mod->hal->micros();
   transmitDirect(baseFreq + tones[i], baseFreqHz + tonesHz[i]);
   mod->waitForMicroseconds(start, bitDuration);
 }

--- a/src/protocols/FSK4/FSK4.h
+++ b/src/protocols/FSK4/FSK4.h
@@ -84,7 +84,7 @@ class FSK4Client {
 
     uint32_t baseFreq = 0, baseFreqHz = 0;
     uint32_t shiftFreq = 0, shiftFreqHz = 0;
-    uint32_t bitDuration = 0;
+    RadioLibTime_t bitDuration = 0;
     uint32_t tones[4];
     uint32_t tonesHz[4];
 

--- a/src/protocols/Hellschreiber/Hellschreiber.cpp
+++ b/src/protocols/Hellschreiber/Hellschreiber.cpp
@@ -36,7 +36,7 @@ size_t HellClient::printGlyph(uint8_t* buff) {
   bool transmitting = false;
   for(uint8_t mask = 0x40; mask >= 0x01; mask >>= 1) {
     for(int8_t i = RADIOLIB_HELL_FONT_HEIGHT - 1; i >= 0; i--) {
-        unsigned long start = mod->hal->micros();
+        RadioLibTime_t start = mod->hal->micros();
         if((buff[i] & mask) && (!transmitting)) {
           transmitting = true;
           transmitDirect(baseFreq, baseFreqHz);

--- a/src/protocols/Hellschreiber/Hellschreiber.cpp
+++ b/src/protocols/Hellschreiber/Hellschreiber.cpp
@@ -36,7 +36,7 @@ size_t HellClient::printGlyph(uint8_t* buff) {
   bool transmitting = false;
   for(uint8_t mask = 0x40; mask >= 0x01; mask >>= 1) {
     for(int8_t i = RADIOLIB_HELL_FONT_HEIGHT - 1; i >= 0; i--) {
-        uint32_t start = mod->hal->micros();
+        unsigned long start = mod->hal->micros();
         if((buff[i] & mask) && (!transmitting)) {
           transmitting = true;
           transmitDirect(baseFreq, baseFreqHz);

--- a/src/protocols/LoRaWAN/LoRaWAN.cpp
+++ b/src/protocols/LoRaWAN/LoRaWAN.cpp
@@ -877,7 +877,7 @@ int16_t LoRaWANNode::uplink(uint8_t* data, size_t len, uint8_t port, bool isConf
   }
 
   // if adhering to dutyCycle and the time since last uplink + interval has not elapsed, return an error
-  if(this->dutyCycleEnabled && this->rxDelayStart + (unsigned long)dutyCycleInterval(this->dutyCycle, this->lastToA) > mod->hal->millis()) {
+  if(this->dutyCycleEnabled && this->rxDelayStart + (RadioLibTime_t)dutyCycleInterval(this->dutyCycle, this->lastToA) > mod->hal->millis()) {
     return(RADIOLIB_ERR_UPLINK_UNAVAILABLE);
   }
 
@@ -1143,7 +1143,7 @@ int16_t LoRaWANNode::uplink(uint8_t* data, size_t len, uint8_t port, bool isConf
 
 int16_t LoRaWANNode::downlinkCommon() {
   Module* mod = this->phyLayer->getMod();
-  const uint32_t scanGuard = 10;
+  const RadioLibTime_t scanGuard = 10;
 
   // check if there are any upcoming Rx windows
   // if the Rx1 window has already started, you're too late, because most downlinks happen in Rx1
@@ -1181,12 +1181,12 @@ int16_t LoRaWANNode::downlinkCommon() {
     // calculate the Rx timeout
     // according to the spec, this must be at least enough time to effectively detect a preamble
     // but pad it a bit on both sides (start and end) to make sure it is wide enough
-    uint32_t timeoutHost = this->phyLayer->getTimeOnAir(0) + 2*scanGuard*1000;
-    uint32_t timeoutMod  = this->phyLayer->calculateRxTimeout(timeoutHost);
+    RadioLibTime_t timeoutHost = this->phyLayer->getTimeOnAir(0) + 2*scanGuard*1000;
+    RadioLibTime_t timeoutMod  = this->phyLayer->calculateRxTimeout(timeoutHost);
 
     // wait for the start of the Rx window
     // the waiting duration is shortened a bit to cover any possible timing errors
-    uint32_t waitLen = this->rxDelays[i] - (mod->hal->millis() - this->rxDelayStart);
+    RadioLibTime_t waitLen = this->rxDelays[i] - (mod->hal->millis() - this->rxDelayStart);
     if(waitLen > scanGuard) {
       waitLen -= scanGuard;
     }
@@ -1942,7 +1942,7 @@ void LoRaWANNode::setADR(bool enable) {
   this->adrEnabled = enable;
 }
 
-void LoRaWANNode::setDutyCycle(bool enable, uint32_t msPerHour) {
+void LoRaWANNode::setDutyCycle(bool enable, RadioLibTime_t msPerHour) {
   this->dutyCycleEnabled = enable;
   if(msPerHour <= 0) {
     this->dutyCycle = this->band->dutyCycle;
@@ -1953,26 +1953,26 @@ void LoRaWANNode::setDutyCycle(bool enable, uint32_t msPerHour) {
 
 // given an airtime in milliseconds, calculate the minimum uplink interval
 // to adhere to a given dutyCycle
-uint32_t LoRaWANNode::dutyCycleInterval(uint32_t msPerHour, uint32_t airtime) {
+RadioLibTime_t LoRaWANNode::dutyCycleInterval(RadioLibTime_t msPerHour, RadioLibTime_t airtime) {
   if(msPerHour == 0 || airtime == 0) {
     return(0);
   }
-  uint32_t oneHourInMs = (uint32_t)60 * (uint32_t)60 * (uint32_t)1000;
+  RadioLibTime_t oneHourInMs = (RadioLibTime_t)60 * (RadioLibTime_t)60 * (RadioLibTime_t)1000;
   float numPackets = msPerHour / airtime;
-  uint32_t delayMs = oneHourInMs / numPackets + 1;  // + 1 to prevent rounding problems
+  RadioLibTime_t delayMs = oneHourInMs / numPackets + 1;  // + 1 to prevent rounding problems
   return(delayMs);
 }
 
-uint32_t LoRaWANNode::timeUntilUplink() {
+RadioLibTime_t LoRaWANNode::timeUntilUplink() {
   Module* mod = this->phyLayer->getMod();
-  unsigned long nextUplink = this->rxDelayStart + dutyCycleInterval(this->dutyCycle, this->lastToA);
+  RadioLibTime_t nextUplink = this->rxDelayStart + dutyCycleInterval(this->dutyCycle, this->lastToA);
   if(mod->hal->millis() > nextUplink){
     return(0);
   }
   return(nextUplink - mod->hal->millis() + 1);
 }
 
-void LoRaWANNode::setDwellTime(bool enable, uint32_t msPerUplink) {
+void LoRaWANNode::setDwellTime(bool enable, RadioLibTime_t msPerUplink) {
   this->dwellTimeEnabledUp = enable;
   if(msPerUplink <= 0) {
     this->dwellTimeUp = this->band->dwellTimeUp;
@@ -2320,7 +2320,7 @@ bool LoRaWANNode::execMacCommand(LoRaWANMacCommand_t* cmd) {
       if(maxDutyCycle == 0) {
         this->dutyCycle = this->band->dutyCycle;
       } else {
-        this->dutyCycle = (uint32_t)60 * (uint32_t)60 * (uint32_t)1000 / (uint32_t)(1UL << maxDutyCycle);
+        this->dutyCycle = (RadioLibTime_t)60 * (RadioLibTime_t)60 * (RadioLibTime_t)1000 / (RadioLibTime_t)(1UL << maxDutyCycle);
       }
 
       memcpy(&this->bufferSession[RADIOLIB_LORAWAN_SESSION_DUTY_CYCLE], cmd->payload, cmd->len);

--- a/src/protocols/LoRaWAN/LoRaWAN.cpp
+++ b/src/protocols/LoRaWAN/LoRaWAN.cpp
@@ -877,7 +877,7 @@ int16_t LoRaWANNode::uplink(uint8_t* data, size_t len, uint8_t port, bool isConf
   }
 
   // if adhering to dutyCycle and the time since last uplink + interval has not elapsed, return an error
-  if(this->dutyCycleEnabled && this->rxDelayStart + dutyCycleInterval(this->dutyCycle, this->lastToA) > mod->hal->millis()) {
+  if(this->dutyCycleEnabled && this->rxDelayStart + (unsigned long)dutyCycleInterval(this->dutyCycle, this->lastToA) > mod->hal->millis()) {
     return(RADIOLIB_ERR_UPLINK_UNAVAILABLE);
   }
 
@@ -1965,7 +1965,7 @@ uint32_t LoRaWANNode::dutyCycleInterval(uint32_t msPerHour, uint32_t airtime) {
 
 uint32_t LoRaWANNode::timeUntilUplink() {
   Module* mod = this->phyLayer->getMod();
-  uint32_t nextUplink = this->rxDelayStart + dutyCycleInterval(this->dutyCycle, this->lastToA);
+  unsigned long nextUplink = this->rxDelayStart + dutyCycleInterval(this->dutyCycle, this->lastToA);
   if(mod->hal->millis() > nextUplink){
     return(0);
   }

--- a/src/protocols/LoRaWAN/LoRaWAN.h
+++ b/src/protocols/LoRaWAN/LoRaWAN.h
@@ -361,13 +361,13 @@ struct LoRaWANBand_t {
   int8_t powerNumSteps;
 
   /*! \brief Number of milliseconds per hour of allowed Time-on-Air */
-  uint32_t dutyCycle;
+  RadioLibTime_t dutyCycle;
 
   /*! \brief Maximum dwell time per uplink message in milliseconds */
-  uint32_t dwellTimeUp;
+  RadioLibTime_t dwellTimeUp;
 
   /*! \brief Maximum dwell time per downlink message in milliseconds */
-  uint32_t dwellTimeDn;
+  RadioLibTime_t dwellTimeDn;
 
   /*! \brief A set of default uplink (TX) channels for frequency-type bands */
   LoRaWANChannel_t txFreqs[3];
@@ -772,7 +772,7 @@ class LoRaWANNode {
       \param msPerHour The maximum allowed Time-on-Air per hour in milliseconds 
       (default 0 = maximum allowed for configured band).
     */
-    void setDutyCycle(bool enable = true, uint32_t msPerHour = 0);
+    void setDutyCycle(bool enable = true, RadioLibTime_t msPerHour = 0);
 
     /*!
       \brief Calculate the minimum interval to adhere to a certain dutyCycle.
@@ -781,10 +781,10 @@ class LoRaWANNode {
       \param airtime The airtime of the uplink.
       \returns Required interval (delay) in milliseconds between consecutive uplinks.
     */
-    uint32_t dutyCycleInterval(uint32_t msPerHour, uint32_t airtime);
+    RadioLibTime_t dutyCycleInterval(RadioLibTime_t msPerHour, RadioLibTime_t airtime);
 
     /*! \brief Returns time in milliseconds until next uplink is available under dutyCycle limits */
-    uint32_t timeUntilUplink();
+    RadioLibTime_t timeUntilUplink();
 
     /*!
       \brief Toggle adherence to dwellTime limits to on or off.
@@ -792,7 +792,7 @@ class LoRaWANNode {
       \param msPerUplink The maximum allowed Time-on-Air per uplink in milliseconds 
       (default 0 = maximum allowed for configured band).
     */
-    void setDwellTime(bool enable, uint32_t msPerUplink = 0);
+    void setDwellTime(bool enable, RadioLibTime_t msPerUplink = 0);
 
     /*! 
       \brief Returns the maximum payload given the currently present dwell time limits.
@@ -932,16 +932,16 @@ class LoRaWANNode {
     uint8_t rev = 0;
 
     // Time on Air of last uplink
-    uint32_t lastToA = 0;
+    RadioLibTime_t lastToA = 0;
 
     // timestamp to measure the RX1/2 delay (from uplink end)
-    unsigned long rxDelayStart = 0;
+    RadioLibTime_t rxDelayStart = 0;
 
     // timestamp when the Rx1/2 windows were closed (timeout or uplink received)
-    unsigned long rxDelayEnd = 0;
+    RadioLibTime_t rxDelayEnd = 0;
 
     // delays between the uplink and RX1/2 windows
-    uint32_t rxDelays[2] = { RADIOLIB_LORAWAN_RECEIVE_DELAY_1_MS, RADIOLIB_LORAWAN_RECEIVE_DELAY_2_MS };
+    RadioLibTime_t rxDelays[2] = { RADIOLIB_LORAWAN_RECEIVE_DELAY_1_MS, RADIOLIB_LORAWAN_RECEIVE_DELAY_2_MS };
 
     // device status - battery level
     uint8_t battLevel = 0xFF;

--- a/src/protocols/LoRaWAN/LoRaWAN.h
+++ b/src/protocols/LoRaWAN/LoRaWAN.h
@@ -935,10 +935,10 @@ class LoRaWANNode {
     uint32_t lastToA = 0;
 
     // timestamp to measure the RX1/2 delay (from uplink end)
-    uint32_t rxDelayStart = 0;
+    unsigned long rxDelayStart = 0;
 
     // timestamp when the Rx1/2 windows were closed (timeout or uplink received)
-    uint32_t rxDelayEnd = 0;
+    unsigned long rxDelayEnd = 0;
 
     // delays between the uplink and RX1/2 windows
     uint32_t rxDelays[2] = { RADIOLIB_LORAWAN_RECEIVE_DELAY_1_MS, RADIOLIB_LORAWAN_RECEIVE_DELAY_2_MS };

--- a/src/protocols/Morse/Morse.h
+++ b/src/protocols/Morse/Morse.h
@@ -167,9 +167,9 @@ class MorseClient: public RadioLibPrint {
 
     // variables to keep decoding state
     uint32_t signalCounter = 0;
-    unsigned long signalStart = 0;
+    RadioLibTime_t signalStart = 0;
     uint32_t pauseCounter = 0;
-    unsigned long pauseStart = 0;
+    RadioLibTime_t pauseStart = 0;
 
     size_t printNumber(unsigned long, uint8_t);
     size_t printFloat(double, uint8_t);

--- a/src/protocols/Morse/Morse.h
+++ b/src/protocols/Morse/Morse.h
@@ -167,9 +167,9 @@ class MorseClient: public RadioLibPrint {
 
     // variables to keep decoding state
     uint32_t signalCounter = 0;
-    uint32_t signalStart = 0;
+    unsigned long signalStart = 0;
     uint32_t pauseCounter = 0;
-    uint32_t pauseStart = 0;
+    unsigned long pauseStart = 0;
 
     size_t printNumber(unsigned long, uint8_t);
     size_t printFloat(double, uint8_t);

--- a/src/protocols/Pager/Pager.cpp
+++ b/src/protocols/Pager/Pager.cpp
@@ -511,7 +511,7 @@ void PagerClient::write(uint32_t codeWord) {
   Module* mod = phyLayer->getMod();
   for(int8_t i = 31; i >= 0; i--) {
     uint32_t mask = (uint32_t)0x01 << i;
-    uint32_t start = mod->hal->micros();
+    unsigned long start = mod->hal->micros();
 
     // figure out the shift direction - start by assuming the bit is 0
     int16_t change = shiftFreq;
@@ -532,7 +532,7 @@ void PagerClient::write(uint32_t codeWord) {
     // this is pretty silly, while(mod->hal->micros() ... ) would be enough
     // but for some reason, MegaCore throws a linker error on it
     // "relocation truncated to fit: R_AVR_7_PCREL against `no symbol'"
-    uint32_t now = mod->hal->micros();
+    unsigned long now = mod->hal->micros();
     while(now - start < bitDuration) {
       now = mod->hal->micros();
     }

--- a/src/protocols/Pager/Pager.cpp
+++ b/src/protocols/Pager/Pager.cpp
@@ -36,7 +36,7 @@ PagerClient::PagerClient(PhysicalLayer* phy) {
 int16_t PagerClient::begin(float base, uint16_t speed, bool invert, uint16_t shift) {
   // calculate duration of 1 bit in us
   dataRate = (float)speed/1000.0f;
-  bitDuration = (uint32_t)1000000/speed;
+  bitDuration = (RadioLibTime_t)1000000/speed;
 
   // calculate 24-bit frequency
   baseFreq = base;
@@ -511,7 +511,7 @@ void PagerClient::write(uint32_t codeWord) {
   Module* mod = phyLayer->getMod();
   for(int8_t i = 31; i >= 0; i--) {
     uint32_t mask = (uint32_t)0x01 << i;
-    unsigned long start = mod->hal->micros();
+    RadioLibTime_t start = mod->hal->micros();
 
     // figure out the shift direction - start by assuming the bit is 0
     int16_t change = shiftFreq;
@@ -532,7 +532,7 @@ void PagerClient::write(uint32_t codeWord) {
     // this is pretty silly, while(mod->hal->micros() ... ) would be enough
     // but for some reason, MegaCore throws a linker error on it
     // "relocation truncated to fit: R_AVR_7_PCREL against `no symbol'"
-    unsigned long now = mod->hal->micros();
+    RadioLibTime_t now = mod->hal->micros();
     while(now - start < bitDuration) {
       now = mod->hal->micros();
     }

--- a/src/protocols/Pager/Pager.h
+++ b/src/protocols/Pager/Pager.h
@@ -182,7 +182,7 @@ class PagerClient {
     uint32_t baseFreqRaw;
     uint16_t shiftFreq;
     uint16_t shiftFreqHz;
-    uint16_t bitDuration;
+    RadioLibTime_t bitDuration;
     uint32_t filterAddr;
     uint32_t filterMask;
     uint32_t *filterAddresses;

--- a/src/protocols/PhysicalLayer/PhysicalLayer.cpp
+++ b/src/protocols/PhysicalLayer/PhysicalLayer.cpp
@@ -294,12 +294,12 @@ float PhysicalLayer::getSNR() {
   return(RADIOLIB_ERR_UNSUPPORTED);
 }
 
-uint32_t PhysicalLayer::getTimeOnAir(size_t len) {
+RadioLibTime_t PhysicalLayer::getTimeOnAir(size_t len) {
   (void)len;
   return(0);
 }
 
-uint32_t PhysicalLayer::calculateRxTimeout(uint32_t timeoutUs) {
+RadioLibTime_t PhysicalLayer::calculateRxTimeout(RadioLibTime_t timeoutUs) {
   (void)timeoutUs;
   return(0); 
 }

--- a/src/protocols/PhysicalLayer/PhysicalLayer.h
+++ b/src/protocols/PhysicalLayer/PhysicalLayer.h
@@ -335,14 +335,14 @@ class PhysicalLayer {
       \param len Payload length in bytes.
       \returns Expected time-on-air in microseconds.
     */
-    virtual uint32_t getTimeOnAir(size_t len);
+    virtual RadioLibTime_t getTimeOnAir(size_t len);
 
     /*!
       \brief Calculate the timeout value for this specific module / series (in number of symbols or units of time)
       \param timeoutUs Timeout in microseconds to listen for
       \returns Timeout value in a unit that is specific for the used module
     */
-    virtual uint32_t calculateRxTimeout(uint32_t timeoutUs);
+    virtual RadioLibTime_t calculateRxTimeout(RadioLibTime_t timeoutUs);
 
     /*!
       \brief Create the flags that make up RxDone and RxTimeout used for receiving downlinks

--- a/src/protocols/RTTY/RTTY.cpp
+++ b/src/protocols/RTTY/RTTY.cpp
@@ -91,14 +91,14 @@ size_t RTTYClient::write(uint8_t b) {
 
 void RTTYClient::mark() {
   Module* mod = phyLayer->getMod();
-  uint32_t start = mod->hal->micros();
+  unsigned long start = mod->hal->micros();
   transmitDirect(baseFreq + shiftFreq, baseFreqHz + shiftFreqHz);
   mod->waitForMicroseconds(start, bitDuration);
 }
 
 void RTTYClient::space() {
   Module* mod = phyLayer->getMod();
-  uint32_t start = mod->hal->micros();
+  unsigned long start = mod->hal->micros();
   transmitDirect(baseFreq, baseFreqHz);
   mod->waitForMicroseconds(start, bitDuration);
 }

--- a/src/protocols/RTTY/RTTY.cpp
+++ b/src/protocols/RTTY/RTTY.cpp
@@ -28,7 +28,7 @@ int16_t RTTYClient::begin(float base, uint32_t shift, uint16_t rate, uint8_t enc
   shiftFreqHz = shift;
 
   // calculate duration of 1 bit
-  bitDuration = (uint32_t)1000000/rate;
+  bitDuration = (RadioLibTime_t)1000000/rate;
 
   // calculate module carrier frequency resolution
   uint32_t step = round(phyLayer->getFreqStep());
@@ -91,14 +91,14 @@ size_t RTTYClient::write(uint8_t b) {
 
 void RTTYClient::mark() {
   Module* mod = phyLayer->getMod();
-  unsigned long start = mod->hal->micros();
+  RadioLibTime_t start = mod->hal->micros();
   transmitDirect(baseFreq + shiftFreq, baseFreqHz + shiftFreqHz);
   mod->waitForMicroseconds(start, bitDuration);
 }
 
 void RTTYClient::space() {
   Module* mod = phyLayer->getMod();
-  unsigned long start = mod->hal->micros();
+  RadioLibTime_t start = mod->hal->micros();
   transmitDirect(baseFreq, baseFreqHz);
   mod->waitForMicroseconds(start, bitDuration);
 }

--- a/src/protocols/RTTY/RTTY.h
+++ b/src/protocols/RTTY/RTTY.h
@@ -71,7 +71,7 @@ class RTTYClient: public RadioLibPrint {
 
     uint32_t baseFreq = 0, baseFreqHz = 0;
     uint32_t shiftFreq = 0, shiftFreqHz = 0;
-    uint32_t bitDuration = 0;
+    RadioLibTime_t bitDuration = 0;
     uint8_t stopBitsNum = 0;
 
     void mark();

--- a/src/protocols/SSTV/SSTV.cpp
+++ b/src/protocols/SSTV/SSTV.cpp
@@ -289,9 +289,9 @@ uint16_t SSTVClient::getPictureHeight() const {
   return(txMode.height);
 }
 
-void SSTVClient::tone(float freq, uint32_t len) {
+void SSTVClient::tone(float freq, RadioLibTime_t len) {
   Module* mod = phyLayer->getMod();
-  unsigned long start = mod->hal->micros();
+  RadioLibTime_t start = mod->hal->micros();
   #if !RADIOLIB_EXCLUDE_AFSK
   if(audioClient != nullptr) {
     audioClient->tone(freq, false);

--- a/src/protocols/SSTV/SSTV.cpp
+++ b/src/protocols/SSTV/SSTV.cpp
@@ -291,7 +291,7 @@ uint16_t SSTVClient::getPictureHeight() const {
 
 void SSTVClient::tone(float freq, uint32_t len) {
   Module* mod = phyLayer->getMod();
-  uint32_t start = mod->hal->micros();
+  unsigned long start = mod->hal->micros();
   #if !RADIOLIB_EXCLUDE_AFSK
   if(audioClient != nullptr) {
     audioClient->tone(freq, false);

--- a/src/protocols/SSTV/SSTV.h
+++ b/src/protocols/SSTV/SSTV.h
@@ -54,7 +54,7 @@ struct tone_t {
   /*!
     \brief Length of tone in us, set to 0 for picture scan tones.
   */
-  uint32_t len;
+  RadioLibTime_t len;
 
   /*!
     \brief Frequency of tone in Hz, set to 0 for picture scan tones.
@@ -194,7 +194,7 @@ class SSTVClient {
     SSTVMode_t txMode = Scottie1;
     bool firstLine = true;
 
-    void tone(float freq, uint32_t len = 0);
+    void tone(float freq, RadioLibTime_t len = 0);
 };
 
 #endif


### PR DESCRIPTION
Although `sizeof(uint32_t) == sizeof(unsigned long)` on Arduino, this is not the case on 64-bit Linux, where `sizeof(unsigned long) == sizeof(uint64_t)`.

Most timestamp arithmetic and comparisons have been left alone, to reduce code churn. This is fine, as `uint32_t` is perfectly wide to store most timestamp deltas this library will deal with, and C will promote the integer rather than do a narrowing conversion. The real problem arises with narrowing conversions being done by assuming timestamps are 32-bit.

No functional changes intended for platforms where `sizeof(uint32_t) == sizeof(unsigned long)` (so most 8/16/32-bit platforms).