### PR TITLE
add support for Pi Pico + sx1262 module to LoRaWAN examples

### DIFF
--- a/examples/LoRaWAN/LoRaWAN_ABP/LoRaWAN_ABP.ino
+++ b/examples/LoRaWAN/LoRaWAN_ABP/LoRaWAN_ABP.ino
@@ -37,14 +37,14 @@ void setup() {
   delay(5000);  // Give time to switch to the serial monitor
   Serial.println(F("\nSetup ... "));
   
-#if defined(Pi_Pico_1262_LoRa)
-  SPI1.setSCK(10);            // fix from https://github.com/jgromes/RadioLib/issues/729
-  SPI1.setTX(11);             // ~
-  SPI1.setRX(12);             // ~
-  pinMode(3, OUTPUT);         // ~
-  digitalWrite(3, HIGH);      // ~
-  SPI1.begin(false);          // fix from https://github.com/jgromes/RadioLib/issues/729
-#endif
+  #if defined(Pi_Pico_1262_LoRa)
+    SPI1.setSCK(10);            // fix from https://github.com/jgromes/RadioLib/issues/729
+    SPI1.setTX(11);             // ~
+    SPI1.setRX(12);             // ~
+    pinMode(3, OUTPUT);         // ~
+    digitalWrite(3, HIGH);      // ~
+    SPI1.begin(false);          // fix from https://github.com/jgromes/RadioLib/issues/729
+  #endif
 
   Serial.println(F("Initialise the radio"));
   int state = radio.begin();

--- a/examples/LoRaWAN/LoRaWAN_ABP/LoRaWAN_ABP.ino
+++ b/examples/LoRaWAN/LoRaWAN_ABP/LoRaWAN_ABP.ino
@@ -36,6 +36,15 @@ void setup() {
   while(!Serial);
   delay(5000);  // Give time to switch to the serial monitor
   Serial.println(F("\nSetup ... "));
+  
+#if defined(Pi_Pico_1262_LoRa)
+  SPI1.setSCK(10);            // fix from https://github.com/jgromes/RadioLib/issues/729
+  SPI1.setTX(11);             // ~
+  SPI1.setRX(12);             // ~
+  pinMode(3, OUTPUT);         // ~
+  digitalWrite(3, HIGH);      // ~
+  SPI1.begin(false);          // fix from https://github.com/jgromes/RadioLib/issues/729
+#endif
 
   Serial.println(F("Initialise the radio"));
   int state = radio.begin();

--- a/examples/LoRaWAN/LoRaWAN_ABP/configABP.h
+++ b/examples/LoRaWAN/LoRaWAN_ABP/configABP.h
@@ -3,6 +3,8 @@
 
 #include <RadioLib.h>
 
+#define Pi_Pico_1262_LoRa   // set to match hardware in-use (see pin maps below!)
+
 // how often to send an uplink - consider legal & FUP constraints - see notes
 const uint32_t uplinkIntervalSeconds = 5UL * 60UL;    // minutes x seconds
 
@@ -46,6 +48,11 @@ const uint8_t subBand = 0;  // For US915, change this to 2, otherwise leave on 0
     #pragma message ("Link required on board")
     SX1276 radio = new Module(8, 3, 4, 6);
 
+// Pi_Pico_1262_LoRa
+#elif defined(Pi_Pico_1262_LoRa)
+  #pragma message ("Pi_Pico_1262_LoRa")
+     // fix from https://github.com/jgromes/RadioLib/issues/729
+  SX1262 radio = new Module(3, 20, 15, 2, SPI1, RADIOLIB_DEFAULT_SPI_SETTINGS);
 
 // LilyGo 
 #elif defined(ARDUINO_TTGO_LORA32_V1)

--- a/examples/LoRaWAN/LoRaWAN_Reference/LoRaWAN_Reference.ino
+++ b/examples/LoRaWAN/LoRaWAN_Reference/LoRaWAN_Reference.ino
@@ -39,6 +39,15 @@ void setup() {
   delay(5000);  // Give time to switch to the serial monitor
   Serial.println(F("\nSetup"));
 
+  #if defined(Pi_Pico_1262_LoRa)
+    SPI1.setSCK(10);            // fix from https://github.com/jgromes/RadioLib/issues/729
+    SPI1.setTX(11);             // ~
+    SPI1.setRX(12);             // ~
+    pinMode(3, OUTPUT);         // ~
+    digitalWrite(3, HIGH);      // ~
+    SPI1.begin(false);          // fix from https://github.com/jgromes/RadioLib/issues/729
+  #endif
+
   int16_t state = 0;  // return value for calls to RadioLib
 
   Serial.println(F("Initialise the radio"));

--- a/examples/LoRaWAN/LoRaWAN_Reference/config.h
+++ b/examples/LoRaWAN/LoRaWAN_Reference/config.h
@@ -3,6 +3,8 @@
 
 #include <RadioLib.h>
 
+#define Pi_Pico_1262_LoRa   // set to match hardware in-use (see pin maps below!)
+
 // how often to send an uplink - consider legal & FUP constraints - see notes
 const uint32_t uplinkIntervalSeconds = 5UL * 60UL;    // minutes x seconds
 
@@ -41,6 +43,11 @@ const uint8_t subBand = 0;  // For US915, change this to 2, otherwise leave on 0
     #pragma message ("Link required on board")
     SX1276 radio = new Module(8, 3, 4, 6);
 
+// Pi_Pico_1262_LoRa
+#elif defined(Pi_Pico_1262_LoRa)
+  #pragma message ("Pi_Pico_1262_LoRa")
+     // fix from https://github.com/jgromes/RadioLib/issues/729
+  SX1262 radio = new Module(3, 20, 15, 2, SPI1, RADIOLIB_DEFAULT_SPI_SETTINGS);
 
 // LilyGo 
 #elif defined(ARDUINO_TTGO_LORA32_V1)

--- a/examples/LoRaWAN/LoRaWAN_Starter/LoRaWAN_Starter.ino
+++ b/examples/LoRaWAN/LoRaWAN_Starter/LoRaWAN_Starter.ino
@@ -29,6 +29,15 @@ void setup() {
   while(!Serial);
   delay(5000);  // Give time to switch to the serial monitor
   Serial.println(F("\nSetup ... "));
+  
+  #if defined(Pi_Pico_1262_LoRa)
+    SPI1.setSCK(10);            // fix from https://github.com/jgromes/RadioLib/issues/729
+    SPI1.setTX(11);             // ~
+    SPI1.setRX(12);             // ~
+    pinMode(3, OUTPUT);         // ~
+    digitalWrite(3, HIGH);      // ~
+    SPI1.begin(false);          // fix from https://github.com/jgromes/RadioLib/issues/729
+  #endif
 
   Serial.println(F("Initialise the radio"));
   int state = radio.begin();

--- a/examples/LoRaWAN/LoRaWAN_Starter/config.h
+++ b/examples/LoRaWAN/LoRaWAN_Starter/config.h
@@ -3,6 +3,8 @@
 
 #include <RadioLib.h>
 
+#define Pi_Pico_1262_LoRa   // set to match hardware in-use (see pin maps below!)
+
 // how often to send an uplink - consider legal & FUP constraints - see notes
 const uint32_t uplinkIntervalSeconds = 5UL * 60UL;    // minutes x seconds
 
@@ -41,6 +43,11 @@ const uint8_t subBand = 0;  // For US915, change this to 2, otherwise leave on 0
     #pragma message ("Link required on board")
     SX1276 radio = new Module(8, 3, 4, 6);
 
+// Pi_Pico_1262_LoRa
+#elif defined(Pi_Pico_1262_LoRa)
+  #pragma message ("Pi_Pico_1262_LoRa")
+     // fix from https://github.com/jgromes/RadioLib/issues/729
+  SX1262 radio = new Module(3, 20, 15, 2, SPI1, RADIOLIB_DEFAULT_SPI_SETTINGS);
 
 // LilyGo 
 #elif defined(ARDUINO_TTGO_LORA32_V1)


### PR DESCRIPTION
Hello!   After finding success w/ the LoRaWAN examples using my Arduino UNO + sx1278 hardware, I wanted to be able to utilize the excellent **Waveshare SX1262 LoRa Node Module for Raspberry Pi Pico** (https://www.waveshare.com/pico-lora-sx1262-868m.htm) that is a direct header plug-in to the Pi Pico microcontroller.

![pico+sx1262](https://github.com/jgromes/RadioLib/assets/19886368/d55e5da2-128a-4439-a002-8a16f8bb30ef)


A previous issue (https://github.com/jgromes/RadioLib/issues/729) identified the syntax required to use the sx1262 module.

After modifying my local code to successfully uplink a LoRaWAN payload using the Pi Pico / sx1262 combination, I wanted to share the code if by chance you would like to integrate this hardware option into the list of choices in the LoRaWAN examples.

Thanks!

-Scott,  K4KDR