### PR TITLE
Fixes overload warning when building with ESP IDF

### DIFF
--- a/src/modules/LR11x0/LR11x0.cpp
+++ b/src/modules/LR11x0/LR11x0.cpp
@@ -312,6 +312,10 @@ int16_t LR11x0::standby(uint8_t mode, bool wakeup) {
   return(this->SPIcommand(RADIOLIB_LR11X0_CMD_SET_STANDBY, true, buff, 1));
 }
 
+int16_t LR11x0::sleep() {
+  return(LR11x0::sleep(true, 0));
+}
+
 int16_t LR11x0::sleep(bool retainConfig, uint32_t sleepTime) {
   // set RF switch (if present)
   this->mod->setRfSwitchState(Module::MODE_IDLE);

--- a/src/modules/LR11x0/LR11x0.h
+++ b/src/modules/LR11x0/LR11x0.h
@@ -774,7 +774,10 @@ class LR11x0: public PhysicalLayer {
       \param sleepTime Sleep duration (enables automatic wakeup), in multiples of 30.52 us. Ignored if set to 0.
       \returns \ref status_codes
     */
-    int16_t sleep(bool retainConfig = true, uint32_t sleepTime = 0);
+
+    int16_t sleep();
+
+    int16_t sleep(bool retainConfig, uint32_t sleepTime);
     
     // interrupt methods
 

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -442,6 +442,11 @@ int16_t SX126x::scanChannel(uint8_t symbolNum, uint8_t detPeak, uint8_t detMin) 
   return(getChannelScanResult());
 }
 
+
+int16_t SX126x::sleep() {
+  return(SX126x::sleep(true));
+}
+
 int16_t SX126x::sleep(bool retainConfig) {
   // set RF switch (if present)
   this->mod->setRfSwitchState(Module::MODE_IDLE);

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -552,7 +552,11 @@ class SX126x: public PhysicalLayer {
       or to false to discard current configuration ("cold start"). Defaults to true.
       \returns \ref status_codes
     */
-    int16_t sleep(bool retainConfig = true);
+
+
+    int16_t sleep(); 
+
+    int16_t sleep(bool retainConfig);
 
     /*!
       \brief Sets the module to standby mode (overload for PhysicalLayer compatibility, uses 13 MHz RC oscillator).

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -552,10 +552,7 @@ class SX126x: public PhysicalLayer {
       or to false to discard current configuration ("cold start"). Defaults to true.
       \returns \ref status_codes
     */
-
-
     int16_t sleep(); 
-
     int16_t sleep(bool retainConfig);
 
     /*!

--- a/src/modules/SX128x/SX128x.cpp
+++ b/src/modules/SX128x/SX128x.cpp
@@ -424,6 +424,10 @@ int16_t SX128x::scanChannel() {
   return(getChannelScanResult());
 }
 
+int16_t SX128x::sleep() {
+  return(SX128x::sleep(true));
+}
+
 int16_t SX128x::sleep(bool retainConfig) {
   // set RF switch (if present)
   this->mod->setRfSwitchState(Module::MODE_IDLE);

--- a/src/modules/SX128x/SX128x.h
+++ b/src/modules/SX128x/SX128x.h
@@ -463,9 +463,7 @@ class SX128x: public PhysicalLayer {
       to discard current configuration and data buffer. Defaults to true.
       \returns \ref status_codes
     */
-
     int16_t sleep();
-
     int16_t sleep(bool retainConfig);
 
     /*!

--- a/src/modules/SX128x/SX128x.h
+++ b/src/modules/SX128x/SX128x.h
@@ -463,7 +463,10 @@ class SX128x: public PhysicalLayer {
       to discard current configuration and data buffer. Defaults to true.
       \returns \ref status_codes
     */
-    int16_t sleep(bool retainConfig = true);
+
+    int16_t sleep();
+
+    int16_t sleep(bool retainConfig);
 
     /*!
       \brief Sets the module to standby mode (overload for PhysicalLayer compatibility, uses 13 MHz RC oscillator).


### PR DESCRIPTION
Similar to previous fixes on overload on getRSSI - a fix was also needed on some of the sleep functions. 

Those were added. 