### PR TITLE
[LoRaWAN] Change session activation

### DIFF
--- a/examples/LoRaWAN/LoRaWAN_ABP/LoRaWAN_ABP.ino
+++ b/examples/LoRaWAN/LoRaWAN_ABP/LoRaWAN_ABP.ino
@@ -43,7 +43,7 @@ void setup() {
   
   Serial.println(F("Initialise LoRaWAN Network credentials"));
   state = node.beginABP(devAddr, fNwkSIntKey, sNwkSIntKey, nwkSEncKey, appSKey, true);
-  debug(state < RADIOLIB_ERR_NONE, F("Session setup failed"), state, true);
+  debug(state != RADIOLIB_LORAWAN_NEW_SESSION, F("Session setup failed"), state, true);
 
   Serial.println(F("Ready!\n"));
 }

--- a/examples/LoRaWAN/LoRaWAN_Reference/LoRaWAN_Reference.ino
+++ b/examples/LoRaWAN/LoRaWAN_Reference/LoRaWAN_Reference.ino
@@ -46,11 +46,11 @@ void setup() {
   debug(state != RADIOLIB_ERR_NONE, F("Initialise radio failed"), state, true);
 
   // Override the default join rate
-  // uint8_t joinDR = 3;
+  uint8_t joinDR = 4;
 
   Serial.println(F("Join ('login') to the LoRaWAN Network"));
-  state = node.beginOTAA(joinEUI, devEUI, nwkKey, appKey, true);
-  debug(state < RADIOLIB_ERR_NONE, F("Join failed"), state, true);
+  state = node.beginOTAA(joinEUI, devEUI, nwkKey, appKey, true, joinDR);
+  debug(state != RADIOLIB_LORAWAN_NEW_SESSION, F("Join failed"), state, true);
 
   // Print the DevAddr
   Serial.print("[LoRaWAN] DevAddr: ");

--- a/examples/LoRaWAN/LoRaWAN_Starter/LoRaWAN_Starter.ino
+++ b/examples/LoRaWAN/LoRaWAN_Starter/LoRaWAN_Starter.ino
@@ -35,8 +35,8 @@ void setup() {
   debug(state != RADIOLIB_ERR_NONE, F("Initialise radio failed"), state, true);
 
   Serial.println(F("Join ('login') to the LoRaWAN Network"));
-  state = node.beginOTAA(joinEUI, devEUI, nwkKey, appKey, true);
-  debug(state < RADIOLIB_ERR_NONE, F("Join failed"), state, true);
+  state = node.beginOTAA(joinEUI, devEUI, nwkKey, appKey);
+  debug(state != RADIOLIB_LORAWAN_NEW_SESSION, F("Join failed"), state, true);
 
   Serial.println(F("Ready!\n"));
 }

--- a/keywords.txt
+++ b/keywords.txt
@@ -319,8 +319,10 @@ setBufferNonces	KEYWORD2
 getBufferSession	KEYWORD2
 setBufferSession	KEYWORD2
 beginOTAA	KEYWORD2
+activateOTAA	KEYWORD2
 beginABP	KEYWORD2
-isJoined	KEYWORD2
+activateABP	KEYWORD2
+isActivated	KEYWORD2
 sendMacCommandReq	KEYWORD2
 uplink	KEYWORD2
 downlink	KEYWORD2

--- a/keywords.txt
+++ b/keywords.txt
@@ -313,6 +313,7 @@ checkDataRate	KEYWORD2
 setModem	KEYWORD2
 
 # LoRaWAN
+clearSession	KEYWORD2
 getBufferNonces	KEYWORD2
 setBufferNonces	KEYWORD2
 getBufferSession	KEYWORD2

--- a/keywords.txt
+++ b/keywords.txt
@@ -313,7 +313,6 @@ checkDataRate	KEYWORD2
 setModem	KEYWORD2
 
 # LoRaWAN
-wipe	KEYWORD2
 getBufferNonces	KEYWORD2
 setBufferNonces	KEYWORD2
 getBufferSession	KEYWORD2

--- a/src/TypeDef.h
+++ b/src/TypeDef.h
@@ -573,6 +573,11 @@
 */
 #define RADIOLIB_LORAWAN_NEW_SESSION                            (-1118)
 
+/*!
+  \brief The supplied Nonces buffer is discarded as its activation information is invalid.
+*/
+#define RADIOLIB_LORAWAN_NONCES_DISCARDED                       (-1119)
+
 // LR11x0-specific status codes
 
 /*!

--- a/src/TypeDef.h
+++ b/src/TypeDef.h
@@ -578,6 +578,11 @@
 */
 #define RADIOLIB_LORAWAN_NONCES_DISCARDED                       (-1119)
 
+/*!
+  \brief The supplied Session buffer is discarded as it doesn't match the Nonces.
+*/
+#define RADIOLIB_LORAWAN_SESSION_DISCARDED                       (-1120)
+
 // LR11x0-specific status codes
 
 /*!

--- a/src/TypeDef.h
+++ b/src/TypeDef.h
@@ -563,6 +563,16 @@
 */
 #define RADIOLIB_LORAWAN_NO_DOWNLINK                            (-1116)
 
+/*!
+  \brief The LoRaWAN session was successfully re-activated.
+*/
+#define RADIOLIB_LORAWAN_SESSION_RESTORED                       (-1117)
+
+/*!
+  \brief A new LoRaWAN session is started.
+*/
+#define RADIOLIB_LORAWAN_NEW_SESSION                            (-1118)
+
 // LR11x0-specific status codes
 
 /*!

--- a/src/modules/LR11x0/LR11x0.cpp
+++ b/src/modules/LR11x0/LR11x0.cpp
@@ -2019,7 +2019,7 @@ int16_t LR11x0::writeInfoPage(uint16_t addr, uint32_t* data, size_t len) {
   }
 
   int16_t state = this->SPIcommand(RADIOLIB_LR11X0_CMD_WRITE_INFO_PAGE, true, dataBuff, buffLen);
-  #if RADIOLIB_STATIC_ONLY
+  #if !RADIOLIB_STATIC_ONLY
     delete[] dataBuff;
   #endif
   return(state);
@@ -2442,7 +2442,7 @@ int16_t LR11x0::lrFhssBuildFrame(uint8_t hdrCount, uint8_t cr, uint8_t grid, boo
   memcpy(&dataBuff[9], payload, len);
 
   int16_t state = this->SPIcommand(RADIOLIB_LR11X0_CMD_LR_FHSS_BUILD_FRAME, true, dataBuff, buffLen);
-  #if RADIOLIB_STATIC_ONLY
+  #if !RADIOLIB_STATIC_ONLY
     delete[] dataBuff;
   #endif
   return(state);
@@ -2493,7 +2493,7 @@ int16_t LR11x0::bleBeaconCommon(uint16_t cmd, uint8_t chan, uint8_t* payload, si
   memcpy(&dataBuff[1], payload, len);
 
   int16_t state = this->SPIcommand(cmd, true, dataBuff, sizeof(uint8_t) + len);
-  #if RADIOLIB_STATIC_ONLY
+  #if !RADIOLIB_STATIC_ONLY
     delete[] dataBuff;
   #endif
   return(state);
@@ -2758,7 +2758,7 @@ int16_t LR11x0::gnssGetSvDetected(uint8_t* svId, uint8_t* snr, uint16_t* doppler
     }
   }
 
-  #if RADIOLIB_STATIC_ONLY
+  #if !RADIOLIB_STATIC_ONLY
     delete[] dataBuff;
   #endif
   return(state);
@@ -2902,7 +2902,7 @@ int16_t LR11x0::cryptoComputeAesCmac(uint8_t keyId, uint8_t* data, size_t len, u
   memcpy(&reqBuff[1], data, len);
 
   int16_t state = this->SPIcommand(RADIOLIB_LR11X0_CMD_CRYPTO_COMPUTE_AES_CMAC, false, rplBuff, sizeof(rplBuff), reqBuff, reqLen);
-  #if RADIOLIB_STATIC_ONLY
+  #if !RADIOLIB_STATIC_ONLY
     delete[] reqBuff;
   #endif
 
@@ -2933,7 +2933,7 @@ int16_t LR11x0::cryptoVerifyAesCmac(uint8_t keyId, uint32_t micExp, uint8_t* dat
   memcpy(&reqBuff[5], data, len);
 
   int16_t state = this->SPIcommand(RADIOLIB_LR11X0_CMD_CRYPTO_VERIFY_AES_CMAC, false, rplBuff, sizeof(rplBuff), reqBuff, reqLen);
-  #if RADIOLIB_STATIC_ONLY
+  #if !RADIOLIB_STATIC_ONLY
     delete[] reqBuff;
   #endif
 
@@ -3064,7 +3064,7 @@ int16_t LR11x0::writeCommon(uint16_t cmd, uint32_t addrOffset, uint32_t* data, s
   }
 
   int16_t state = this->SPIcommand(cmd, true, dataBuff, buffLen);
-  #if RADIOLIB_STATIC_ONLY
+  #if !RADIOLIB_STATIC_ONLY
     delete[] dataBuff;
   #endif
   return(state);

--- a/src/protocols/LoRaWAN/LoRaWAN.cpp
+++ b/src/protocols/LoRaWAN/LoRaWAN.cpp
@@ -832,6 +832,8 @@ int16_t LoRaWANNode::activateABP(bool force, uint8_t initialDr) {
   LoRaWANNode::hton<uint32_t>(&this->bufferSession[RADIOLIB_LW_SESSION_HOMENET_ID], this->homeNetId);
   LoRaWANNode::hton<uint8_t>(&this->bufferSession[RADIOLIB_LW_SESSION_VERSION], this->rev);
 
+  this->isActive = true;
+  
   return(RADIOLIB_LORAWAN_NEW_SESSION);
 }
 

--- a/src/protocols/LoRaWAN/LoRaWAN.cpp
+++ b/src/protocols/LoRaWAN/LoRaWAN.cpp
@@ -130,7 +130,7 @@ int16_t LoRaWANNode::setBufferSession(uint8_t* persistentBuffer) {
   uint16_t signatureInSession = LoRaWANNode::ntoh<uint16_t>(&persistentBuffer[RADIOLIB_LW_SESSION_NONCES_SIGNATURE]);
   if(signatureNonces != signatureInSession) {
     RADIOLIB_DEBUG_PROTOCOL_PRINTLN("The supplied session buffer does not match the Nonces buffer");
-    return(RADIOLIB_ERR_CHECKSUM_MISMATCH);
+    return(RADIOLIB_LORAWAN_SESSION_DISCARDED);
   }
 
   // copy the whole buffer over
@@ -833,7 +833,7 @@ int16_t LoRaWANNode::activateABP(bool force, uint8_t initialDr) {
   LoRaWANNode::hton<uint8_t>(&this->bufferSession[RADIOLIB_LW_SESSION_VERSION], this->rev);
 
   this->isActive = true;
-  
+
   return(RADIOLIB_LORAWAN_NEW_SESSION);
 }
 

--- a/src/protocols/LoRaWAN/LoRaWAN.cpp
+++ b/src/protocols/LoRaWAN/LoRaWAN.cpp
@@ -452,7 +452,7 @@ int16_t LoRaWANNode::beginOTAA(uint64_t joinEUI, uint64_t devEUI, uint8_t* nwkKe
 
   // if the device is activated with a valid session, and user didn't force a new session, return
   if(this->isJoined() && !force) {
-    return(RADIOLIB_ERR_NONE);
+    return(RADIOLIB_LORAWAN_SESSION_RESTORED);
   }
 
   int16_t state = RADIOLIB_ERR_UNKNOWN;
@@ -718,7 +718,7 @@ int16_t LoRaWANNode::beginOTAA(uint64_t joinEUI, uint64_t devEUI, uint8_t* nwkKe
   LoRaWANNode::hton<uint32_t>(&this->bufferSession[RADIOLIB_LW_SESSION_HOMENET_ID], this->homeNetId);
   LoRaWANNode::hton<uint8_t>(&this->bufferSession[RADIOLIB_LW_SESSION_VERSION], this->rev);
 
-  return(RADIOLIB_ERR_NONE);
+  return(RADIOLIB_LORAWAN_NEW_SESSION);
 }
 
 int16_t LoRaWANNode::beginABP(uint32_t addr, uint8_t* fNwkSIntKey, uint8_t* sNwkSIntKey, uint8_t* nwkSEncKey, uint8_t* appSKey, bool force, uint8_t initialDr) {
@@ -1955,6 +1955,9 @@ void LoRaWANNode::setADR(bool enable) {
 
 void LoRaWANNode::setDutyCycle(bool enable, RadioLibTime_t msPerHour) {
   this->dutyCycleEnabled = enable;
+  if(!enable) {
+    this->dutyCycle = 0;
+  }
   if(msPerHour <= 0) {
     this->dutyCycle = this->band->dutyCycle;
   } else {

--- a/src/protocols/LoRaWAN/LoRaWAN.h
+++ b/src/protocols/LoRaWAN/LoRaWAN.h
@@ -528,6 +528,11 @@ class LoRaWANNode {
     LoRaWANNode(PhysicalLayer* phy, const LoRaWANBand_t* band, uint8_t subBand = 0);
 
     /*!
+      \brief Clear an active session, so that the device will have to rejoin the network.
+    */
+    void clearSession();
+
+    /*!
       \brief Returns the pointer to the internal buffer that holds the LW base parameters
       \returns Pointer to uint8_t array of size RADIOLIB_LW_NONCES_BUF_SIZE
     */
@@ -565,11 +570,10 @@ class LoRaWANNode {
     /*!
       \brief Join network by restoring OTAA session or performing over-the-air activation. By this procedure,
       the device will perform an exchange with the network server and set all necessary configuration. 
-      \param force Set to true to force joining even if previously joined.
       \param joinDr The datarate at which to send the join-request and any subsequent uplinks (unless ADR is enabled)
       \returns \ref status_codes
     */
-    int16_t activateOTAA(bool force = false, uint8_t initialDr = RADIOLIB_LW_DATA_RATE_UNUSED, LoRaWANJoinEvent_t *joinEvent = NULL);
+    int16_t activateOTAA(uint8_t initialDr = RADIOLIB_LW_DATA_RATE_UNUSED, LoRaWANJoinEvent_t *joinEvent = NULL);
 
     /*!
       \brief Set the device credentials and activation configuration
@@ -585,12 +589,10 @@ class LoRaWANNode {
     /*!
       \brief Join network by restoring ABP session or performing over-the-air activation. 
       In this procedure, all necessary configuration must be provided by the user.
-      \param force Set to true to force joining even if previously joined.
       \param initialDr The datarate at which to send the first uplink and any subsequent uplinks (unless ADR is enabled)
       \returns \ref status_codes
     */
-    int16_t activateABP(bool force = false, uint8_t initialDr = RADIOLIB_LW_DATA_RATE_UNUSED);
-
+    int16_t activateABP(uint8_t initialDr = RADIOLIB_LW_DATA_RATE_UNUSED);
 
     /*! \brief Whether there is an ongoing session active */
     bool isActivated();
@@ -977,9 +979,6 @@ class LoRaWANNode {
 
     // this will reset the device credentials, so the device starts completely new
     void clearNonces();
-
-    // this will reset all counters and saved variables, so the device will have to rejoin the network.
-    void clearSession();
 
     // wait for, open and listen during Rx1 and Rx2 windows; only performs listening
     int16_t downlinkCommon();

--- a/src/protocols/LoRaWAN/LoRaWAN.h
+++ b/src/protocols/LoRaWAN/LoRaWAN.h
@@ -528,12 +528,6 @@ class LoRaWANNode {
     LoRaWANNode(PhysicalLayer* phy, const LoRaWANBand_t* band, uint8_t subBand = 0);
 
     /*!
-      \brief Wipe internal persistent parameters.
-      This will reset all counters and saved variables, so the device will have to rejoin the network.
-    */
-    void wipe();
-
-    /*!
       \brief Returns the pointer to the internal buffer that holds the LW base parameters
       \returns Pointer to uint8_t array of size RADIOLIB_LW_NONCES_BUF_SIZE
     */
@@ -980,6 +974,12 @@ class LoRaWANNode {
 
     // save the selected sub-band in case this must be restored in ADR control
     uint8_t subBand = 0;
+
+    // this will reset the device credentials, so the device starts completely new
+    void clearNonces();
+
+    // this will reset all counters and saved variables, so the device will have to rejoin the network.
+    void clearSession();
 
     // wait for, open and listen during Rx1 and Rx2 windows; only performs listening
     int16_t downlinkCommon();


### PR DESCRIPTION
Due to a slight bug introduced in one of my recent patches, I decided after conferring with @HeadBoffin to shift around some of the logic around session restoring / activation.

Restoring the Nonces and Session buffer now immediately restores all the contents of the buffer, instead of waiting for this to happen in begin(). Should make it easier to read and maintain. Now if begin() is called with the `force` argument set to false (default), it will check if a restored session is available for the current activitation information (keys, plan and the like) and return `SESSION_RESTORED` if this is the case - if there was none or not a valid session, it will immediately do a join and return (if succeeded) `NEW_SESSION`. Hence there is no need to set `force` to true anymore, simplifying logic and being more intuitive. It is still available for rejoining while a session is active, however.

For the examples in this repository there is not much difference (just begin()'s return code and dropping the argument to begin()), but the persistence examples should see nice improvements. 

Also, a slight bug has been fixed regarding Nonces not increasing on a failed join (buffer checksum was not recalculated and could result in restoring rejection).

Pending confirmation by @HeadBoffin (already tested to run fine, but slight misuse-testing also welcome), and ready for review.