### PR TITLE
LW examples updated for new initialisation / join sequence

### DIFF
--- a/examples/LoRaWAN/LoRaWAN_ABP/LoRaWAN_ABP.ino
+++ b/examples/LoRaWAN/LoRaWAN_ABP/LoRaWAN_ABP.ino
@@ -42,8 +42,10 @@ void setup() {
   debug(state != RADIOLIB_ERR_NONE, F("Initialise radio failed"), state, true);
   
   Serial.println(F("Initialise LoRaWAN Network credentials"));
-  state = node.beginABP(devAddr, fNwkSIntKey, sNwkSIntKey, nwkSEncKey, appSKey, true);
-  debug(state != RADIOLIB_LORAWAN_NEW_SESSION, F("Session setup failed"), state, true);
+  node.beginABP(devAddr, fNwkSIntKey, sNwkSIntKey, nwkSEncKey, appSKey);
+
+  node.activateABP();
+  debug(state != RADIOLIB_ERR_NONE, F("Activate ABP failed"), state, true);
 
   Serial.println(F("Ready!\n"));
 }

--- a/examples/LoRaWAN/LoRaWAN_ABP/configABP.h
+++ b/examples/LoRaWAN/LoRaWAN_ABP/configABP.h
@@ -73,14 +73,11 @@ const uint8_t subBand = 0;  // For US915, change this to 2, otherwise leave on 0
   #pragma message ("Using Heltec WiFi LoRa32")
   SX1276 radio = new Module(18, 26, 14, 33);
 
-#elif defined (ARDUINO_heltec_wireless_stick)
-  #pragma message ("Using Heltec Wireless Stick")
-  SX1278 radio = new Module(14, 4, 12, 16);
-
 #elif defined(ARDUINO_heltec_wifi_lora_32_V2)
   #pragma message ("Using Heltec WiFi LoRa32 v2")
   SX1278 radio = new Module(14, 4, 12, 16);
 
+// Pending verfication of which radio is shipped
 // #elif defined(ARDUINO_heltec_wifi_lora_32_V2)
 //   #pragma message ("ARDUINO_heltec_wifi_kit_32_V2 awaiting pin map")
 //   SX1276 radio = new Module(18, 26, 14, 35);
@@ -89,8 +86,12 @@ const uint8_t subBand = 0;  // For US915, change this to 2, otherwise leave on 0
   #pragma message ("Using Heltec WiFi LoRa32 v3 - Display + USB-C")
   SX1262 radio = new Module(8, 14, 12, 13);
   
-  
+
 // Following not verified  
+#elif defined (ARDUINO_heltec_wireless_stick)
+  #pragma message ("Using Heltec Wireless Stick")
+  SX1278 radio = new Module(14, 4, 12, 16);
+  
 #elif defined (ARDUINO_HELTEC_WIRELESS_STICK)
   #pragma message ("Using Heltec Wireless Stick")
   SX1276 radio = new Module(18, 26, 14, 35);
@@ -106,15 +107,6 @@ const uint8_t subBand = 0;  // For US915, change this to 2, otherwise leave on 0
 #elif defined (ARDUINO_HELTEC_WIRELESS_STICK_LITE_V3)
   #pragma message ("Using Heltec Wireless Stick Lite v3")
   SX1262 radio = new Module(34, 14, 12, 13);
-
-
-// Following may experience timing issues 
-#elif defined(ARDUINO_CUBECELL_BOARD)
-  #pragma message ("Using CubeCell")
-  SX1262 radio = new Module(RADIOLIB_BUILTIN_MODULE);
-
-#elif defined(ARDUINO_CUBECELL_BOARD_V2)
-  #pragma error ("ARDUINO_CUBECELL_BOARD_V2 awaiting pin map")
 
 
 // If we don't recognise the board

--- a/examples/LoRaWAN/LoRaWAN_ABP/configABP.h
+++ b/examples/LoRaWAN/LoRaWAN_ABP/configABP.h
@@ -80,6 +80,9 @@ const uint8_t subBand = 0;  // For US915, change this to 2, otherwise leave on 0
 #elif defined(ARDUINO_HELTEC_WIFI_LORA_32_V3)
   #pragma message ("Using Heltec WiFi LoRa32 v3")
    SX1262 radio = new Module(8, 14, 12, 13);
+#elif defined(ARDUINO_heltec_wifi_lora_32_V3)
+  #pragma message ("Using Heltec WiFi LoRa32 v3 - Display + USB-C")
+  SX1262 radio = new Module(8, 14, 12, 13);
 
 #elif defined (ARDUINO_HELTEC_WIRELESS_STICK)
   #pragma message ("Using Heltec Wireless Stick")
@@ -126,16 +129,88 @@ uint8_t appSKey[] =     { RADIOLIB_LORAWAN_APPS_KEY };
 // create the LoRaWAN node
 LoRaWANNode node(&radio, &Region, subBand);
 
+
+// result code to text ...
+String stateDecode(const int16_t result) {
+  switch (result) {
+  case RADIOLIB_ERR_NONE:
+    return "ERR_NONE";
+  case RADIOLIB_ERR_CHIP_NOT_FOUND:
+    return "ERR_CHIP_NOT_FOUND";
+  case RADIOLIB_ERR_PACKET_TOO_LONG:
+    return "ERR_PACKET_TOO_LONG";
+  case RADIOLIB_ERR_RX_TIMEOUT:
+    return "ERR_RX_TIMEOUT";
+  case RADIOLIB_ERR_CRC_MISMATCH:
+    return "ERR_CRC_MISMATCH";
+  case RADIOLIB_ERR_INVALID_BANDWIDTH:
+    return "ERR_INVALID_BANDWIDTH";
+  case RADIOLIB_ERR_INVALID_SPREADING_FACTOR:
+    return "ERR_INVALID_SPREADING_FACTOR";
+  case RADIOLIB_ERR_INVALID_CODING_RATE:
+    return "ERR_INVALID_CODING_RATE";
+  case RADIOLIB_ERR_INVALID_FREQUENCY:
+    return "ERR_INVALID_FREQUENCY";
+  case RADIOLIB_ERR_INVALID_OUTPUT_POWER:
+    return "ERR_INVALID_OUTPUT_POWER";
+  case RADIOLIB_ERR_NETWORK_NOT_JOINED:
+	  return "RADIOLIB_ERR_NETWORK_NOT_JOINED";
+
+  case RADIOLIB_ERR_DOWNLINK_MALFORMED:
+    return "RADIOLIB_ERR_DOWNLINK_MALFORMED";
+  case RADIOLIB_ERR_INVALID_REVISION:
+    return "RADIOLIB_ERR_INVALID_REVISION";
+  case RADIOLIB_ERR_INVALID_PORT:
+    return "RADIOLIB_ERR_INVALID_PORT";
+  case RADIOLIB_ERR_NO_RX_WINDOW:
+    return "RADIOLIB_ERR_NO_RX_WINDOW";
+  case RADIOLIB_ERR_INVALID_CHANNEL:
+    return "RADIOLIB_ERR_INVALID_CHANNEL";
+  case RADIOLIB_ERR_INVALID_CID:
+    return "RADIOLIB_ERR_INVALID_CID";
+  case RADIOLIB_ERR_UPLINK_UNAVAILABLE:
+    return "RADIOLIB_ERR_UPLINK_UNAVAILABLE";
+  case RADIOLIB_ERR_COMMAND_QUEUE_FULL:
+    return "RADIOLIB_ERR_COMMAND_QUEUE_FULL";
+  case RADIOLIB_ERR_COMMAND_QUEUE_ITEM_NOT_FOUND:
+    return "RADIOLIB_ERR_COMMAND_QUEUE_ITEM_NOT_FOUND";
+  case RADIOLIB_ERR_JOIN_NONCE_INVALID:
+    return "RADIOLIB_ERR_JOIN_NONCE_INVALID";
+  case RADIOLIB_ERR_N_FCNT_DOWN_INVALID:
+    return "RADIOLIB_ERR_N_FCNT_DOWN_INVALID";
+  case RADIOLIB_ERR_A_FCNT_DOWN_INVALID:
+    return "RADIOLIB_ERR_A_FCNT_DOWN_INVALID";
+  case RADIOLIB_ERR_DWELL_TIME_EXCEEDED:
+    return "RADIOLIB_ERR_DWELL_TIME_EXCEEDED";
+  case RADIOLIB_ERR_CHECKSUM_MISMATCH:
+    return "RADIOLIB_ERR_CHECKSUM_MISMATCH";
+  case RADIOLIB_LORAWAN_NO_DOWNLINK:
+    return "RADIOLIB_LORAWAN_NO_DOWNLINK";
+  case RADIOLIB_LORAWAN_SESSION_RESTORED:
+    return "RADIOLIB_LORAWAN_SESSION_RESTORED";
+  case RADIOLIB_LORAWAN_NEW_SESSION:
+    return "RADIOLIB_LORAWAN_NEW_SESSION";
+  case RADIOLIB_LORAWAN_NONCES_DISCARDED:
+    return "RADIOLIB_LORAWAN_NONCES_DISCARDED";
+  case RADIOLIB_LORAWAN_SESSION_DISCARDED:
+    return "RADIOLIB_LORAWAN_SESSION_DISCARDED";
+  }
+  return "See TypeDef.h";
+}
+
 // helper function to display any issues
 void debug(bool isFail, const __FlashStringHelper* message, int state, bool Freeze) {
   if (isFail) {
     Serial.print(message);
-    Serial.print("(");
+    Serial.print(" - ");
+    Serial.print(stateDecode(state));
+    Serial.print(" (");
     Serial.print(state);
     Serial.println(")");
     while (Freeze);
   }
 }
+
 
 // helper function to display a byte array
 void arrayDump(uint8_t *buffer, uint16_t len) {

--- a/examples/LoRaWAN/LoRaWAN_ABP/configABP.h
+++ b/examples/LoRaWAN/LoRaWAN_ABP/configABP.h
@@ -73,17 +73,24 @@ const uint8_t subBand = 0;  // For US915, change this to 2, otherwise leave on 0
   #pragma message ("Using Heltec WiFi LoRa32")
   SX1276 radio = new Module(18, 26, 14, 33);
 
-#elif defined(ARDUINO_HELTEC_WIFI_LORA_32_V2)
-  #pragma message ("Using Heltec WiFi LoRa32 v2")
-  SX1276 radio = new Module(18, 26, 14, 35);
+#elif defined (ARDUINO_heltec_wireless_stick)
+  #pragma message ("Using Heltec Wireless Stick")
+  SX1278 radio = new Module(14, 4, 12, 16);
 
-#elif defined(ARDUINO_HELTEC_WIFI_LORA_32_V3)
-  #pragma message ("Using Heltec WiFi LoRa32 v3")
-   SX1262 radio = new Module(8, 14, 12, 13);
+#elif defined(ARDUINO_heltec_wifi_lora_32_V2)
+  #pragma message ("Using Heltec WiFi LoRa32 v2")
+  SX1278 radio = new Module(14, 4, 12, 16);
+
+// #elif defined(ARDUINO_heltec_wifi_lora_32_V2)
+//   #pragma message ("ARDUINO_heltec_wifi_kit_32_V2 awaiting pin map")
+//   SX1276 radio = new Module(18, 26, 14, 35);
+
 #elif defined(ARDUINO_heltec_wifi_lora_32_V3)
   #pragma message ("Using Heltec WiFi LoRa32 v3 - Display + USB-C")
   SX1262 radio = new Module(8, 14, 12, 13);
-
+  
+  
+// Following not verified  
 #elif defined (ARDUINO_HELTEC_WIRELESS_STICK)
   #pragma message ("Using Heltec Wireless Stick")
   SX1276 radio = new Module(18, 26, 14, 35);
@@ -100,6 +107,8 @@ const uint8_t subBand = 0;  // For US915, change this to 2, otherwise leave on 0
   #pragma message ("Using Heltec Wireless Stick Lite v3")
   SX1262 radio = new Module(34, 14, 12, 13);
 
+
+// Following may experience timing issues 
 #elif defined(ARDUINO_CUBECELL_BOARD)
   #pragma message ("Using CubeCell")
   SX1262 radio = new Module(RADIOLIB_BUILTIN_MODULE);
@@ -108,6 +117,7 @@ const uint8_t subBand = 0;  // For US915, change this to 2, otherwise leave on 0
   #pragma error ("ARDUINO_CUBECELL_BOARD_V2 awaiting pin map")
 
 
+// If we don't recognise the board
 #else
   #pragma message ("Unknown board - no automagic pinmap available")
 
@@ -116,6 +126,9 @@ const uint8_t subBand = 0;  // For US915, change this to 2, otherwise leave on 0
 
   // SX1278 pin order: Module(NSS/CS, DIO0, RESET, DIO1);
   // SX1278 radio = new Module(10, 2, 9, 3);
+  
+  // For Pi Pico + Waveshare HAT - work in progress
+  // SX1262 radio = new Module(3, 20, 15, 2, SPI1, RADIOLIB_DEFAULT_SPI_SETTINGS);
 
 #endif
 

--- a/examples/LoRaWAN/LoRaWAN_Reference/LoRaWAN_Reference.ino
+++ b/examples/LoRaWAN/LoRaWAN_Reference/LoRaWAN_Reference.ino
@@ -48,8 +48,11 @@ void setup() {
   // Override the default join rate
   uint8_t joinDR = 4;
 
-  Serial.println(F("Join ('login') to the LoRaWAN Network"));
-  state = node.beginOTAA(joinEUI, devEUI, nwkKey, appKey, true, joinDR);
+  // Setup the OTAA session information
+  node.beginOTAA(joinEUI, devEUI, nwkKey, appKey);
+
+  Serial.println(F("Join ('login') the LoRaWAN Network"));
+  state = node.activateOTAA(joinDR);
   debug(state != RADIOLIB_LORAWAN_NEW_SESSION, F("Join failed"), state, true);
 
   // Print the DevAddr
@@ -72,7 +75,7 @@ void setup() {
 }
 
 void loop() {
-  int state = RADIOLIB_ERR_NONE;
+  int16_t state = RADIOLIB_ERR_NONE;
 
   // set battery fill level - the LoRaWAN network server
   // may periodically request this information

--- a/examples/LoRaWAN/LoRaWAN_Reference/config.h
+++ b/examples/LoRaWAN/LoRaWAN_Reference/config.h
@@ -68,14 +68,11 @@ const uint8_t subBand = 0;  // For US915, change this to 2, otherwise leave on 0
   #pragma message ("Using Heltec WiFi LoRa32")
   SX1276 radio = new Module(18, 26, 14, 33);
 
-#elif defined (ARDUINO_heltec_wireless_stick)
-  #pragma message ("Using Heltec Wireless Stick")
-  SX1278 radio = new Module(14, 4, 12, 16);
-
 #elif defined(ARDUINO_heltec_wifi_lora_32_V2)
   #pragma message ("Using Heltec WiFi LoRa32 v2")
   SX1278 radio = new Module(14, 4, 12, 16);
 
+// Pending verfication of which radio is shipped
 // #elif defined(ARDUINO_heltec_wifi_lora_32_V2)
 //   #pragma message ("ARDUINO_heltec_wifi_kit_32_V2 awaiting pin map")
 //   SX1276 radio = new Module(18, 26, 14, 35);
@@ -84,8 +81,12 @@ const uint8_t subBand = 0;  // For US915, change this to 2, otherwise leave on 0
   #pragma message ("Using Heltec WiFi LoRa32 v3 - Display + USB-C")
   SX1262 radio = new Module(8, 14, 12, 13);
   
-  
+
 // Following not verified  
+#elif defined (ARDUINO_heltec_wireless_stick)
+  #pragma message ("Using Heltec Wireless Stick")
+  SX1278 radio = new Module(14, 4, 12, 16);
+  
 #elif defined (ARDUINO_HELTEC_WIRELESS_STICK)
   #pragma message ("Using Heltec Wireless Stick")
   SX1276 radio = new Module(18, 26, 14, 35);
@@ -101,15 +102,6 @@ const uint8_t subBand = 0;  // For US915, change this to 2, otherwise leave on 0
 #elif defined (ARDUINO_HELTEC_WIRELESS_STICK_LITE_V3)
   #pragma message ("Using Heltec Wireless Stick Lite v3")
   SX1262 radio = new Module(34, 14, 12, 13);
-
-
-// Following may experience timing issues 
-#elif defined(ARDUINO_CUBECELL_BOARD)
-  #pragma message ("Using CubeCell")
-  SX1262 radio = new Module(RADIOLIB_BUILTIN_MODULE);
-
-#elif defined(ARDUINO_CUBECELL_BOARD_V2)
-  #pragma error ("ARDUINO_CUBECELL_BOARD_V2 awaiting pin map")
 
 
 // If we don't recognise the board

--- a/examples/LoRaWAN/LoRaWAN_Reference/config.h
+++ b/examples/LoRaWAN/LoRaWAN_Reference/config.h
@@ -68,14 +68,24 @@ const uint8_t subBand = 0;  // For US915, change this to 2, otherwise leave on 0
   #pragma message ("Using Heltec WiFi LoRa32")
   SX1276 radio = new Module(18, 26, 14, 33);
 
-#elif defined(ARDUINO_HELTEC_WIFI_LORA_32_V2)
+#elif defined (ARDUINO_heltec_wireless_stick)
+  #pragma message ("Using Heltec Wireless Stick")
+  SX1278 radio = new Module(14, 4, 12, 16);
+
+#elif defined(ARDUINO_heltec_wifi_lora_32_V2)
   #pragma message ("Using Heltec WiFi LoRa32 v2")
-  SX1276 radio = new Module(18, 26, 14, 35);
+  SX1278 radio = new Module(14, 4, 12, 16);
 
-#elif defined(ARDUINO_HELTEC_WIFI_LORA_32_V3)
-  #pragma message ("Using Heltec WiFi LoRa32 v3")
-   SX1262 radio = new Module(8, 14, 12, 13);
+// #elif defined(ARDUINO_heltec_wifi_lora_32_V2)
+//   #pragma message ("ARDUINO_heltec_wifi_kit_32_V2 awaiting pin map")
+//   SX1276 radio = new Module(18, 26, 14, 35);
 
+#elif defined(ARDUINO_heltec_wifi_lora_32_V3)
+  #pragma message ("Using Heltec WiFi LoRa32 v3 - Display + USB-C")
+  SX1262 radio = new Module(8, 14, 12, 13);
+  
+  
+// Following not verified  
 #elif defined (ARDUINO_HELTEC_WIRELESS_STICK)
   #pragma message ("Using Heltec Wireless Stick")
   SX1276 radio = new Module(18, 26, 14, 35);
@@ -92,6 +102,8 @@ const uint8_t subBand = 0;  // For US915, change this to 2, otherwise leave on 0
   #pragma message ("Using Heltec Wireless Stick Lite v3")
   SX1262 radio = new Module(34, 14, 12, 13);
 
+
+// Following may experience timing issues 
 #elif defined(ARDUINO_CUBECELL_BOARD)
   #pragma message ("Using CubeCell")
   SX1262 radio = new Module(RADIOLIB_BUILTIN_MODULE);
@@ -100,6 +112,7 @@ const uint8_t subBand = 0;  // For US915, change this to 2, otherwise leave on 0
   #pragma error ("ARDUINO_CUBECELL_BOARD_V2 awaiting pin map")
 
 
+// If we don't recognise the board
 #else
   #pragma message ("Unknown board - no automagic pinmap available")
 
@@ -108,6 +121,9 @@ const uint8_t subBand = 0;  // For US915, change this to 2, otherwise leave on 0
 
   // SX1278 pin order: Module(NSS/CS, DIO0, RESET, DIO1);
   // SX1278 radio = new Module(10, 2, 9, 3);
+  
+  // For Pi Pico + Waveshare HAT - work in progress
+  // SX1262 radio = new Module(3, 20, 15, 2, SPI1, RADIOLIB_DEFAULT_SPI_SETTINGS);
 
 #endif
 
@@ -120,16 +136,88 @@ uint8_t nwkKey[] = { RADIOLIB_LORAWAN_NWK_KEY };
 // create the LoRaWAN node
 LoRaWANNode node(&radio, &Region, subBand);
 
+
+// result code to text ...
+String stateDecode(const int16_t result) {
+  switch (result) {
+  case RADIOLIB_ERR_NONE:
+    return "ERR_NONE";
+  case RADIOLIB_ERR_CHIP_NOT_FOUND:
+    return "ERR_CHIP_NOT_FOUND";
+  case RADIOLIB_ERR_PACKET_TOO_LONG:
+    return "ERR_PACKET_TOO_LONG";
+  case RADIOLIB_ERR_RX_TIMEOUT:
+    return "ERR_RX_TIMEOUT";
+  case RADIOLIB_ERR_CRC_MISMATCH:
+    return "ERR_CRC_MISMATCH";
+  case RADIOLIB_ERR_INVALID_BANDWIDTH:
+    return "ERR_INVALID_BANDWIDTH";
+  case RADIOLIB_ERR_INVALID_SPREADING_FACTOR:
+    return "ERR_INVALID_SPREADING_FACTOR";
+  case RADIOLIB_ERR_INVALID_CODING_RATE:
+    return "ERR_INVALID_CODING_RATE";
+  case RADIOLIB_ERR_INVALID_FREQUENCY:
+    return "ERR_INVALID_FREQUENCY";
+  case RADIOLIB_ERR_INVALID_OUTPUT_POWER:
+    return "ERR_INVALID_OUTPUT_POWER";
+  case RADIOLIB_ERR_NETWORK_NOT_JOINED:
+	  return "RADIOLIB_ERR_NETWORK_NOT_JOINED";
+
+  case RADIOLIB_ERR_DOWNLINK_MALFORMED:
+    return "RADIOLIB_ERR_DOWNLINK_MALFORMED";
+  case RADIOLIB_ERR_INVALID_REVISION:
+    return "RADIOLIB_ERR_INVALID_REVISION";
+  case RADIOLIB_ERR_INVALID_PORT:
+    return "RADIOLIB_ERR_INVALID_PORT";
+  case RADIOLIB_ERR_NO_RX_WINDOW:
+    return "RADIOLIB_ERR_NO_RX_WINDOW";
+  case RADIOLIB_ERR_INVALID_CHANNEL:
+    return "RADIOLIB_ERR_INVALID_CHANNEL";
+  case RADIOLIB_ERR_INVALID_CID:
+    return "RADIOLIB_ERR_INVALID_CID";
+  case RADIOLIB_ERR_UPLINK_UNAVAILABLE:
+    return "RADIOLIB_ERR_UPLINK_UNAVAILABLE";
+  case RADIOLIB_ERR_COMMAND_QUEUE_FULL:
+    return "RADIOLIB_ERR_COMMAND_QUEUE_FULL";
+  case RADIOLIB_ERR_COMMAND_QUEUE_ITEM_NOT_FOUND:
+    return "RADIOLIB_ERR_COMMAND_QUEUE_ITEM_NOT_FOUND";
+  case RADIOLIB_ERR_JOIN_NONCE_INVALID:
+    return "RADIOLIB_ERR_JOIN_NONCE_INVALID";
+  case RADIOLIB_ERR_N_FCNT_DOWN_INVALID:
+    return "RADIOLIB_ERR_N_FCNT_DOWN_INVALID";
+  case RADIOLIB_ERR_A_FCNT_DOWN_INVALID:
+    return "RADIOLIB_ERR_A_FCNT_DOWN_INVALID";
+  case RADIOLIB_ERR_DWELL_TIME_EXCEEDED:
+    return "RADIOLIB_ERR_DWELL_TIME_EXCEEDED";
+  case RADIOLIB_ERR_CHECKSUM_MISMATCH:
+    return "RADIOLIB_ERR_CHECKSUM_MISMATCH";
+  case RADIOLIB_LORAWAN_NO_DOWNLINK:
+    return "RADIOLIB_LORAWAN_NO_DOWNLINK";
+  case RADIOLIB_LORAWAN_SESSION_RESTORED:
+    return "RADIOLIB_LORAWAN_SESSION_RESTORED";
+  case RADIOLIB_LORAWAN_NEW_SESSION:
+    return "RADIOLIB_LORAWAN_NEW_SESSION";
+  case RADIOLIB_LORAWAN_NONCES_DISCARDED:
+    return "RADIOLIB_LORAWAN_NONCES_DISCARDED";
+  case RADIOLIB_LORAWAN_SESSION_DISCARDED:
+    return "RADIOLIB_LORAWAN_SESSION_DISCARDED";
+  }
+  return "See TypeDef.h";
+}
+
 // helper function to display any issues
 void debug(bool isFail, const __FlashStringHelper* message, int state, bool Freeze) {
   if (isFail) {
     Serial.print(message);
-    Serial.print("(");
+    Serial.print(" - ");
+    Serial.print(stateDecode(state));
+    Serial.print(" (");
     Serial.print(state);
     Serial.println(")");
     while (Freeze);
   }
 }
+
 
 // helper function to display a byte array
 void arrayDump(uint8_t *buffer, uint16_t len) {
@@ -140,5 +228,6 @@ void arrayDump(uint8_t *buffer, uint16_t len) {
   }
   Serial.println();
 }
+
 
 #endif

--- a/examples/LoRaWAN/LoRaWAN_Starter/LoRaWAN_Starter.ino
+++ b/examples/LoRaWAN/LoRaWAN_Starter/LoRaWAN_Starter.ino
@@ -31,11 +31,14 @@ void setup() {
   Serial.println(F("\nSetup ... "));
 
   Serial.println(F("Initialise the radio"));
-  int state = radio.begin();
+  int16_t state = radio.begin();
   debug(state != RADIOLIB_ERR_NONE, F("Initialise radio failed"), state, true);
 
-  Serial.println(F("Join ('login') to the LoRaWAN Network"));
-  state = node.beginOTAA(joinEUI, devEUI, nwkKey, appKey);
+  // Setup the OTAA session information
+  node.beginOTAA(joinEUI, devEUI, nwkKey, appKey);
+
+  Serial.println(F("Join ('login') the LoRaWAN Network"));
+  state = node.activateOTAA();
   debug(state != RADIOLIB_LORAWAN_NEW_SESSION, F("Join failed"), state, true);
 
   Serial.println(F("Ready!\n"));
@@ -56,7 +59,7 @@ void loop() {
   uplinkPayload[2] = lowByte(value2);
   
   // Perform an uplink
-  int state = node.sendReceive(uplinkPayload, sizeof(uplinkPayload));    
+  int16_t state = node.sendReceive(uplinkPayload, sizeof(uplinkPayload));    
   debug((state != RADIOLIB_LORAWAN_NO_DOWNLINK) && (state != RADIOLIB_ERR_NONE), F("Error in sendReceive"), state, false);
 
   Serial.print(F("Uplink complete, next in "));

--- a/examples/LoRaWAN/LoRaWAN_Starter/config.h
+++ b/examples/LoRaWAN/LoRaWAN_Starter/config.h
@@ -68,14 +68,11 @@ const uint8_t subBand = 0;  // For US915, change this to 2, otherwise leave on 0
   #pragma message ("Using Heltec WiFi LoRa32")
   SX1276 radio = new Module(18, 26, 14, 33);
 
-#elif defined (ARDUINO_heltec_wireless_stick)
-  #pragma message ("Using Heltec Wireless Stick")
-  SX1278 radio = new Module(14, 4, 12, 16);
-
 #elif defined(ARDUINO_heltec_wifi_lora_32_V2)
   #pragma message ("Using Heltec WiFi LoRa32 v2")
   SX1278 radio = new Module(14, 4, 12, 16);
 
+// Pending verfication of which radio is shipped
 // #elif defined(ARDUINO_heltec_wifi_lora_32_V2)
 //   #pragma message ("ARDUINO_heltec_wifi_kit_32_V2 awaiting pin map")
 //   SX1276 radio = new Module(18, 26, 14, 35);
@@ -84,8 +81,12 @@ const uint8_t subBand = 0;  // For US915, change this to 2, otherwise leave on 0
   #pragma message ("Using Heltec WiFi LoRa32 v3 - Display + USB-C")
   SX1262 radio = new Module(8, 14, 12, 13);
   
-  
+
 // Following not verified  
+#elif defined (ARDUINO_heltec_wireless_stick)
+  #pragma message ("Using Heltec Wireless Stick")
+  SX1278 radio = new Module(14, 4, 12, 16);
+  
 #elif defined (ARDUINO_HELTEC_WIRELESS_STICK)
   #pragma message ("Using Heltec Wireless Stick")
   SX1276 radio = new Module(18, 26, 14, 35);
@@ -101,15 +102,6 @@ const uint8_t subBand = 0;  // For US915, change this to 2, otherwise leave on 0
 #elif defined (ARDUINO_HELTEC_WIRELESS_STICK_LITE_V3)
   #pragma message ("Using Heltec Wireless Stick Lite v3")
   SX1262 radio = new Module(34, 14, 12, 13);
-
-
-// Following may experience timing issues 
-#elif defined(ARDUINO_CUBECELL_BOARD)
-  #pragma message ("Using CubeCell")
-  SX1262 radio = new Module(RADIOLIB_BUILTIN_MODULE);
-
-#elif defined(ARDUINO_CUBECELL_BOARD_V2)
-  #pragma error ("ARDUINO_CUBECELL_BOARD_V2 awaiting pin map")
 
 
 // If we don't recognise the board

--- a/examples/LoRaWAN/LoRaWAN_Starter/config.h
+++ b/examples/LoRaWAN/LoRaWAN_Starter/config.h
@@ -68,14 +68,24 @@ const uint8_t subBand = 0;  // For US915, change this to 2, otherwise leave on 0
   #pragma message ("Using Heltec WiFi LoRa32")
   SX1276 radio = new Module(18, 26, 14, 33);
 
-#elif defined(ARDUINO_HELTEC_WIFI_LORA_32_V2)
+#elif defined (ARDUINO_heltec_wireless_stick)
+  #pragma message ("Using Heltec Wireless Stick")
+  SX1278 radio = new Module(14, 4, 12, 16);
+
+#elif defined(ARDUINO_heltec_wifi_lora_32_V2)
   #pragma message ("Using Heltec WiFi LoRa32 v2")
-  SX1276 radio = new Module(18, 26, 14, 35);
+  SX1278 radio = new Module(14, 4, 12, 16);
 
-#elif defined(ARDUINO_HELTEC_WIFI_LORA_32_V3)
-  #pragma message ("Using Heltec WiFi LoRa32 v3")
-   SX1262 radio = new Module(8, 14, 12, 13);
+// #elif defined(ARDUINO_heltec_wifi_lora_32_V2)
+//   #pragma message ("ARDUINO_heltec_wifi_kit_32_V2 awaiting pin map")
+//   SX1276 radio = new Module(18, 26, 14, 35);
 
+#elif defined(ARDUINO_heltec_wifi_lora_32_V3)
+  #pragma message ("Using Heltec WiFi LoRa32 v3 - Display + USB-C")
+  SX1262 radio = new Module(8, 14, 12, 13);
+  
+  
+// Following not verified  
 #elif defined (ARDUINO_HELTEC_WIRELESS_STICK)
   #pragma message ("Using Heltec Wireless Stick")
   SX1276 radio = new Module(18, 26, 14, 35);
@@ -92,6 +102,8 @@ const uint8_t subBand = 0;  // For US915, change this to 2, otherwise leave on 0
   #pragma message ("Using Heltec Wireless Stick Lite v3")
   SX1262 radio = new Module(34, 14, 12, 13);
 
+
+// Following may experience timing issues 
 #elif defined(ARDUINO_CUBECELL_BOARD)
   #pragma message ("Using CubeCell")
   SX1262 radio = new Module(RADIOLIB_BUILTIN_MODULE);
@@ -100,6 +112,7 @@ const uint8_t subBand = 0;  // For US915, change this to 2, otherwise leave on 0
   #pragma error ("ARDUINO_CUBECELL_BOARD_V2 awaiting pin map")
 
 
+// If we don't recognise the board
 #else
   #pragma message ("Unknown board - no automagic pinmap available")
 
@@ -108,6 +121,9 @@ const uint8_t subBand = 0;  // For US915, change this to 2, otherwise leave on 0
 
   // SX1278 pin order: Module(NSS/CS, DIO0, RESET, DIO1);
   // SX1278 radio = new Module(10, 2, 9, 3);
+  
+  // For Pi Pico + Waveshare HAT - work in progress
+  // SX1262 radio = new Module(3, 20, 15, 2, SPI1, RADIOLIB_DEFAULT_SPI_SETTINGS);
 
 #endif
 
@@ -120,16 +136,88 @@ uint8_t nwkKey[] = { RADIOLIB_LORAWAN_NWK_KEY };
 // create the LoRaWAN node
 LoRaWANNode node(&radio, &Region, subBand);
 
+
+// result code to text ...
+String stateDecode(const int16_t result) {
+  switch (result) {
+  case RADIOLIB_ERR_NONE:
+    return "ERR_NONE";
+  case RADIOLIB_ERR_CHIP_NOT_FOUND:
+    return "ERR_CHIP_NOT_FOUND";
+  case RADIOLIB_ERR_PACKET_TOO_LONG:
+    return "ERR_PACKET_TOO_LONG";
+  case RADIOLIB_ERR_RX_TIMEOUT:
+    return "ERR_RX_TIMEOUT";
+  case RADIOLIB_ERR_CRC_MISMATCH:
+    return "ERR_CRC_MISMATCH";
+  case RADIOLIB_ERR_INVALID_BANDWIDTH:
+    return "ERR_INVALID_BANDWIDTH";
+  case RADIOLIB_ERR_INVALID_SPREADING_FACTOR:
+    return "ERR_INVALID_SPREADING_FACTOR";
+  case RADIOLIB_ERR_INVALID_CODING_RATE:
+    return "ERR_INVALID_CODING_RATE";
+  case RADIOLIB_ERR_INVALID_FREQUENCY:
+    return "ERR_INVALID_FREQUENCY";
+  case RADIOLIB_ERR_INVALID_OUTPUT_POWER:
+    return "ERR_INVALID_OUTPUT_POWER";
+  case RADIOLIB_ERR_NETWORK_NOT_JOINED:
+	  return "RADIOLIB_ERR_NETWORK_NOT_JOINED";
+
+  case RADIOLIB_ERR_DOWNLINK_MALFORMED:
+    return "RADIOLIB_ERR_DOWNLINK_MALFORMED";
+  case RADIOLIB_ERR_INVALID_REVISION:
+    return "RADIOLIB_ERR_INVALID_REVISION";
+  case RADIOLIB_ERR_INVALID_PORT:
+    return "RADIOLIB_ERR_INVALID_PORT";
+  case RADIOLIB_ERR_NO_RX_WINDOW:
+    return "RADIOLIB_ERR_NO_RX_WINDOW";
+  case RADIOLIB_ERR_INVALID_CHANNEL:
+    return "RADIOLIB_ERR_INVALID_CHANNEL";
+  case RADIOLIB_ERR_INVALID_CID:
+    return "RADIOLIB_ERR_INVALID_CID";
+  case RADIOLIB_ERR_UPLINK_UNAVAILABLE:
+    return "RADIOLIB_ERR_UPLINK_UNAVAILABLE";
+  case RADIOLIB_ERR_COMMAND_QUEUE_FULL:
+    return "RADIOLIB_ERR_COMMAND_QUEUE_FULL";
+  case RADIOLIB_ERR_COMMAND_QUEUE_ITEM_NOT_FOUND:
+    return "RADIOLIB_ERR_COMMAND_QUEUE_ITEM_NOT_FOUND";
+  case RADIOLIB_ERR_JOIN_NONCE_INVALID:
+    return "RADIOLIB_ERR_JOIN_NONCE_INVALID";
+  case RADIOLIB_ERR_N_FCNT_DOWN_INVALID:
+    return "RADIOLIB_ERR_N_FCNT_DOWN_INVALID";
+  case RADIOLIB_ERR_A_FCNT_DOWN_INVALID:
+    return "RADIOLIB_ERR_A_FCNT_DOWN_INVALID";
+  case RADIOLIB_ERR_DWELL_TIME_EXCEEDED:
+    return "RADIOLIB_ERR_DWELL_TIME_EXCEEDED";
+  case RADIOLIB_ERR_CHECKSUM_MISMATCH:
+    return "RADIOLIB_ERR_CHECKSUM_MISMATCH";
+  case RADIOLIB_LORAWAN_NO_DOWNLINK:
+    return "RADIOLIB_LORAWAN_NO_DOWNLINK";
+  case RADIOLIB_LORAWAN_SESSION_RESTORED:
+    return "RADIOLIB_LORAWAN_SESSION_RESTORED";
+  case RADIOLIB_LORAWAN_NEW_SESSION:
+    return "RADIOLIB_LORAWAN_NEW_SESSION";
+  case RADIOLIB_LORAWAN_NONCES_DISCARDED:
+    return "RADIOLIB_LORAWAN_NONCES_DISCARDED";
+  case RADIOLIB_LORAWAN_SESSION_DISCARDED:
+    return "RADIOLIB_LORAWAN_SESSION_DISCARDED";
+  }
+  return "See TypeDef.h";
+}
+
 // helper function to display any issues
 void debug(bool isFail, const __FlashStringHelper* message, int state, bool Freeze) {
   if (isFail) {
     Serial.print(message);
-    Serial.print("(");
+    Serial.print(" - ");
+    Serial.print(stateDecode(state));
+    Serial.print(" (");
     Serial.print(state);
     Serial.println(")");
     while (Freeze);
   }
 }
+
 
 // helper function to display a byte array
 void arrayDump(uint8_t *buffer, uint16_t len) {
@@ -140,5 +228,6 @@ void arrayDump(uint8_t *buffer, uint16_t len) {
   }
   Serial.println();
 }
+
 
 #endif


### PR DESCRIPTION
Somewhere we need to make it clear that we've put in some breaking changes - not a whole rework required but the startup sequence is so much clearer now - setup keys, restore NVM as appropriate, enough feedback to know what will happen next when you activateXXX.

The previous flow was OK but got messy when debugging edge cases so this mostly this informs the more savvy developer what is going on.

It will also make it easier to do "interesting" things like maintain more than one session with different backends - useful when switching networks if you are moving and/or a device switches, fails to join and switches back, or a backup session is in place.

ALSO: Some of the pinmaps were borked, I've fixed the ones I originally made so that they work again and kept the new entries but marked them as needing review