### PR TITLE
Fixed SX128X checkOutputPower

### DIFF
--- a/src/modules/SX128x/SX128x.cpp
+++ b/src/modules/SX128x/SX128x.cpp
@@ -792,11 +792,11 @@ int16_t SX128x::setOutputPower(int8_t pwr) {
   return(setTxParams(this->power));
 }
 
-int16_t SX128x::checkOutputPower(int8_t power, int8_t* clipped) {
+int16_t SX128x::checkOutputPower(int8_t pwr, int8_t* clipped) {
   if(clipped) {
-    *clipped = RADIOLIB_MAX(-18, RADIOLIB_MIN(13, power));
+    *clipped = RADIOLIB_MAX(-18, RADIOLIB_MIN(13, pwr));
   }
-  RADIOLIB_CHECK_RANGE(power, -18, 13, RADIOLIB_ERR_INVALID_OUTPUT_POWER);
+  RADIOLIB_CHECK_RANGE(pwr, -18, 13, RADIOLIB_ERR_INVALID_OUTPUT_POWER);
   return(RADIOLIB_ERR_NONE);
 }
 


### PR DESCRIPTION
The checkOutputPower parameter name is the same as the class member variable. As a result, when checking the set power, the value in the member variable is obtained. Therefore, as long as the set power value is greater than 0, an error will be returned.