### PR TITLE
[CC1101] Fix getRSSI data source

### DIFF
--- a/src/modules/CC1101/CC1101.cpp
+++ b/src/modules/CC1101/CC1101.cpp
@@ -1023,7 +1023,7 @@ int16_t CC1101::directMode(bool sync) {
   SPIsendCommand(RADIOLIB_CC1101_CMD_IDLE);
 
   int16_t state = 0;
-  this->directModeEnabled = sync;
+  this->directModeEnabled = true;
   if(sync) {
     // set GDO0 and GDO2 mapping
     state |= SPIsetRegValue(RADIOLIB_CC1101_REG_IOCFG0, RADIOLIB_CC1101_GDOX_SERIAL_CLOCK , 5, 0);

--- a/src/modules/CC1101/CC1101.cpp
+++ b/src/modules/CC1101/CC1101.cpp
@@ -1083,6 +1083,9 @@ int16_t CC1101::setPacketMode(uint8_t mode, uint16_t len) {
   state = SPIsetRegValue(RADIOLIB_CC1101_REG_PKTLEN, len);
   RADIOLIB_ASSERT(state);
 
+  // no longer in a direct mode
+  this->directModeEnabled = false;
+
   // update the cached values
   this->packetLength = len;
   this->packetLengthConfig = mode;

--- a/src/modules/CC1101/CC1101.h
+++ b/src/modules/CC1101/CC1101.h
@@ -845,7 +845,7 @@ class CC1101: public PhysicalLayer {
 
     /*!
       \brief Gets RSSI (Recorded Signal Strength Indicator) of the last received packet.
-      In asynchronous direct mode, returns the current RSSI level.
+      In direct or asynchronous direct mode, returns the current RSSI level.
       \returns RSSI in dBm.
     */
     float getRSSI() override;
@@ -1003,7 +1003,7 @@ class CC1101: public PhysicalLayer {
 
     bool promiscuous = false;
     bool crcOn = true;
-    bool directModeEnabled = true;
+    bool directModeEnabled = false;
 
     int8_t power = RADIOLIB_CC1101_DEFAULT_POWER;
 


### PR DESCRIPTION
Class variable `directModeEnabled` is set to true by default and is only set to false when calling `CC1101::receiveDirectAsync`. This has the following effects:

- When using asynchronous direct receive mode, -74.00 is always returned as RSSI data is not pulled from the RSSI register and class variable `rawRSSI` has never been changed from the default of 0.
- When using the non-direct receive mode, RSSI is pulled from the RSSI register rather than being from the last packet's status.

I am not an expert in how the CC1101 works, but under my current understanding data should be pulled from the RSSI register when using either of the direct modes and from the status of the previous packet when using the non-direct mode. 

Thank you for the wonderful library!