### PR TITLE
Fixed LR1121 initialization and power settings

### DIFF
--- a/src/modules/LR11x0/LR1121.cpp
+++ b/src/modules/LR11x0/LR1121.cpp
@@ -5,4 +5,44 @@ LR1121::LR1121(Module* mod) : LR1120(mod) {
   chipType = RADIOLIB_LR11X0_DEVICE_LR1121;
 }
 
+int16_t LR1121::setOutputPower(int8_t power, bool useHighFreqPa)
+{
+
+    int16_t state = RADIOLIB_ERR_INVALID_OUTPUT_POWER;
+
+    if (useHighFreqPa) {
+        if ((-18 <= power ) && ( power <= 13 )) {
+            state = setPaConfig(0x02, //  High-frequency Power Amplifier
+                                0x00, //  Power amplifier supplied by the main regulator
+                                0x04, //  Power Amplifier duty cycle (Default 0x04)
+                                0x07  //  Number of slices for HPA (Default 0x07)
+                               );
+        } else {
+            return RADIOLIB_ERR_INVALID_OUTPUT_POWER;
+        }
+    } else {
+        if (( -17 <= power ) && (power <= 22 )) {
+            if (power == 22) {
+                state = setPaConfig(0x01, //  High-power Power Amplifier
+                                    0x01, //  Power amplifier supplied by the battery
+                                    0x04, //  Power Amplifier duty cycle (Default 0x04)
+                                    0x07  //  Number of slices for HPA (Default 0x07)
+                                   );
+            } else {
+                state = setPaConfig(0x00, //  Low-power Power Amplifier
+                                    0x00, //  Power amplifier supplied by the main regulator
+                                    0x04, //  Power Amplifier duty cycle (Default 0x04)
+                                    0x07  //  Number of slices for HPA (Default 0x07)
+                                   );
+            }
+        } else {
+            return RADIOLIB_ERR_INVALID_OUTPUT_POWER;
+        }
+    }
+    RADIOLIB_ASSERT(state);
+
+    // set output power
+    state = setTxParams(power, RADIOLIB_LR11X0_PA_RAMP_48U);
+    return (state);
+}
 #endif

--- a/src/modules/LR11x0/LR1121.h
+++ b/src/modules/LR11x0/LR1121.h
@@ -21,6 +21,15 @@ class LR1121: public LR1120 {
     */
     LR1121(Module* mod); // cppcheck-suppress noExplicitConstructor
 
+    /*!
+      \brief Sets output power. Allowed values are in range from -17 to 22 dBm (high-power PA) or -18 to 13 dBm (High-frequency PA).
+      \param power Output power to be set in dBm.
+      \param useHighFreqPa  When using 2.4G frequency, need to switch to High-frequency PA
+      \returns \ref status_codes
+    */
+    int16_t setOutputPower(int8_t power,bool useHighFreqPa = false);
+
+
     // TODO this is where overrides to disable GNSS+WiFi scanning methods on LR1121
     // will be put once those are implemented
 

--- a/src/modules/LR11x0/LR11x0.cpp
+++ b/src/modules/LR11x0/LR11x0.cpp
@@ -1626,9 +1626,14 @@ int16_t LR11x0::getVersionInfo(LR11x0VersionInfo_t* info) {
 
   int16_t state = this->getVersion(&info->hardware, &info->device, &info->fwMajor, &info->fwMinor);
   RADIOLIB_ASSERT(state);
-  state = this->wifiReadVersion(&info->fwMajorWiFi, &info->fwMinorWiFi);
-  RADIOLIB_ASSERT(state);
-  return(this->gnssReadVersion(&info->fwGNSS, &info->almanacGNSS));
+
+  if(this->chipType != RADIOLIB_LR11X0_DEVICE_LR1121){
+    state = this->wifiReadVersion(&info->fwMajorWiFi, &info->fwMinorWiFi);
+    RADIOLIB_ASSERT(state);
+    return(this->gnssReadVersion(&info->fwGNSS, &info->almanacGNSS));
+  }
+
+  return RADIOLIB_ERR_NONE;
 }
 
 int16_t LR11x0::updateFirmware(const uint32_t* image, size_t size, bool nonvolatile) {
@@ -1787,8 +1792,10 @@ bool LR11x0::findChip(uint8_t ver) {
     if((state == RADIOLIB_ERR_NONE) && (info.device == ver)) {
       RADIOLIB_DEBUG_BASIC_PRINTLN("Found LR11x0: RADIOLIB_LR11X0_CMD_GET_VERSION = 0x%02x", info.device);
       RADIOLIB_DEBUG_BASIC_PRINTLN("Base FW version: %d.%d", (int)info.fwMajor, (int)info.fwMinor);
-      RADIOLIB_DEBUG_BASIC_PRINTLN("WiFi FW version: %d.%d", (int)info.fwMajorWiFi, (int)info.fwMinorWiFi);
-      RADIOLIB_DEBUG_BASIC_PRINTLN("GNSS FW version: %d.%d", (int)info.fwGNSS, (int)info.almanacGNSS);
+      if(this->chipType != RADIOLIB_LR11X0_DEVICE_LR1121){
+        RADIOLIB_DEBUG_BASIC_PRINTLN("WiFi FW version: %d.%d", (int)info.fwMajorWiFi, (int)info.fwMinorWiFi);
+        RADIOLIB_DEBUG_BASIC_PRINTLN("GNSS FW version: %d.%d", (int)info.fwGNSS, (int)info.almanacGNSS);
+      }
       flagFound = true;
     } else {
       RADIOLIB_DEBUG_BASIC_PRINTLN("LR11x0 not found! (%d of 10 tries) RADIOLIB_LR11X0_CMD_GET_VERSION = 0x%02x", i + 1, info.device);


### PR DESCRIPTION
1. Fixed the problem of LR1121 initialization failure. Because LR1121 does not have WiFi and GNSS, calling gnssReadVersion and wifiReadVersion will return failure. The solution is to determine whether it is LR1121. If so, do not read these two information.
2. Fix the problem of no output power when using the 2.4G band. When using 2.4G, you need to switch the PA to the High-frequency Power Amplifier, otherwise the output power is very weak and cannot be used normally.

It is not very good to write a setOutputPower method alone. I don't know the parameters of the other two models (LR1110, LR1120), but I used this method to quickly fix it.
Submitting this PR is just to tell you the current solution. If there is a better way, please close this PR