### PR TITLE
NonArduino: Tock: Handle zero delays

### DIFF
--- a/examples/NonArduino/Tock/libtockHal.h
+++ b/examples/NonArduino/Tock/libtockHal.h
@@ -157,19 +157,23 @@ class TockHal : public RadioLibHal {
     }
 
     void delay(unsigned long ms) override {
+      uint32_t delay;
+
 #if !defined(RADIOLIB_CLOCK_DRIFT_MS)
-      libtocksync_alarm_delay_ms(ms);
+      delay = ms;
 #else
-      libtocksync_alarm_delay_ms(ms * 1000 / (1000 + RADIOLIB_CLOCK_DRIFT_MS));
+      delay = ms * 1000 / (1000 + RADIOLIB_CLOCK_DRIFT_MS);
 #endif
+
+      if (delay == 0) {
+        return;
+      }
+
+      libtocksync_alarm_delay_ms(delay);
     }
 
     void delayMicroseconds(unsigned long us) override {
-#if !defined(RADIOLIB_CLOCK_DRIFT_MS)
-      libtocksync_alarm_delay_ms(us / 1000);
-#else
-      libtocksync_alarm_delay_ms((us * 1000 / (1000 + RADIOLIB_CLOCK_DRIFT_MS)) / 1000);
-#endif
+      delay(us / 1000);
     }
 
     unsigned long millis() override {


### PR DESCRIPTION
Calling `libtocksync_alarm_delay_ms()` on a zero ms/us delay is a large overhead, so let's just return if the `RADIOLIB_CLOCK_DRIFT_MS` scaling results in a 0ms delay