### PR TITLE
Added class member cc1101::setBitRateTolerance with new error code -109 in typeDef.h

### DIFF
--- a/src/TypeDef.h
+++ b/src/TypeDef.h
@@ -292,6 +292,11 @@
 */
 #define RADIOLIB_ERR_INVALID_OOK_RSSI_PEAK_TYPE                (-108)
 
+/*!
+  \brief Supplied Bitrate tolerance value is out of Range.
+*/
+#define RADIOLIB_ERR_INVALID_BIT_RATE_TOLERANCE_VALUE          (-109)
+
 // APRS status codes
 
 /*!

--- a/src/modules/CC1101/CC1101.cpp
+++ b/src/modules/CC1101/CC1101.cpp
@@ -471,7 +471,7 @@ int16_t CC1101::setBitRate(float br) {
 }
 
 int16_t CC1101::setBitRateTolerance(uint8_t brt) {
-  RADIOLIB_CHECK_RANGE(brt, 0x00, 0x03, RADIOLIB_ERR_INVALID_BIT_RATE_TOLERANCE_VALUE);
+  if (brt > 0x03)  return (RADIOLIB_ERR_INVALID_BIT_RATE_TOLERANCE_VALUE);
 
   // Set Bit Rate tolerance
   int16_t state = SPIsetRegValue(RADIOLIB_CC1101_REG_BSCFG, brt, 1, 0);

--- a/src/modules/CC1101/CC1101.cpp
+++ b/src/modules/CC1101/CC1101.cpp
@@ -470,6 +470,15 @@ int16_t CC1101::setBitRate(float br) {
   return(state);
 }
 
+int16_t CC1101::setBitRateTolerance(uint8_t brt) {
+  RADIOLIB_CHECK_RANGE(brt, 0x00, 0x03, RADIOLIB_ERR_INVALID_BIT_RATE_TOLERANCE_VALUE);
+
+  // Set Bit Rate tolerance
+  int16_t state = SPIsetRegValue(RADIOLIB_CC1101_REG_BSCFG, brt, 1, 0);
+
+  return(state);
+}
+
 int16_t CC1101::setRxBandwidth(float rxBw) {
   RADIOLIB_CHECK_RANGE(rxBw, 58.0, 812.0, RADIOLIB_ERR_INVALID_RX_BANDWIDTH);
 

--- a/src/modules/CC1101/CC1101.h
+++ b/src/modules/CC1101/CC1101.h
@@ -739,6 +739,13 @@ class CC1101: public PhysicalLayer {
     int16_t setBitRate(float br) override;
 
     /*!
+      \brief Sets bit rate tolerance in BSCFG register. Allowed values are 0:(0%), 1(3,125%), 2:(6,25%) and 3:(12,5%).
+      \param brt Bit rate tolerance to be set.
+      \returns \ref status_codes
+    */
+    int16_t setBitRateTolerance(uint8_t brt);
+
+    /*!
       \brief Sets receiver bandwidth. Allowed values are 58, 68, 81, 102, 116, 135, 162,
       203, 232, 270, 325, 406, 464, 541, 650 and 812 kHz.
       \param rxBw Receiver bandwidth to be set in kHz.


### PR DESCRIPTION
Changes in CC1101.cpp, CC1101.h and TypeDef.h

Function added to set Bitrate Tolerance in BSCFG register of CC1101
Added class member CC1101::setBitRateTolerance as proposed from jgromes after discussion.

Added new Error code "RADIOLIB_ERR_INVALID_BIT_RATE_TOLERANCE_VALUE" with value -109 to TypeDef.h 

Tested with ESP32 and PlatformIO Environment. 
Could not test on other platforms.

