### PR TITLE
[SX127x] When clearing the FHSS interrupt, don't also clear all the others

### DIFF
--- a/src/modules/SX127x/SX127x.cpp
+++ b/src/modules/SX127x/SX127x.cpp
@@ -1660,7 +1660,7 @@ uint8_t SX127x::getFHSSChannel(void) {
 void SX127x::clearFHSSInt(void) {
   int16_t modem = getActiveModem();
   if(modem == RADIOLIB_SX127X_LORA) {
-    this->mod->SPIwriteRegister(RADIOLIB_SX127X_REG_IRQ_FLAGS, getIRQFlags() | RADIOLIB_SX127X_CLEAR_IRQ_FLAG_FHSS_CHANGE_CHANNEL);
+    this->mod->SPIwriteRegister(RADIOLIB_SX127X_REG_IRQ_FLAGS, RADIOLIB_SX127X_CLEAR_IRQ_FLAG_FHSS_CHANGE_CHANNEL);
   } else if(modem == RADIOLIB_SX127X_FSK_OOK) {
     return; //These are not the interrupts you are looking for
   }


### PR DESCRIPTION
Writing `1` bits to the ReqIrqFlags register clears the corresponding interrupt sources.

![Screenshot from 2024-07-08 15-39-08](https://github.com/jgromes/RadioLib/assets/400548/73795284-92ce-4e10-bee7-41786cf401c6)

Before this commit, the `clearFHSSInterrupt()` function would clear *all set bits*, plus unconditionally clear the `FhssChangeChannel` bit.  This could cause the following problem:
1. A receiver receives a packet, hopping frequencies as requested by the `FhssChangeChannel` interrupt.  Each interrupt clears all other interrupt bits.
2. At the conclusion of the packet, the SX127x simultaneously sets `FhssChangeChannel` to request a hop back to the starting channel, and also sets `RxDone` to indicate that there is a complete packet to read from the FIFO.  If the packet had CRC enabled and the CRC failed, the `PayloadCrcError` bit will also be set at this point.
3. If the receiving application services the `FhssChangeChannel` interrupt before the `RxDone` interrupt, the other two bits (`RxDone` and `PayloadCrcError`) will be lost.  At worst this will mean that the packet will not be read (but will remain in the FIFO). At best this will mean that `readData()` will not know that the packet failed CRC, and will deliver a corrupted packet.

The old behavior seems like a just a simple bug, if i've missed something here please let me know. 