### PR TITLE
Update SX1278.cpp Turn on LnaBoost even in AutoAGC mode

### DIFF
--- a/src/modules/SX127x/SX1278.cpp
+++ b/src/modules/SX127x/SX1278.cpp
@@ -380,6 +380,7 @@ int16_t SX1278::setGain(uint8_t gain) {
     if(gain == 0) {
       // gain set to 0, enable AGC loop
       state |= mod->SPIsetRegValue(RADIOLIB_SX1278_REG_MODEM_CONFIG_3, RADIOLIB_SX1278_AGC_AUTO_ON, 2, 2);
+      state |= mod->SPIsetRegValue(RADIOLIB_SX127X_REG_LNA, RADIOLIB_SX127X_LNA_BOOST_ON, 1, 0);
     } else {
       state |= mod->SPIsetRegValue(RADIOLIB_SX1278_REG_MODEM_CONFIG_3, RADIOLIB_SX1278_AGC_AUTO_OFF, 2, 2);
       state |= mod->SPIsetRegValue(RADIOLIB_SX127X_REG_LNA, (gain << 5) | RADIOLIB_SX127X_LNA_BOOST_ON);


### PR DESCRIPTION
LnaBoost can still be enabled when the gain is not manually set. The Receiver Sensitivity ratings in the SX1276/7/8 datasheet are specified with the LnaBoost enabled.

I tested this on a few boards here and on average get a 3dB increase in signal strength. This is comparable to the SX1262 "Boosted Gain" setting
