### PR TITLE
SX127x: Set FIFO read pointer to the start of the current packet

### DIFF
--- a/src/modules/SX127x/SX127x.cpp
+++ b/src/modules/SX127x/SX127x.cpp
@@ -658,6 +658,12 @@ int16_t SX127x::readData(uint8_t* data, size_t len) {
       // CRC is disabled according to packet header and enabled according to user
       // most likely damaged packet header
       state = RADIOLIB_ERR_LORA_HEADER_DAMAGED;
+    } else {
+      // set FIFO read pointer to the start of the current packet
+      state = this->mod->SPIgetRegValue(RADIOLIB_SX127X_REG_FIFO_RX_CURRENT_ADDR);
+      if (state >= 0) {
+        state = this->mod->SPIsetRegValue(RADIOLIB_SX127X_REG_FIFO_ADDR_PTR, state);
+      }
     }
 
   } else if(modem == RADIOLIB_SX127X_FSK_OOK) {


### PR DESCRIPTION
This addresses #1183. It moves the FIFO read pointer to the current packet so it matches the packet length returned from `getPacketLength` in case there were multiple packets of different lengths received between reads.