### PR TITLE
[SX126x/SX128x] Start reading from Rx buffer offset

### DIFF
--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -1391,7 +1391,6 @@ float SX126x::getFrequencyError() {
 }
 
 size_t SX126x::getPacketLength(bool update) {
-  (void)update;
   return(this->getPacketLength(update, NULL));
 }
 

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -709,20 +709,17 @@ int16_t SX126x::readData(uint8_t* data, size_t len) {
   if((irq & RADIOLIB_SX126X_IRQ_CRC_ERR) || (irq & RADIOLIB_SX126X_IRQ_HEADER_ERR)) {
     crcState = RADIOLIB_ERR_CRC_MISMATCH;
   }
-
-  // get packet length
-  size_t length = getPacketLength();
+  
+  // get packet length and Rx buffer offset
+  uint8_t offset = 0;
+  size_t length = getPacketLength(true, &offset);
   if((len != 0) && (len < length)) {
     // user requested less data than we got, only return what was requested
     length = len;
   }
 
-  // read packet data
-  state = readBuffer(data, length);
-  RADIOLIB_ASSERT(state);
-
-  // reset the base addresses
-  state = setBufferBaseAddress();
+  // read packet data starting at offset
+  state = readBuffer(data, length, offset);
   RADIOLIB_ASSERT(state);
 
   // clear interrupt flags
@@ -1395,6 +1392,11 @@ float SX126x::getFrequencyError() {
 
 size_t SX126x::getPacketLength(bool update) {
   (void)update;
+  return(this->getPacketLength(update, NULL));
+}
+
+size_t SX126x::getPacketLength(bool update, uint8_t* offset) {
+  (void)update;
 
   // in implicit mode, return the cached value
   if((getPacketType() == RADIOLIB_SX126X_PACKET_TYPE_LORA) && (this->headerType == RADIOLIB_SX126X_LORA_HEADER_IMPLICIT)) {
@@ -1403,6 +1405,9 @@ size_t SX126x::getPacketLength(bool update) {
 
   uint8_t rxBufStatus[2] = {0, 0};
   this->mod->SPIreadStream(RADIOLIB_SX126X_CMD_GET_RX_BUFFER_STATUS, rxBufStatus, 2);
+
+  if(offset) { *offset = rxBufStatus[1]; }
+
   return((size_t)rxBufStatus[0]);
 }
 

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -953,6 +953,14 @@ class SX126x: public PhysicalLayer {
     size_t getPacketLength(bool update = true) override;
 
     /*!
+      \brief Query modem for the packet length of received payload and Rx buffer offset.
+      \param update Update received packet length. Will return cached value when set to false.
+      \param offset Pointer to variable to store the Rx buffer offset.
+      \returns Length of last received packet in bytes.
+    */
+    size_t getPacketLength(bool update, uint8_t* offset);
+
+    /*!
       \brief Set modem in fixed packet length mode. Available in FSK mode only.
       \param len Packet length.
       \returns \ref status_codes

--- a/src/modules/SX128x/SX128x.cpp
+++ b/src/modules/SX128x/SX128x.cpp
@@ -1254,7 +1254,6 @@ float SX128x::getFrequencyError() {
 }
 
 size_t SX128x::getPacketLength(bool update) {
-  (void)update;
   return(this->getPacketLength(update, NULL));
 }
 

--- a/src/modules/SX128x/SX128x.cpp
+++ b/src/modules/SX128x/SX128x.cpp
@@ -617,15 +617,16 @@ int16_t SX128x::readData(uint8_t* data, size_t len) {
     crcState = RADIOLIB_ERR_CRC_MISMATCH;
   }
 
-  // get packet length
-  size_t length = getPacketLength();
+  // get packet length and Rx buffer offset
+  uint8_t offset = 0;
+  size_t length = getPacketLength(true, &offset);
   if((len != 0) && (len < length)) {
     // user requested less data than we got, only return what was requested
     length = len;
   }
 
-  // read packet data
-  state = readBuffer(data, length);
+  // read packet data starting at offset 
+  state = readBuffer(data, length, offset);
   RADIOLIB_ASSERT(state);
 
   // clear interrupt flags
@@ -1254,6 +1255,11 @@ float SX128x::getFrequencyError() {
 
 size_t SX128x::getPacketLength(bool update) {
   (void)update;
+  return(this->getPacketLength(update, NULL));
+}
+
+size_t SX128x::getPacketLength(bool update, uint8_t* offset) {
+  (void)update;
 
   // in implicit mode, return the cached value
   if((getPacketType() == RADIOLIB_SX128X_PACKET_TYPE_LORA) && (this->headerType == RADIOLIB_SX128X_LORA_HEADER_IMPLICIT)) {
@@ -1262,6 +1268,9 @@ size_t SX128x::getPacketLength(bool update) {
 
   uint8_t rxBufStatus[2] = {0, 0};
   this->mod->SPIreadStream(RADIOLIB_SX128X_CMD_GET_RX_BUFFER_STATUS, rxBufStatus, 2);
+
+  if(offset) { *offset = rxBufStatus[1]; }
+
   return((size_t)rxBufStatus[0]);
 }
 
@@ -1412,8 +1421,8 @@ int16_t SX128x::writeBuffer(uint8_t* data, uint8_t numBytes, uint8_t offset) {
   return(this->mod->SPIwriteStream(cmd, 2, data, numBytes));
 }
 
-int16_t SX128x::readBuffer(uint8_t* data, uint8_t numBytes) {
-  uint8_t cmd[] = { RADIOLIB_SX128X_CMD_READ_BUFFER, RADIOLIB_SX128X_CMD_NOP };
+int16_t SX128x::readBuffer(uint8_t* data, uint8_t numBytes, uint8_t offset) {
+  uint8_t cmd[] = { RADIOLIB_SX128X_CMD_READ_BUFFER, offset };
   return(this->mod->SPIreadStream(cmd, 2, data, numBytes));
 }
 

--- a/src/modules/SX128x/SX128x.h
+++ b/src/modules/SX128x/SX128x.h
@@ -746,6 +746,14 @@ class SX128x: public PhysicalLayer {
     size_t getPacketLength(bool update = true) override;
 
     /*!
+      \brief Query modem for the packet length of received payload and Rx buffer offset.
+      \param update Update received packet length. Will return cached value when set to false.
+      \param offset Pointer to variable to store the Rx buffer offset.
+      \returns Length of last received packet in bytes.
+    */
+    size_t getPacketLength(bool update, uint8_t* offset);
+
+    /*!
       \brief Get expected time-on-air for a given size of payload.
       \param len Payload length in bytes.
       \returns Expected time-on-air in microseconds.
@@ -820,7 +828,7 @@ class SX128x: public PhysicalLayer {
     int16_t writeRegister(uint16_t addr, uint8_t* data, uint8_t numBytes);
     int16_t readRegister(uint16_t addr, uint8_t* data, uint8_t numBytes);
     int16_t writeBuffer(uint8_t* data, uint8_t numBytes, uint8_t offset = 0x00);
-    int16_t readBuffer(uint8_t* data, uint8_t numBytes);
+    int16_t readBuffer(uint8_t* data, uint8_t numBytes, uint8_t offset = 0x00);
     int16_t setTx(uint16_t periodBaseCount = RADIOLIB_SX128X_TX_TIMEOUT_NONE, uint8_t periodBase = RADIOLIB_SX128X_PERIOD_BASE_15_625_US);
     int16_t setRx(uint16_t periodBaseCount, uint8_t periodBase = RADIOLIB_SX128X_PERIOD_BASE_15_625_US);
     int16_t setCad();


### PR DESCRIPTION
As discussed in #1159 and similar to #1184, this will let SX126x and SX128x radios read the data in its buffer from the offset as returned by _GetRxBufferStatus_ in order to match the data with the returned packet length of the last packet in case you skipped reading a packet. The behaviour is the same for both radios and this is the relevant part of the datasheet:

> Two possibilities exist to obtain the offset value:
> •First is to use the RxBaseAddr value since the user defines it before receiving a payload.
> •Second, offset can be initialized with the value of RxStartBufferPointer returned by GetRxbufferStatus(...) command.
> Note:
> (...) When receiving, if the packet size exceeds the buffer memory allocated for the Rx, it will overwrite the
> transmit portion of the data buffer.

So we're now changing to the second method, with the downside that there's a higher chance you will overwrite Rx data when transmitting. However, I would argue that it's easier to make sure you don't transmit before reading available data than to make sure you always read the data in time.

For the SX126x, I had to remove the call to `setBufferBaseAddress()`, since it will force the data to start at 0, while the returned pointer is still from the previous packet (if you don't go to standby in between). I tested that this works with and without going to standby in between.

For the SX128x, there was no call to `setBufferBaseAddress()`, but it calls `standBy()` in `readData()` and therefore the returned pointer will be correct. I'm not sure if it's really necessary anymore to call `standBy()` here (and thus the interrupt example wouldn't need to call `startReceive()` again), but since I don't have the hardware, I haven't tested this.