### PR TITLE
[CI] Arduino platform versions & ESP32 3.0.x workaround

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,6 +79,7 @@ jobs:
           - id: esp32:esp32:esp32
             run: |
               python -m pip install pyserial
+              echo "version=3.0.0"
               echo "index-url=--additional-urls https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json" >> $GITHUB_OUTPUT
           - id: esp8266:esp8266:generic
             run: |
@@ -166,7 +167,7 @@ jobs:
         run:
           |
           arduino-cli core update-index ${{ format('{0}', steps.prep.outputs.index-url) }}
-          arduino-cli core install ${{ format('{0}:{1} {2}', steps.split.outputs._0, steps.split.outputs._1, steps.prep.outputs.index-url) }}
+          arduino-cli core install ${{ format('{0}:{1}@{3} {2}', steps.split.outputs._0, steps.split.outputs._1, steps.prep.outputs.index-url, steps.prep.outputs.version) }}
 
       - name: Checkout repository
         if: ${{ env.run-build == 'true' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,7 +79,7 @@ jobs:
           - id: esp32:esp32:esp32
             run: |
               python -m pip install pyserial
-              echo "version=3.0.0"
+              echo "version=3.0.0" >> $GITHUB_OUTPUT
               echo "index-url=--additional-urls https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json" >> $GITHUB_OUTPUT
           - id: esp8266:esp8266:generic
             run: |
@@ -167,7 +167,11 @@ jobs:
         run:
           |
           arduino-cli core update-index ${{ format('{0}', steps.prep.outputs.index-url) }}
-          arduino-cli core install ${{ format('{0}:{1}@{3} {2}', steps.split.outputs._0, steps.split.outputs._1, steps.prep.outputs.index-url, steps.prep.outputs.version) }}
+          if [ -z '${{ steps.prep.outputs.version }}' ]; then
+            arduino-cli core install ${{ format('{0}:{1}@{3} {2}', steps.split.outputs._0, steps.split.outputs._1, steps.prep.outputs.index-url, steps.prep.outputs.version) }}
+          else
+            arduino-cli core install ${{ format('{0}:{1} {2}', steps.split.outputs._0, steps.split.outputs._1, steps.prep.outputs.index-url) }}
+          fi
 
       - name: Checkout repository
         if: ${{ env.run-build == 'true' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,7 +79,7 @@ jobs:
           - id: esp32:esp32:esp32
             run: |
               python -m pip install pyserial
-              echo "version=3.0.0" >> $GITHUB_OUTPUT
+              echo "version=2.0.17" >> $GITHUB_OUTPUT
               echo "index-url=--additional-urls https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json" >> $GITHUB_OUTPUT
           - id: esp8266:esp8266:generic
             run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,9 +168,9 @@ jobs:
           |
           arduino-cli core update-index ${{ format('{0}', steps.prep.outputs.index-url) }}
           if [ -z '${{ steps.prep.outputs.version }}' ]; then
-            arduino-cli core install ${{ format('{0}:{1}@{3} {2}', steps.split.outputs._0, steps.split.outputs._1, steps.prep.outputs.index-url, steps.prep.outputs.version) }}
-          else
             arduino-cli core install ${{ format('{0}:{1} {2}', steps.split.outputs._0, steps.split.outputs._1, steps.prep.outputs.index-url) }}
+          else
+            arduino-cli core install ${{ format('{0}:{1}@{3} {2}', steps.split.outputs._0, steps.split.outputs._1, steps.prep.outputs.index-url, steps.prep.outputs.version) }}
           fi
 
       - name: Checkout repository


### PR DESCRIPTION
Adds a way to enforce specific version of Arduino platform package, by exporting `version` into GitHub output. This is needed to work around linker errors observed for ESP32 arduino core 3.0.x (see e.g. https://github.com/jgromes/RadioLib/actions/runs/10797679624/job/29949459765). This PR sets the ESP32 Arduino core to use 2.0.17, which seems to be the last version that actually builds.

The root cause for this behavior is currently unknown, it seems to only happen in the CI.