### PR TITLE
[LR112x] enabled higher bandwidth settings for 2.4G lora

### DIFF
--- a/src/modules/LR11x0/LR1120.cpp
+++ b/src/modules/LR11x0/LR1120.cpp
@@ -7,7 +7,7 @@ LR1120::LR1120(Module* mod) : LR11x0(mod) {
 
 int16_t LR1120::begin(float freq, float bw, uint8_t sf, uint8_t cr, uint8_t syncWord, int8_t power, uint16_t preambleLength, float tcxoVoltage) {
   // execute common part
-  int16_t state = LR11x0::begin(bw, sf, cr, syncWord, preambleLength, tcxoVoltage);
+  int16_t state = LR11x0::begin(bw, sf, cr, syncWord, preambleLength, tcxoVoltage, freq > 1000.0);
   RADIOLIB_ASSERT(state);
 
   // configure publicly accessible settings

--- a/src/modules/LR11x0/LR11x0.h
+++ b/src/modules/LR11x0/LR11x0.h
@@ -776,7 +776,7 @@ class LR11x0: public PhysicalLayer {
       \param syncWord 1-byte LoRa sync word.
       \param preambleLength LoRa preamble length in symbols
       \param tcxoVoltage TCXO reference voltage to be set.
-      \param high defaults to false for Sub-GHz band, true for frequencies above 1.8GHz
+      \param high defaults to false for Sub-GHz band, true for frequencies above 1GHz
       \returns \ref status_codes
     */
     int16_t begin(float bw, uint8_t sf, uint8_t cr, uint8_t syncWord, uint16_t preambleLength, float tcxoVoltage, bool high = false);
@@ -999,7 +999,7 @@ class LR11x0: public PhysicalLayer {
     /*!
       \brief Sets LoRa bandwidth. Allowed values are 62.5, 125.0, 250.0 and 500.0 kHz. (default, high = false)
       \param bw LoRa bandwidth to be set in kHz.
-      \param high if set to true, allowed bandwidth is 203.125, 406.25 and 812.5 kHz, frequency must be above 1.8GHz
+      \param high if set to true, allowed bandwidth is 203.125, 406.25 and 812.5 kHz, frequency must be above 1GHz
       \returns \ref status_codes
     */
     int16_t setBandwidth(float bw, bool high = false);

--- a/src/modules/LR11x0/LR11x0.h
+++ b/src/modules/LR11x0/LR11x0.h
@@ -776,6 +776,7 @@ class LR11x0: public PhysicalLayer {
       \param syncWord 1-byte LoRa sync word.
       \param preambleLength LoRa preamble length in symbols
       \param tcxoVoltage TCXO reference voltage to be set.
+      \param high defaults to false for Sub-GHz band, true for frequencies above 1.8GHz
       \returns \ref status_codes
     */
     int16_t begin(float bw, uint8_t sf, uint8_t cr, uint8_t syncWord, uint16_t preambleLength, float tcxoVoltage, bool high = false);
@@ -996,8 +997,9 @@ class LR11x0: public PhysicalLayer {
     // configuration methods
 
     /*!
-      \brief Sets LoRa bandwidth. Allowed values are 62.5, 125.0, 250.0 and 500.0 kHz.
+      \brief Sets LoRa bandwidth. Allowed values are 62.5, 125.0, 250.0 and 500.0 kHz. (default, high = false)
       \param bw LoRa bandwidth to be set in kHz.
+      \param high if set to true, allowed bandwidth is 203.125, 406.25 and 812.5 kHz, frequency must be above 1.8GHz
       \returns \ref status_codes
     */
     int16_t setBandwidth(float bw, bool high = false);

--- a/src/modules/LR11x0/LR11x0.h
+++ b/src/modules/LR11x0/LR11x0.h
@@ -364,6 +364,9 @@
 #define RADIOLIB_LR11X0_LORA_BW_125_0                           (0x04UL << 0)   //  7     0                     125.0 kHz
 #define RADIOLIB_LR11X0_LORA_BW_250_0                           (0x05UL << 0)   //  7     0                     250.0 kHz
 #define RADIOLIB_LR11X0_LORA_BW_500_0                           (0x06UL << 0)   //  7     0                     500.0 kHz
+#define RADIOLIB_LR11X0_LORA_BW_203_125                         (0x0DUL << 0)   //  7     0                     203.0 kHz (2.4GHz only)
+#define RADIOLIB_LR11X0_LORA_BW_406_25                          (0x0EUL << 0)   //  7     0                     406.0 kHz (2.4GHz only)
+#define RADIOLIB_LR11X0_LORA_BW_812_50                          (0x0FUL << 0)   //  7     0                     812.0 kHz (2.4GHz only)
 #define RADIOLIB_LR11X0_LORA_CR_4_5_SHORT                       (0x01UL << 0)   //  7     0     coding rate: 4/5 with short interleaver
 #define RADIOLIB_LR11X0_LORA_CR_4_6_SHORT                       (0x02UL << 0)   //  7     0                  4/6 with short interleaver
 #define RADIOLIB_LR11X0_LORA_CR_4_7_SHORT                       (0x03UL << 0)   //  7     0                  4/7 with short interleaver
@@ -775,7 +778,7 @@ class LR11x0: public PhysicalLayer {
       \param tcxoVoltage TCXO reference voltage to be set.
       \returns \ref status_codes
     */
-    int16_t begin(float bw, uint8_t sf, uint8_t cr, uint8_t syncWord, uint16_t preambleLength, float tcxoVoltage);
+    int16_t begin(float bw, uint8_t sf, uint8_t cr, uint8_t syncWord, uint16_t preambleLength, float tcxoVoltage, bool high = false);
 
     /*!
       \brief Initialization method for FSK modem.
@@ -997,7 +1000,7 @@ class LR11x0: public PhysicalLayer {
       \param bw LoRa bandwidth to be set in kHz.
       \returns \ref status_codes
     */
-    int16_t setBandwidth(float bw);
+    int16_t setBandwidth(float bw, bool high = false);
 
     /*!
       \brief Sets LoRa spreading factor. Allowed values range from 5 to 12.


### PR DESCRIPTION
2.4G lora works with differend BW presets, and we set this first before knowing about the frequency. Passing a 'high band' flag for the LR112x chips successfully inits them. Without this patch Radiolib Error -8 is returned.