### PR TITLE
[SX127x] Fix missing CRC mismatch error

### DIFF
--- a/src/modules/SX127x/SX127x.cpp
+++ b/src/modules/SX127x/SX127x.cpp
@@ -672,12 +672,11 @@ int16_t SX127x::readData(uint8_t* data, size_t len) {
       // CRC is disabled according to packet header and enabled according to user
       // most likely damaged packet header
       state = RADIOLIB_ERR_LORA_HEADER_DAMAGED;
-    } else {
-      // set FIFO read pointer to the start of the current packet
-      state = this->mod->SPIgetRegValue(RADIOLIB_SX127X_REG_FIFO_RX_CURRENT_ADDR);
-      if (state >= 0) {
-        state = this->mod->SPIsetRegValue(RADIOLIB_SX127X_REG_FIFO_ADDR_PTR, state);
-      }
+    } 
+    // set FIFO read pointer to the start of the current packet
+    int16_t addr = this->mod->SPIgetRegValue(RADIOLIB_SX127X_REG_FIFO_RX_CURRENT_ADDR);
+    if (addr >= 0) {
+      this->mod->SPIsetRegValue(RADIOLIB_SX127X_REG_FIFO_ADDR_PTR, addr);
     }
 
   } else if(modem == RADIOLIB_SX127X_FSK_OOK) {


### PR DESCRIPTION
After upgrading to version 7.0 we saw that SX127x radios sometimes got garbled data through. Seems due to #1184 the variable `state` gets overwritten (normally to 0) and thus it would loose a potential `RADIOLIB_ERR_CRC_MISMATCH` set before this.
I therefore introduced a new variable for it, and I also moved the SPI calls outside the `else` clause, because the data might still be valuable even if the header is damaged.