### PR TITLE
feat: Add tones support for the RPi Pico

### DIFF
--- a/examples/NonArduino/Pico/CMakeLists.txt
+++ b/examples/NonArduino/Pico/CMakeLists.txt
@@ -23,7 +23,7 @@ add_executable(${PROJECT_NAME}
 )
 
 # Pull in common dependencies
-target_link_libraries(${PROJECT_NAME} pico_stdlib hardware_spi hardware_gpio hardware_timer RadioLib)
+target_link_libraries(${PROJECT_NAME} pico_stdlib hardware_spi hardware_gpio hardware_timer pico_multicore hardware_pwm RadioLib)
 
 
 pico_enable_stdio_usb(${PROJECT_NAME} 1)

--- a/examples/NonArduino/Pico/PicoHal.h
+++ b/examples/NonArduino/Pico/PicoHal.h
@@ -21,6 +21,10 @@ unsigned long toneLoopDuration;
 #define SLEEP_1200 416.666
 #define SLEEP_2200 227.272
 
+// === NOTE ===
+// The tone(...) implementation uses the second core on the RPi Pico. This is to diminish as much 
+// jitter in the output tones as possible.
+
 void toneLoop(){
   gpio_set_dir(toneLoopPin, GPIO_OUT);
 
@@ -50,20 +54,13 @@ void toneLoop(){
 // and implement all of its virtual methods
 class PicoHal : public RadioLibHal {
 public:
-  PicoHal(spi_inst_t *spiChannel, uint32_t misoPin, uint32_t mosiPin, uint32_t sckPin, uint32_t pwmPin, uint32_t spiSpeed = 500 * 1000)
+  PicoHal(spi_inst_t *spiChannel, uint32_t misoPin, uint32_t mosiPin, uint32_t sckPin, uint32_t spiSpeed = 500 * 1000)
     : RadioLibHal(GPIO_IN, GPIO_OUT, 0, 1, GPIO_IRQ_EDGE_RISE, GPIO_IRQ_EDGE_FALL),
     _spiChannel(spiChannel),
     _spiSpeed(spiSpeed),
     _misoPin(misoPin),
     _mosiPin(mosiPin),
-    _sckPin(sckPin){
-      if (pwmPin == RADIOLIB_NC){
-        return;
-      }
-      // for AFSK
-      gpio_init(pwmPin);
-      gpio_set_dir(pwmPin, GPIO_OUT);
-    }
+    _sckPin(sckPin){}
 
   void init() override {
     stdio_init_all();

--- a/examples/NonArduino/Pico/main.cpp
+++ b/examples/NonArduino/Pico/main.cpp
@@ -44,7 +44,7 @@
 #include "PicoHal.h"
 
 // create a new instance of the HAL class
-PicoHal* hal = new PicoHal(SPI_PORT, SPI_MISO, SPI_MOSI, SPI_SCK, RADIOLIB_NC);
+PicoHal* hal = new PicoHal(SPI_PORT, SPI_MISO, SPI_MOSI, SPI_SCK);
 
 // now we can create the radio module
 // NSS pin:  26

--- a/examples/NonArduino/Pico/main.cpp
+++ b/examples/NonArduino/Pico/main.cpp
@@ -44,7 +44,7 @@
 #include "PicoHal.h"
 
 // create a new instance of the HAL class
-PicoHal* hal = new PicoHal(SPI_PORT, SPI_MISO, SPI_MOSI, SPI_SCK);
+PicoHal* hal = new PicoHal(SPI_PORT, SPI_MISO, SPI_MOSI, SPI_SCK, RADIOLIB_NC);
 
 // now we can create the radio module
 // NSS pin:  26


### PR DESCRIPTION
The following PR adds overrides for the `tone()` and `noTone()` functions in the HAL for the RPi Pico. Tones are added based on bitbangs.

This code was tested using the APRS_Position.ino example, modified for the Pico. Closes #1230 
