### PR TITLE
[SX128x] Add setDataRate method for LoRa modem

### DIFF
--- a/src/modules/SX128x/SX128x.cpp
+++ b/src/modules/SX128x/SX128x.cpp
@@ -902,6 +902,22 @@ int16_t SX128x::setPreambleLength(uint32_t preambleLength) {
   return(RADIOLIB_ERR_WRONG_MODEM);
 }
 
+int16_t SX128x::setDataRate(DataRate_t dr) {
+  // check active modem
+  uint8_t modem = getPacketType();
+  int16_t state = RADIOLIB_ERR_NONE;
+  if (modem == RADIOLIB_SX128X_PACKET_TYPE_LORA) {
+      state = this->setBandwidth(dr.lora.bandwidth);
+      RADIOLIB_ASSERT(state);
+      state = this->setSpreadingFactor(dr.lora.spreadingFactor);
+      RADIOLIB_ASSERT(state);
+      state = this->setCodingRate(dr.lora.codingRate);
+  } else {
+      return(RADIOLIB_ERR_WRONG_MODEM);
+  }
+  return(state);
+}
+
 int16_t SX128x::setBitRate(float br) {
   // check active modem
   uint8_t modem = getPacketType();

--- a/src/modules/SX128x/SX128x.h
+++ b/src/modules/SX128x/SX128x.h
@@ -679,6 +679,13 @@ class SX128x: public PhysicalLayer {
     int16_t setPreambleLength(uint32_t preambleLength);
 
     /*!
+      \brief Set data rate.
+      \param dr Data rate struct. Interpretation depends on currently active modem (FSK or LoRa).
+      \returns \ref status_codes
+    */
+    int16_t setDataRate(DataRate_t dr) override;
+
+    /*!
       \brief Sets FSK or FLRC bit rate. Allowed values are 125, 250, 400, 500, 800, 1000,
       1600 and 2000 kbps (for FSK modem) or 260, 325, 520, 650, 1000 and 1300 (for FLRC modem).
       \param br FSK/FLRC bit rate to be set in kbps.


### PR DESCRIPTION
This PR is tested (on an SX1280 only). It adds the setDataRate function for the LoRa modem of the SX128x series chips, as I was using this modem in a situation where it was preferable to address it through the use of a `PhysicalLayer` pointer instead of the base class. I noticed setDataRate wasn't implemented yet, so I implemented it myself.

One thing I should mention, would it be a good idea to add support for the ranging modem also? This could always be done at a later date of course, but currently I don't have time to look into it.