### PR TITLE
[SX1276, LoRaWAN] Fix confusing return value in LoRaWAN::processJoinAccept(...)

### DIFF
--- a/src/protocols/LoRaWAN/LoRaWAN.cpp
+++ b/src/protocols/LoRaWAN/LoRaWAN.cpp
@@ -688,6 +688,8 @@ int16_t LoRaWANNode::processJoinAccept(LoRaWANJoinEvent_t *joinEvent) {
   // we can ignore that error
   if(state != RADIOLIB_ERR_LORA_HEADER_DAMAGED) {
     RADIOLIB_ASSERT(state);
+  } else {
+    state = RADIOLIB_ERR_NONE;
   }
 
   // check reply message type


### PR DESCRIPTION
The error `RADIOLIB_ERR_LORA_HEADER_DAMAGED` returned from `phyLayer->readData(...)` and signaled from a SX1276 is in fact correctly ignored but the `state` variable is not corrected.

This confuses the caller due to the wrongly returned state value `RADIOLIB_ERR_LORA_HEADER_DAMAGED`.  Especially [radiolib-persistence](https://github.com/radiolib-org/radiolib-persistence) did think it can not join a network.

Maybe this can be a hotfix? 
Because I just have a lot of SX1276 on hand and  need the library working with them under Arduino IDE and PlatformIO in my class in two weeks. I don't want to ask and instruct every student to fix its RadioLib installation by hand if it's not absolutely necessary. This could confuse some students. ;-)

Best regards
Volker