### PR TITLE
[LoRaWAN] Just for convenience: Add a `frmPending` field in `LoRaWANEvent_t`

### DIFF
--- a/src/protocols/LoRaWAN/LoRaWAN.cpp
+++ b/src/protocols/LoRaWAN/LoRaWAN.cpp
@@ -1807,6 +1807,7 @@ int16_t LoRaWANNode::parseDownlink(uint8_t* data, size_t* len, LoRaWANEvent_t* e
     event->dir = RADIOLIB_LORAWAN_DOWNLINK;
     event->confirmed = isConfirmedDown;
     event->confirming = isConfirmingUp;
+    event->frmPending = (downlinkMsg[RADIOLIB_LORAWAN_FHDR_FCTRL_POS] & RADIOLIB_LORAWAN_FCTRL_FRAME_PENDING) != 0;
     event->datarate = this->channels[RADIOLIB_LORAWAN_DOWNLINK].dr;
     event->freq = channels[event->dir].freq / 10000.0;
     event->power = this->txPowerMax - this->txPowerSteps * 2;

--- a/src/protocols/LoRaWAN/LoRaWAN.h
+++ b/src/protocols/LoRaWAN/LoRaWAN.h
@@ -504,6 +504,9 @@ struct LoRaWANEvent_t {
   (e.g., server downlink reply to confirmed uplink sent by user application)*/
   bool confirming;
 
+  /*! \brief Whether further downlink messages are pending on the server side. */
+  bool frmPending;
+
   /*! \brief Datarate */
   uint8_t datarate;
   


### PR DESCRIPTION
Add a `frmPending` bit from `FCtrl` as a field in `LoRaWANEvent_t`. 

This bit signals that further downlink frames are pending on the server side.

LoRaWAN class A devices, in case further frames are pending, shall initiate another uplink immediately in order to trigger the downlink of this pending frame on the server side. Using this `frmPending` bit, the initiation of one or more further uplinks can then easily be formulated as a loop in the user code.

Have a look at [this quick and dirty example](https://github.com/PCo-IoT-2024/platform.io/blob/main/LoRaWAN-HelloWorld-radiolib/src/ESP32_LoRaWAN_SX1276_DeepSleep_radiolib.cpp) based on [radiolib-persistent](https://github.com/radiolib-org/radiolib-persistence) starting at line 201 (currently) .

