### PR TITLE
[LR11X0] pay more attention to selection of FSK preamble detector length

### DIFF
--- a/src/modules/LR11x0/LR11x0.cpp
+++ b/src/modules/LR11x0/LR11x0.cpp
@@ -1117,7 +1117,11 @@ int16_t LR11x0::setPreambleLength(size_t preambleLength) {
     return(setPacketParamsLoRa(this->preambleLengthLoRa, this->headerType,  this->implicitLen, this->crcTypeLoRa, (uint8_t)this->invertIQEnabled));
   } else if(type == RADIOLIB_LR11X0_PACKET_TYPE_GFSK) {
     this->preambleLengthGFSK = preambleLength;
-    this->preambleDetLength = RADIOLIB_LR11X0_GFSK_PREAMBLE_DETECT_16_BITS;
+    this->preambleDetLength = preambleLength >= 32 ? RADIOLIB_LR11X0_GFSK_PREAMBLE_DETECT_32_BITS :
+                              preambleLength >= 24 ? RADIOLIB_LR11X0_GFSK_PREAMBLE_DETECT_24_BITS :
+                              preambleLength >= 16 ? RADIOLIB_LR11X0_GFSK_PREAMBLE_DETECT_16_BITS :
+                              preambleLength >   0 ? RADIOLIB_LR11X0_GFSK_PREAMBLE_DETECT_8_BITS :
+                              RADIOLIB_LR11X0_GFSK_PREAMBLE_DETECT_DISABLED;
     return(setPacketParamsGFSK(this->preambleLengthGFSK, this->preambleDetLength, this->syncWordLength, this->addrComp, this->packetType, RADIOLIB_LR11X0_MAX_PACKET_LENGTH, this->crcTypeGFSK, this->whitening));
   }
 


### PR DESCRIPTION
## Brief description

Most of FSK radio protocols supported by SoftRF project are using 8-bit FSK preamble:
1) https://github.com/lyusupov/SoftRF/blob/master/software/firmware/source/SoftRF/src/protocol/radio/OGNTP.h#L24-L25
2) https://github.com/lyusupov/SoftRF/blob/master/software/firmware/source/SoftRF/src/protocol/radio/ADSL.h#L24-L25
3) https://github.com/lyusupov/SoftRF/blob/master/software/firmware/source/SoftRF/src/protocol/radio/Legacy.h#L25-L26

Current RadioLib code uses explicit 16 bit FSK preamble detector length

<img width="748" alt="image" src="https://github.com/user-attachments/assets/4e22db36-d8ba-4d4b-b80a-4759fd31418b">

This causes **almost 95% loss of packets** while trying to receive radio packets sent by other (SX1262 and SX1276) devices  ( these packets use 8-bit FSK preamble ).

This PR is filed to fix the issue of not receiving 8-bit FSK preamble packets.
