### PR TITLE
[PHY] Get/Set modem

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
         # platform-dependent settings - extra board options, board index URLs, skip patterns etc.
         include:
           - id: arduino:avr:uno
-            run: echo "skip-pattern=(STM32WL|SSTV|LoRaWAN|LR11x0_Firmware_Update|Pager|APRS|Morse|SX126x)" >> $GITHUB_OUTPUT
+            run: echo "skip-pattern=(STM32WL|SSTV|LoRaWAN|LR11x0_Firmware_Update|Pager|APRS|Morse|SX126x|Hellschreiber)" >> $GITHUB_OUTPUT
           - id: arduino:avr:mega
             run: |
               echo "options=':cpu=atmega2560'" >> $GITHUB_OUTPUT

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,12 +10,11 @@ on:
       id:
         description: The ID of the platform on which the build is run
         required: true
-        default: arduino:avr:uno
+        default: arduino:avr:mega
         type: choice
         options:
           - all
           - none
-          - arduino:avr:uno
           - arduino:avr:mega
           - arduino:mbed:nano33ble
           - arduino:mbed:envie_m4
@@ -45,8 +44,6 @@ jobs:
       matrix:
         # platform-dependent settings - extra board options, board index URLs, skip patterns etc.
         include:
-          - id: arduino:avr:uno
-            run: echo "skip-pattern=(STM32WL|SSTV|LoRaWAN|LR11x0_Firmware_Update|Pager|APRS|Morse|SX126x|Hellschreiber)" >> $GITHUB_OUTPUT
           - id: arduino:avr:mega
             run: |
               echo "options=':cpu=atmega2560'" >> $GITHUB_OUTPUT
@@ -131,7 +128,7 @@ jobs:
     runs-on: ubuntu-latest
     name: ${{ matrix.id }}
     env:
-      run-build: ${{ (inputs.id != 'none' && matrix.id == 'arduino:avr:uno') || contains(github.event.head_commit.message, 'CI_BUILD_ALL') || contains(github.event.head_commit.message, 'Bump version to') || contains(github.event.head_commit.message, format('{0}', matrix.id)) || inputs.id == 'all' || inputs.id == matrix.id }}
+      run-build: ${{ (inputs.id != 'none' && matrix.id == 'arduino:avr:mega') || contains(github.event.head_commit.message, 'CI_BUILD_ALL') || contains(github.event.head_commit.message, 'Bump version to') || contains(github.event.head_commit.message, format('{0}', matrix.id)) || inputs.id == 'all' || inputs.id == matrix.id }}
 
     steps:
       - name: Free Disk Space (Ubuntu)

--- a/keywords.txt
+++ b/keywords.txt
@@ -320,6 +320,15 @@ dropRepeaters	KEYWORD2
 sendTone	KEYWORD2
 
 # PhysicalLayer
+RadioLibIrqType_t	KEYWORD1
+LoRaRate_t	KEYWORD1
+FSKRate_t	KEYWORD1
+LrFhssRate_t	KEYWORD1
+DataRate_t	KEYWORD1
+CADScanConfig_t	KEYWORD1
+RSSIScanConfig_t	KEYWORD1
+ChannelScanConfig_t	KEYWORD1
+ModemType_t	KEYWORD1
 dropSync	KEYWORD2
 setTimerFlag	KEYWORD2
 setInterruptSetup	KEYWORD2
@@ -330,9 +339,7 @@ clearPacketSentAction	KEYWORD2
 setDataRate	KEYWORD2
 checkDataRate	KEYWORD2
 setModem	KEYWORD2
-
-# BellModem
-setModem	KEYWORD2
+getModem	KEYWORD2
 
 # LoRaWAN
 getBufferNonces	KEYWORD2

--- a/keywords.txt
+++ b/keywords.txt
@@ -329,6 +329,7 @@ setPacketSentAction	KEYWORD2
 clearPacketSentAction	KEYWORD2
 setDataRate	KEYWORD2
 checkDataRate	KEYWORD2
+setModem	KEYWORD2
 
 # BellModem
 setModem	KEYWORD2

--- a/src/modules/LLCC68/LLCC68.cpp
+++ b/src/modules/LLCC68/LLCC68.cpp
@@ -127,8 +127,9 @@ int16_t LLCC68::setModem(ModemType_t modem) {
     case(ModemType_t::LRFHSS): {
       return(this->beginLRFHSS());
     } break;
+    default:
+      return(RADIOLIB_ERR_WRONG_MODEM);
   }
-  return(RADIOLIB_ERR_WRONG_MODEM);
 }
 
 #endif

--- a/src/modules/LLCC68/LLCC68.cpp
+++ b/src/modules/LLCC68/LLCC68.cpp
@@ -116,4 +116,19 @@ int16_t LLCC68::checkDataRate(DataRate_t dr) {
   return(state);
 }
 
+int16_t LLCC68::setModem(ModemType_t modem) {
+  switch(modem) {
+    case(ModemType_t::LoRa): {
+      return(this->begin());
+    } break;
+    case(ModemType_t::FSK): {
+      return(this->beginFSK());
+    } break;
+    case(ModemType_t::LRFHSS): {
+      return(this->beginLRFHSS());
+    } break;
+  }
+  return(RADIOLIB_ERR_WRONG_MODEM);
+}
+
 #endif

--- a/src/modules/LLCC68/LLCC68.h
+++ b/src/modules/LLCC68/LLCC68.h
@@ -69,6 +69,14 @@ class LLCC68: public SX1262 {
       \returns \ref status_codes
     */
     int16_t checkDataRate(DataRate_t dr) override;
+    
+    /*!
+      \brief Set modem for the radio to use. Will perform full reset and reconfigure the radio
+      using its default parameters.
+      \param modem Modem type to set - FSK, LoRa or LR-FHSS.
+      \returns \ref status_codes
+    */
+    int16_t setModem(ModemType_t modem) override;
 
 #if !RADIOLIB_GODMODE
   private:

--- a/src/modules/LR11x0/LR1110.cpp
+++ b/src/modules/LR11x0/LR1110.cpp
@@ -105,4 +105,19 @@ int16_t LR1110::checkOutputPower(int8_t power, int8_t* clipped, bool forceHighPo
   return(RADIOLIB_ERR_NONE);
 }
 
+int16_t LR1110::setModem(ModemType_t modem) {
+  switch(modem) {
+    case(ModemType_t::LoRa): {
+      return(this->begin());
+    } break;
+    case(ModemType_t::FSK): {
+      return(this->beginGFSK());
+    } break;
+    case(ModemType_t::LRFHSS): {
+      return(this->beginLRFHSS());
+    } break;
+  }
+  return(RADIOLIB_ERR_WRONG_MODEM);
+}
+
 #endif

--- a/src/modules/LR11x0/LR1110.h
+++ b/src/modules/LR11x0/LR1110.h
@@ -123,6 +123,14 @@ class LR1110: public LR11x0 {
     */
     int16_t checkOutputPower(int8_t power, int8_t* clipped, bool forceHighPower);
 
+    /*!
+      \brief Set modem for the radio to use. Will perform full reset and reconfigure the radio
+      using its default parameters.
+      \param modem Modem type to set - FSK, LoRa or LR-FHSS.
+      \returns \ref status_codes
+    */
+    int16_t setModem(ModemType_t modem) override;
+
 #if !RADIOLIB_GODMODE
   private:
 #endif

--- a/src/modules/LR11x0/LR1120.cpp
+++ b/src/modules/LR11x0/LR1120.cpp
@@ -128,4 +128,19 @@ int16_t LR1120::checkOutputPower(int8_t power, int8_t* clipped, bool forceHighPo
   return(RADIOLIB_ERR_NONE);
 }
 
+int16_t LR1120::setModem(ModemType_t modem) {
+  switch(modem) {
+    case(ModemType_t::LoRa): {
+      return(this->begin());
+    } break;
+    case(ModemType_t::FSK): {
+      return(this->beginGFSK());
+    } break;
+    case(ModemType_t::LRFHSS): {
+      return(this->beginLRFHSS());
+    } break;
+  }
+  return(RADIOLIB_ERR_WRONG_MODEM);
+}
+
 #endif

--- a/src/modules/LR11x0/LR1120.h
+++ b/src/modules/LR11x0/LR1120.h
@@ -132,6 +132,14 @@ class LR1120: public LR11x0 {
     */
     int16_t checkOutputPower(int8_t power, int8_t* clipped, bool forceHighPower);
 
+    /*!
+      \brief Set modem for the radio to use. Will perform full reset and reconfigure the radio
+      using its default parameters.
+      \param modem Modem type to set - FSK, LoRa or LR-FHSS.
+      \returns \ref status_codes
+    */
+    int16_t setModem(ModemType_t modem) override;
+
 #if !RADIOLIB_GODMODE
   private:
 #endif

--- a/src/modules/LR11x0/LR11x0.cpp
+++ b/src/modules/LR11x0/LR11x0.cpp
@@ -2009,6 +2009,30 @@ int16_t LR11x0::getGnssSatellites(LR11x0GnssSatellite_t* sats, uint8_t numSats) 
   return(state);
 }
 
+int16_t LR11x0::getModem(ModemType_t* modem) {
+  if(!modem) {
+    return(RADIOLIB_ERR_MEMORY_ALLOCATION_FAILED);
+  }
+
+  uint8_t packetType = RADIOLIB_LR11X0_PACKET_TYPE_NONE;
+  int16_t state = getPacketType(&packetType);
+  RADIOLIB_ASSERT(state);
+
+  switch(packetType) {
+    case(RADIOLIB_LR11X0_PACKET_TYPE_LORA):
+      *modem = ModemType_t::LoRa;
+      return(RADIOLIB_ERR_NONE);
+    case(RADIOLIB_LR11X0_PACKET_TYPE_GFSK):
+      *modem = ModemType_t::FSK;
+      return(RADIOLIB_ERR_NONE);
+    case(RADIOLIB_LR11X0_PACKET_TYPE_LR_FHSS):
+      *modem = ModemType_t::LRFHSS;
+      return(RADIOLIB_ERR_NONE);
+  }
+  
+  return(RADIOLIB_ERR_WRONG_MODEM);
+}
+
 int16_t LR11x0::modSetup(float tcxoVoltage, uint8_t modem) {
   this->mod->init();
   this->mod->hal->pinMode(this->mod->getIrq(), this->mod->hal->GpioModeInput);

--- a/src/modules/LR11x0/LR11x0.h
+++ b/src/modules/LR11x0/LR11x0.h
@@ -1602,6 +1602,13 @@ class LR11x0: public PhysicalLayer {
       \returns \ref status_codes
     */
     int16_t getGnssSatellites(LR11x0GnssSatellite_t* sats, uint8_t numSats);
+
+    /*!
+      \brief Get modem currently in use by the radio.
+      \param modem Pointer to a variable to save the retrieved configuration into.
+      \returns \ref status_codes
+    */
+    int16_t getModem(ModemType_t* modem) override;
     
 #if !RADIOLIB_GODMODE && !RADIOLIB_LOW_LEVEL
   protected:

--- a/src/modules/SX126x/SX1262.cpp
+++ b/src/modules/SX126x/SX1262.cpp
@@ -145,4 +145,19 @@ int16_t SX1262::checkOutputPower(int8_t power, int8_t* clipped) {
   return(RADIOLIB_ERR_NONE);
 }
 
+int16_t SX1262::setModem(ModemType_t modem) {
+  switch(modem) {
+    case(ModemType_t::LoRa): {
+      return(this->begin());
+    } break;
+    case(ModemType_t::FSK): {
+      return(this->beginFSK());
+    } break;
+    case(ModemType_t::LRFHSS): {
+      return(this->beginLRFHSS());
+    } break;
+  }
+  return(RADIOLIB_ERR_WRONG_MODEM);
+}
+
 #endif

--- a/src/modules/SX126x/SX1262.cpp
+++ b/src/modules/SX126x/SX1262.cpp
@@ -156,8 +156,9 @@ int16_t SX1262::setModem(ModemType_t modem) {
     case(ModemType_t::LRFHSS): {
       return(this->beginLRFHSS());
     } break;
+    default:
+      return(RADIOLIB_ERR_WRONG_MODEM);
   }
-  return(RADIOLIB_ERR_WRONG_MODEM);
 }
 
 #endif

--- a/src/modules/SX126x/SX1262.h
+++ b/src/modules/SX126x/SX1262.h
@@ -109,6 +109,14 @@ class SX1262: public SX126x {
       \returns \ref status_codes
     */
     int16_t checkOutputPower(int8_t power, int8_t* clipped) override;
+    
+    /*!
+      \brief Set modem for the radio to use. Will perform full reset and reconfigure the radio
+      using its default parameters.
+      \param modem Modem type to set - FSK, LoRa or LR-FHSS.
+      \returns \ref status_codes
+    */
+    int16_t setModem(ModemType_t modem) override;
 
 #if !RADIOLIB_GODMODE
   private:

--- a/src/modules/SX126x/SX1268.cpp
+++ b/src/modules/SX126x/SX1268.cpp
@@ -151,8 +151,9 @@ int16_t SX1268::setModem(ModemType_t modem) {
     case(ModemType_t::LRFHSS): {
       return(this->beginLRFHSS());
     } break;
+    default:
+      return(RADIOLIB_ERR_WRONG_MODEM);
   }
-  return(RADIOLIB_ERR_WRONG_MODEM);
 }
 
 #endif

--- a/src/modules/SX126x/SX1268.cpp
+++ b/src/modules/SX126x/SX1268.cpp
@@ -140,4 +140,19 @@ int16_t SX1268::checkOutputPower(int8_t power, int8_t* clipped) {
   return(RADIOLIB_ERR_NONE);
 }
 
+int16_t SX1268::setModem(ModemType_t modem) {
+  switch(modem) {
+    case(ModemType_t::LoRa): {
+      return(this->begin());
+    } break;
+    case(ModemType_t::FSK): {
+      return(this->beginFSK());
+    } break;
+    case(ModemType_t::LRFHSS): {
+      return(this->beginLRFHSS());
+    } break;
+  }
+  return(RADIOLIB_ERR_WRONG_MODEM);
+}
+
 #endif

--- a/src/modules/SX126x/SX1268.h
+++ b/src/modules/SX126x/SX1268.h
@@ -107,6 +107,14 @@ class SX1268: public SX126x {
       \returns \ref status_codes
     */
     int16_t checkOutputPower(int8_t power, int8_t* clipped) override;
+    
+    /*!
+      \brief Set modem for the radio to use. Will perform full reset and reconfigure the radio
+      using its default parameters.
+      \param modem Modem type to set - FSK, LoRa or LR-FHSS.
+      \returns \ref status_codes
+    */
+    int16_t setModem(ModemType_t modem) override;
 
 #if !RADIOLIB_GODMODE
   private:

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -1662,6 +1662,27 @@ int16_t SX126x::invertIQ(bool enable) {
   return(setPacketParams(this->preambleLengthLoRa, this->crcTypeLoRa, this->implicitLen, this->headerType, this->invertIQEnabled));
 }
 
+int16_t SX126x::getModem(ModemType_t* modem) {
+  if(!modem) {
+    return(RADIOLIB_ERR_MEMORY_ALLOCATION_FAILED);
+  }
+
+  uint8_t packetType = getPacketType();
+  switch(packetType) {
+    case(RADIOLIB_SX126X_PACKET_TYPE_LORA):
+      *modem = ModemType_t::LoRa;
+      return(RADIOLIB_ERR_NONE);
+    case(RADIOLIB_SX126X_PACKET_TYPE_GFSK):
+      *modem = ModemType_t::FSK;
+      return(RADIOLIB_ERR_NONE);
+    case(RADIOLIB_SX126X_PACKET_TYPE_LR_FHSS):
+      *modem = ModemType_t::LRFHSS;
+      return(RADIOLIB_ERR_NONE);
+  }
+  
+  return(RADIOLIB_ERR_WRONG_MODEM);
+}
+
 #if !RADIOLIB_EXCLUDE_DIRECT_RECEIVE
 void SX126x::setDirectAction(void (*func)(void)) {
   setDio1Action(func);

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -1123,6 +1123,13 @@ class SX126x: public PhysicalLayer {
     */
     int16_t invertIQ(bool enable) override;
 
+    /*!
+      \brief Get modem currently in use by the radio.
+      \param modem Pointer to a variable to save the retrieved configuration into.
+      \returns \ref status_codes
+    */
+    int16_t getModem(ModemType_t* modem) override;
+
     #if !RADIOLIB_EXCLUDE_DIRECT_RECEIVE
     /*!
       \brief Set interrupt service routine function to call when data bit is received in direct mode.

--- a/src/modules/SX127x/SX1272.cpp
+++ b/src/modules/SX127x/SX1272.cpp
@@ -585,4 +585,17 @@ void SX1272::errataFix(bool rx) {
   mod->SPIsetRegValue(0x31, 0b10000000, 7, 7);
 }
 
+int16_t SX1272::setModem(ModemType_t modem) {
+  switch(modem) {
+    case(ModemType_t::LoRa): {
+      return(this->begin());
+    } break;
+    case(ModemType_t::FSK): {
+      return(this->beginFSK());
+    } break;
+    default:
+      return(RADIOLIB_ERR_WRONG_MODEM);
+  }
+}
+
 #endif

--- a/src/modules/SX127x/SX1272.h
+++ b/src/modules/SX127x/SX1272.h
@@ -301,6 +301,14 @@ class SX1272: public SX127x {
       \returns \ref status_codes
     */
     int16_t explicitHeader();
+    
+    /*!
+      \brief Set modem for the radio to use. Will perform full reset and reconfigure the radio
+      using its default parameters.
+      \param modem Modem type to set - FSK or LoRa.
+      \returns \ref status_codes
+    */
+    int16_t setModem(ModemType_t modem) override;
 
 #if !RADIOLIB_GODMODE
   protected:

--- a/src/modules/SX127x/SX1273.cpp
+++ b/src/modules/SX127x/SX1273.cpp
@@ -115,4 +115,17 @@ int16_t SX1273::checkDataRate(DataRate_t dr) {
   return(state);
 }
 
+int16_t SX1273::setModem(ModemType_t modem) {
+  switch(modem) {
+    case(ModemType_t::LoRa): {
+      return(this->begin());
+    } break;
+    case(ModemType_t::FSK): {
+      return(this->beginFSK());
+    } break;
+    default:
+      return(RADIOLIB_ERR_WRONG_MODEM);
+  }
+}
+
 #endif

--- a/src/modules/SX127x/SX1273.h
+++ b/src/modules/SX127x/SX1273.h
@@ -62,6 +62,14 @@ class SX1273: public SX1272 {
       \returns \ref status_codes
     */
     int16_t checkDataRate(DataRate_t dr) override;
+    
+    /*!
+      \brief Set modem for the radio to use. Will perform full reset and reconfigure the radio
+      using its default parameters.
+      \param modem Modem type to set - FSK or LoRa.
+      \returns \ref status_codes
+    */
+    int16_t setModem(ModemType_t modem) override;
 
 #if !RADIOLIB_GODMODE
   private:

--- a/src/modules/SX127x/SX1276.cpp
+++ b/src/modules/SX127x/SX1276.cpp
@@ -79,4 +79,17 @@ int16_t SX1276::setFrequency(float freq) {
   return(state);
 }
 
+int16_t SX1276::setModem(ModemType_t modem) {
+  switch(modem) {
+    case(ModemType_t::LoRa): {
+      return(this->begin());
+    } break;
+    case(ModemType_t::FSK): {
+      return(this->beginFSK());
+    } break;
+    default:
+      return(RADIOLIB_ERR_WRONG_MODEM);
+  }
+}
+
 #endif

--- a/src/modules/SX127x/SX1276.h
+++ b/src/modules/SX127x/SX1276.h
@@ -62,6 +62,14 @@ class SX1276: public SX1278 {
       \returns \ref status_codes
     */
     int16_t setFrequency(float freq) override;
+    
+    /*!
+      \brief Set modem for the radio to use. Will perform full reset and reconfigure the radio
+      using its default parameters.
+      \param modem Modem type to set - FSK or LoRa.
+      \returns \ref status_codes
+    */
+    int16_t setModem(ModemType_t modem) override;
 
 #if !RADIOLIB_GODMODE
   private:

--- a/src/modules/SX127x/SX1277.cpp
+++ b/src/modules/SX127x/SX1277.cpp
@@ -157,4 +157,17 @@ int16_t SX1277::checkDataRate(DataRate_t dr) {
   return(state);
 }
 
+int16_t SX1277::setModem(ModemType_t modem) {
+  switch(modem) {
+    case(ModemType_t::LoRa): {
+      return(this->begin());
+    } break;
+    case(ModemType_t::FSK): {
+      return(this->beginFSK());
+    } break;
+    default:
+      return(RADIOLIB_ERR_WRONG_MODEM);
+  }
+}
+
 #endif

--- a/src/modules/SX127x/SX1277.h
+++ b/src/modules/SX127x/SX1277.h
@@ -83,6 +83,14 @@ class SX1277: public SX1278 {
       \returns \ref status_codes
     */
     int16_t checkDataRate(DataRate_t dr) override;
+    
+    /*!
+      \brief Set modem for the radio to use. Will perform full reset and reconfigure the radio
+      using its default parameters.
+      \param modem Modem type to set - FSK or LoRa.
+      \returns \ref status_codes
+    */
+    int16_t setModem(ModemType_t modem) override;
 
 #if !RADIOLIB_GODMODE
   private:

--- a/src/modules/SX127x/SX1278.cpp
+++ b/src/modules/SX127x/SX1278.cpp
@@ -705,4 +705,17 @@ void SX1278::errataFix(bool rx) {
   mod->SPIsetRegValue(0x30, fixedRegs[2]);
 }
 
+int16_t SX1278::setModem(ModemType_t modem) {
+  switch(modem) {
+    case(ModemType_t::LoRa): {
+      return(this->begin());
+    } break;
+    case(ModemType_t::FSK): {
+      return(this->beginFSK());
+    } break;
+    default:
+      return(RADIOLIB_ERR_WRONG_MODEM);
+  }
+}
+
 #endif

--- a/src/modules/SX127x/SX1278.h
+++ b/src/modules/SX127x/SX1278.h
@@ -313,6 +313,14 @@ class SX1278: public SX127x {
       \returns \ref status_codes
     */
     int16_t explicitHeader();
+    
+    /*!
+      \brief Set modem for the radio to use. Will perform full reset and reconfigure the radio
+      using its default parameters.
+      \param modem Modem type to set - FSK or LoRa.
+      \returns \ref status_codes
+    */
+    int16_t setModem(ModemType_t modem) override;
 
 #if !RADIOLIB_GODMODE
   protected:

--- a/src/modules/SX127x/SX1279.cpp
+++ b/src/modules/SX127x/SX1279.cpp
@@ -79,4 +79,17 @@ int16_t SX1279::setFrequency(float freq) {
   return(state);
 }
 
+int16_t SX1279::setModem(ModemType_t modem) {
+  switch(modem) {
+    case(ModemType_t::LoRa): {
+      return(this->begin());
+    } break;
+    case(ModemType_t::FSK): {
+      return(this->beginFSK());
+    } break;
+    default:
+      return(RADIOLIB_ERR_WRONG_MODEM);
+  }
+}
+
 #endif

--- a/src/modules/SX127x/SX1279.h
+++ b/src/modules/SX127x/SX1279.h
@@ -62,6 +62,14 @@ class SX1279: public SX1278 {
       \returns \ref status_codes
     */
     int16_t setFrequency(float freq) override;
+    
+    /*!
+      \brief Set modem for the radio to use. Will perform full reset and reconfigure the radio
+      using its default parameters.
+      \param modem Modem type to set - FSK or LoRa.
+      \returns \ref status_codes
+    */
+    int16_t setModem(ModemType_t modem) override;
 
 #if !RADIOLIB_GODMODE
   private:

--- a/src/modules/SX127x/SX127x.cpp
+++ b/src/modules/SX127x/SX127x.cpp
@@ -1754,6 +1754,24 @@ int16_t SX127x::invertIQ(bool enable) {
   return(state);
 }
 
+int16_t SX127x::getModem(ModemType_t* modem) {
+  if(!modem) {
+    return(RADIOLIB_ERR_MEMORY_ALLOCATION_FAILED);
+  }
+
+  int16_t packetType = getActiveModem();
+  switch(packetType) {
+    case(RADIOLIB_SX127X_LORA):
+      *modem = ModemType_t::LoRa;
+      return(RADIOLIB_ERR_NONE);
+    case(RADIOLIB_SX127X_FSK_OOK):
+      *modem = ModemType_t::FSK;
+      return(RADIOLIB_ERR_NONE);
+  }
+  
+  return(RADIOLIB_ERR_WRONG_MODEM);
+}
+
 #if !RADIOLIB_EXCLUDE_DIRECT_RECEIVE
 void SX127x::setDirectAction(void (*func)(void)) {
   setDio1Action(func, this->mod->hal->GpioInterruptRising);

--- a/src/modules/SX127x/SX127x.h
+++ b/src/modules/SX127x/SX127x.h
@@ -1149,6 +1149,13 @@ class SX127x: public PhysicalLayer {
     */
     int16_t invertIQ(bool enable) override;
 
+    /*!
+      \brief Get modem currently in use by the radio.
+      \param modem Pointer to a variable to save the retrieved configuration into.
+      \returns \ref status_codes
+    */
+    int16_t getModem(ModemType_t* modem) override;
+
     #if !RADIOLIB_EXCLUDE_DIRECT_RECEIVE
     /*!
       \brief Set interrupt service routine function to call when data bit is received in direct mode.

--- a/src/modules/SX128x/SX128x.cpp
+++ b/src/modules/SX128x/SX128x.cpp
@@ -856,6 +856,37 @@ int16_t SX128x::checkOutputPower(int8_t pwr, int8_t* clipped) {
   return(RADIOLIB_ERR_NONE);
 }
 
+int16_t SX128x::setModem(ModemType_t modem) {
+  switch(modem) {
+    case(ModemType_t::LoRa): {
+      return(this->begin());
+    } break;
+    case(ModemType_t::FSK): {
+      return(this->beginGFSK());
+    } break;
+    default:
+      return(RADIOLIB_ERR_WRONG_MODEM);
+  }
+}
+
+int16_t SX128x::getModem(ModemType_t* modem) {
+  if(!modem) {
+    return(RADIOLIB_ERR_MEMORY_ALLOCATION_FAILED);
+  }
+
+  uint8_t packetType = getPacketType();
+  switch(packetType) {
+    case(RADIOLIB_SX128X_PACKET_TYPE_LORA):
+      *modem = ModemType_t::LoRa;
+      return(RADIOLIB_ERR_NONE);
+    case(RADIOLIB_SX128X_PACKET_TYPE_GFSK):
+      *modem = ModemType_t::FSK;
+      return(RADIOLIB_ERR_NONE);
+  }
+  
+  return(RADIOLIB_ERR_WRONG_MODEM);
+}
+
 int16_t SX128x::setPreambleLength(uint32_t preambleLength) {
   uint8_t modem = getPacketType();
   if((modem == RADIOLIB_SX128X_PACKET_TYPE_LORA) || (modem == RADIOLIB_SX128X_PACKET_TYPE_RANGING)) {

--- a/src/modules/SX128x/SX128x.h
+++ b/src/modules/SX128x/SX128x.h
@@ -671,6 +671,21 @@ class SX128x: public PhysicalLayer {
       \returns \ref status_codes
     */
     int16_t checkOutputPower(int8_t pwr, int8_t* clipped) override;
+    
+    /*!
+      \brief Set modem for the radio to use. Will perform full reset and reconfigure the radio
+      using its default parameters.
+      \param modem Modem type to set - FSK, LoRa or LR-FHSS.
+      \returns \ref status_codes
+    */
+    int16_t setModem(ModemType_t modem) override;
+
+    /*!
+      \brief Get modem currently in use by the radio.
+      \param modem Pointer to a variable to save the retrieved configuration into.
+      \returns \ref status_codes
+    */
+    int16_t getModem(ModemType_t* modem) override;
 
     /*!
       \brief Sets preamble length for currently active modem. Allowed values range from 1 to 65535.

--- a/src/protocols/LoRaWAN/LoRaWAN.cpp
+++ b/src/protocols/LoRaWAN/LoRaWAN.cpp
@@ -2768,10 +2768,13 @@ int16_t LoRaWANNode::setPhyProperties(const LoRaWANChannel_t* chnl, uint8_t dir,
     return(state);
   }
 
-  // TODO implement PhysicalLayer::setModem()
   // set modem-dependent functions
   switch(this->band->dataRates[chnl->dr] & RADIOLIB_LORAWAN_DATA_RATE_MODEM) {
     case(RADIOLIB_LORAWAN_DATA_RATE_LORA):
+      if(this->modulation != RADIOLIB_LORAWAN_MODULATION_LORA) {
+        state = this->phyLayer->setModem(ModemType_t::LoRa);
+        RADIOLIB_ASSERT(state);
+      }
       this->modulation = RADIOLIB_LORAWAN_MODULATION_LORA;
       // downlink messages are sent with inverted IQ
       if(dir == RADIOLIB_LORAWAN_DOWNLINK) {
@@ -2781,16 +2784,27 @@ int16_t LoRaWANNode::setPhyProperties(const LoRaWANChannel_t* chnl, uint8_t dir,
       }
       RADIOLIB_ASSERT(state);
       break;
+    
     case(RADIOLIB_LORAWAN_DATA_RATE_FSK):
+      if(this->modulation != RADIOLIB_LORAWAN_MODULATION_GFSK) {
+        state = this->phyLayer->setModem(ModemType_t::FSK);
+        RADIOLIB_ASSERT(state);
+      }
       this->modulation = RADIOLIB_LORAWAN_MODULATION_GFSK;
       state = this->phyLayer->setDataShaping(RADIOLIB_SHAPING_1_0);
       RADIOLIB_ASSERT(state);
       state = this->phyLayer->setEncoding(RADIOLIB_ENCODING_WHITENING);
       RADIOLIB_ASSERT(state);
       break;
+    
     case(RADIOLIB_LORAWAN_DATA_RATE_LR_FHSS):
+      if(this->modulation != RADIOLIB_LORAWAN_DATA_RATE_LR_FHSS) {
+        state = this->phyLayer->setModem(ModemType_t::LRFHSS);
+        RADIOLIB_ASSERT(state);
+      }
       this->modulation = RADIOLIB_LORAWAN_MODULATION_LR_FHSS;
       break;
+    
     default:
       return(RADIOLIB_ERR_UNSUPPORTED);
   }

--- a/src/protocols/LoRaWAN/LoRaWAN.cpp
+++ b/src/protocols/LoRaWAN/LoRaWAN.cpp
@@ -2768,14 +2768,19 @@ int16_t LoRaWANNode::setPhyProperties(const LoRaWANChannel_t* chnl, uint8_t dir,
     return(state);
   }
 
+  // get the currently configured modem from the radio
+  ModemType_t modem;
+  state = this->phyLayer->getModem(&modem);
+  RADIOLIB_ASSERT(state);
+
   // set modem-dependent functions
   switch(this->band->dataRates[chnl->dr] & RADIOLIB_LORAWAN_DATA_RATE_MODEM) {
     case(RADIOLIB_LORAWAN_DATA_RATE_LORA):
-      if(this->modulation != RADIOLIB_LORAWAN_MODULATION_LORA) {
+      if(modem != ModemType_t::LoRa) {
         state = this->phyLayer->setModem(ModemType_t::LoRa);
         RADIOLIB_ASSERT(state);
       }
-      this->modulation = RADIOLIB_LORAWAN_MODULATION_LORA;
+      modem = ModemType_t::LoRa;
       // downlink messages are sent with inverted IQ
       if(dir == RADIOLIB_LORAWAN_DOWNLINK) {
         state = this->phyLayer->invertIQ(true);
@@ -2786,11 +2791,11 @@ int16_t LoRaWANNode::setPhyProperties(const LoRaWANChannel_t* chnl, uint8_t dir,
       break;
     
     case(RADIOLIB_LORAWAN_DATA_RATE_FSK):
-      if(this->modulation != RADIOLIB_LORAWAN_MODULATION_GFSK) {
+      if(modem != ModemType_t::FSK) {
         state = this->phyLayer->setModem(ModemType_t::FSK);
         RADIOLIB_ASSERT(state);
       }
-      this->modulation = RADIOLIB_LORAWAN_MODULATION_GFSK;
+      modem = ModemType_t::FSK;
       state = this->phyLayer->setDataShaping(RADIOLIB_SHAPING_1_0);
       RADIOLIB_ASSERT(state);
       state = this->phyLayer->setEncoding(RADIOLIB_ENCODING_WHITENING);
@@ -2798,11 +2803,11 @@ int16_t LoRaWANNode::setPhyProperties(const LoRaWANChannel_t* chnl, uint8_t dir,
       break;
     
     case(RADIOLIB_LORAWAN_DATA_RATE_LR_FHSS):
-      if(this->modulation != RADIOLIB_LORAWAN_DATA_RATE_LR_FHSS) {
+      if(modem != ModemType_t::LRFHSS) {
         state = this->phyLayer->setModem(ModemType_t::LRFHSS);
         RADIOLIB_ASSERT(state);
       }
-      this->modulation = RADIOLIB_LORAWAN_MODULATION_LR_FHSS;
+      modem = ModemType_t::LRFHSS;
       break;
     
     default:
@@ -2826,40 +2831,37 @@ int16_t LoRaWANNode::setPhyProperties(const LoRaWANChannel_t* chnl, uint8_t dir,
   state = this->phyLayer->setDataRate(dr);
   RADIOLIB_ASSERT(state);
 
-  if(this->modulation == RADIOLIB_LORAWAN_MODULATION_GFSK) {
-    RADIOLIB_DEBUG_PROTOCOL_PRINTLN("FSK:  BR = %4.1f, FD = %4.1f kHz", 
-                                    dr.fsk.bitRate, dr.fsk.freqDev);
-  }
-  if(this->modulation == RADIOLIB_LORAWAN_MODULATION_LORA) {
-    RADIOLIB_DEBUG_PROTOCOL_PRINTLN("LoRa: SF = %d, BW = %5.1f kHz, CR = 4/%d, IQ: %c", 
-                                    dr.lora.spreadingFactor, dr.lora.bandwidth, dr.lora.codingRate, dir ? 'D' : 'U');
-  }
-
   // this only needs to be done once-ish
   uint8_t syncWord[4] = { 0 };
   uint8_t syncWordLen = 0;
   size_t preLen = 0;
-  switch(this->modulation) {
-    case(RADIOLIB_LORAWAN_MODULATION_GFSK): {
+  switch(modem) {
+    case(ModemType_t::FSK): {
       preLen = 8*RADIOLIB_LORAWAN_GFSK_PREAMBLE_LEN;
       syncWord[0] = (uint8_t)(RADIOLIB_LORAWAN_GFSK_SYNC_WORD >> 16);
       syncWord[1] = (uint8_t)(RADIOLIB_LORAWAN_GFSK_SYNC_WORD >> 8);
       syncWord[2] = (uint8_t)RADIOLIB_LORAWAN_GFSK_SYNC_WORD;
       syncWordLen = 3;
+      RADIOLIB_DEBUG_PROTOCOL_PRINTLN("FSK:  BR = %4.1f, FD = %4.1f kHz", 
+                                      dr.fsk.bitRate, dr.fsk.freqDev);
     } break;
 
-    case(RADIOLIB_LORAWAN_MODULATION_LORA): {
+    case(ModemType_t::LoRa): {
       preLen = RADIOLIB_LORAWAN_LORA_PREAMBLE_LEN;
       syncWord[0] = RADIOLIB_LORAWAN_LORA_SYNC_WORD;
       syncWordLen = 1;
+      RADIOLIB_DEBUG_PROTOCOL_PRINTLN("LoRa: SF = %d, BW = %5.1f kHz, CR = 4/%d, IQ: %c", 
+                                    dr.lora.spreadingFactor, dr.lora.bandwidth, dr.lora.codingRate, dir ? 'D' : 'U');
     } break;
 
-    case(RADIOLIB_LORAWAN_MODULATION_LR_FHSS): {
+    case(ModemType_t::LRFHSS): {
       syncWord[0] = (uint8_t)(RADIOLIB_LORAWAN_LR_FHSS_SYNC_WORD >> 24);
       syncWord[1] = (uint8_t)(RADIOLIB_LORAWAN_LR_FHSS_SYNC_WORD >> 16);
       syncWord[2] = (uint8_t)(RADIOLIB_LORAWAN_LR_FHSS_SYNC_WORD >> 8);
       syncWord[3] = (uint8_t)RADIOLIB_LORAWAN_LR_FHSS_SYNC_WORD;
       syncWordLen = 4;
+      RADIOLIB_DEBUG_PROTOCOL_PRINTLN("LR-FHSS: BW = 0x%02x, CR = 0x%02x kHz, grid = %c", 
+                                    dr.lrfhss.bw, dr.lrfhss.cr, dr.lrFhss.narrowGrid ? 'N' : 'W');
     } break;
 
     default:
@@ -2873,7 +2875,7 @@ int16_t LoRaWANNode::setPhyProperties(const LoRaWANChannel_t* chnl, uint8_t dir,
   if(pre) {
     preLen = pre;
   }
-  if(this->modulation != RADIOLIB_LORAWAN_MODULATION_LR_FHSS) {
+  if(modem != ModemType_t::LRFHSS) {
     state = this->phyLayer->setPreambleLength(preLen);
   }
   return(state);

--- a/src/protocols/LoRaWAN/LoRaWAN.h
+++ b/src/protocols/LoRaWAN/LoRaWAN.h
@@ -15,11 +15,6 @@
 #define RADIOLIB_LORAWAN_CLASS_B                                (0x0B)
 #define RADIOLIB_LORAWAN_CLASS_C                                (0x0C)
 
-// modulation type
-#define RADIOLIB_LORAWAN_MODULATION_LORA                        (0)
-#define RADIOLIB_LORAWAN_MODULATION_GFSK                        (1)
-#define RADIOLIB_LORAWAN_MODULATION_LR_FHSS                     (2)
-
 // preamble format
 #define RADIOLIB_LORAWAN_LORA_SYNC_WORD                         (0x34)
 #define RADIOLIB_LORAWAN_LORA_PREAMBLE_LEN                      (8)
@@ -915,9 +910,6 @@ class LoRaWANNode {
     uint32_t confFCntUp = RADIOLIB_LORAWAN_FCNT_NONE;
     uint32_t confFCntDown = RADIOLIB_LORAWAN_FCNT_NONE;
     uint32_t adrFCnt = 0;
-
-    // modulation of the currently configured channel
-    uint8_t modulation = RADIOLIB_LORAWAN_MODULATION_LORA;
 
     // ADR is enabled by default
     bool adrEnabled = true;

--- a/src/protocols/PhysicalLayer/PhysicalLayer.cpp
+++ b/src/protocols/PhysicalLayer/PhysicalLayer.cpp
@@ -536,6 +536,11 @@ int16_t PhysicalLayer::setModem(ModemType_t modem) {
   return(RADIOLIB_ERR_UNSUPPORTED);
 }
 
+int16_t PhysicalLayer::getModem(ModemType_t* modem) {
+  (void)modem;
+  return(RADIOLIB_ERR_UNSUPPORTED);
+}
+
 #if RADIOLIB_INTERRUPT_TIMING
 void PhysicalLayer::setInterruptSetup(void (*func)(uint32_t)) {
   Module* mod = getMod();

--- a/src/protocols/PhysicalLayer/PhysicalLayer.cpp
+++ b/src/protocols/PhysicalLayer/PhysicalLayer.cpp
@@ -531,6 +531,11 @@ void PhysicalLayer::clearChannelScanAction() {
   
 }
 
+int16_t PhysicalLayer::setModem(ModemType_t modem) {
+  (void)modem;
+  return(RADIOLIB_ERR_UNSUPPORTED);
+}
+
 #if RADIOLIB_INTERRUPT_TIMING
 void PhysicalLayer::setInterruptSetup(void (*func)(uint32_t)) {
   Module* mod = getMod();

--- a/src/protocols/PhysicalLayer/PhysicalLayer.h
+++ b/src/protocols/PhysicalLayer/PhysicalLayer.h
@@ -131,6 +131,16 @@ union ChannelScanConfig_t {
 };
 
 /*!
+  \enum ModemType_t
+  \brief Type of modem, used by setModem.
+*/
+enum ModemType_t {
+  FSK = 0,
+  LoRa,
+  LRFHSS,
+};
+
+/*!
   \class PhysicalLayer
 
   \brief Provides common interface for protocols that run on %LoRa/FSK modules, such as RTTY or LoRaWAN.
@@ -643,6 +653,14 @@ class PhysicalLayer {
       \brief Clears interrupt service routine to call when a channel scan is finished.
     */
     virtual void clearChannelScanAction();
+
+    /*!
+      \brief Set modem for the radio to use. Will perform full reset and reconfigure the radio
+      using its default parameters.
+      \param modem Modem type to set. Not all modems are implemented by all radio modules!
+      \returns \ref status_codes
+    */
+    virtual int16_t setModem(ModemType_t modem);
 
     #if RADIOLIB_INTERRUPT_TIMING
 

--- a/src/protocols/PhysicalLayer/PhysicalLayer.h
+++ b/src/protocols/PhysicalLayer/PhysicalLayer.h
@@ -662,6 +662,13 @@ class PhysicalLayer {
     */
     virtual int16_t setModem(ModemType_t modem);
 
+    /*!
+      \brief Get modem currently in use by the radio.
+      \param modem Pointer to a variable to save the retrieved configuration into.
+      \returns \ref status_codes
+    */
+    virtual int16_t getModem(ModemType_t* modem);
+
     #if RADIOLIB_INTERRUPT_TIMING
 
     /*!
@@ -720,6 +727,7 @@ class PhysicalLayer {
     friend class BellClient;
     friend class FT8Client;
     friend class LoRaWANNode;
+    friend class M17Client;
 };
 
 #endif


### PR DESCRIPTION
This PR adds an interface to get and set modem type (LoRa, FSK or LR-FHSS) through PhysicalLayer. Needed for LoRaWAN to support FSK and LR-FHSS uplinks.

EDIT: Also drupped Arduino Uno from the CI build list, since the library is too large to build on a large portion of the examples.