### PR TITLE
[LoRaWAN] Accept `const uint8_t*` on public API

### DIFF
--- a/src/protocols/LoRaWAN/LoRaWAN.cpp
+++ b/src/protocols/LoRaWAN/LoRaWAN.cpp
@@ -18,7 +18,7 @@ LoRaWANNode::LoRaWANNode(PhysicalLayer* phy, const LoRaWANBand_t* band, uint8_t 
 }
 
 #if defined(RADIOLIB_BUILD_ARDUINO)
-int16_t LoRaWANNode::sendReceive(String& strUp, uint8_t fPort, String& strDown, bool isConfirmed, LoRaWANEvent_t* eventUp, LoRaWANEvent_t* eventDown) {
+int16_t LoRaWANNode::sendReceive(const String& strUp, uint8_t fPort, String& strDown, bool isConfirmed, LoRaWANEvent_t* eventUp, LoRaWANEvent_t* eventDown) {
   int16_t state = RADIOLIB_ERR_UNKNOWN;
   
   const char* dataUp = strUp.c_str();
@@ -28,7 +28,7 @@ int16_t LoRaWANNode::sendReceive(String& strUp, uint8_t fPort, String& strDown, 
   size_t lenDown = 0;
   uint8_t dataDown[251];
 
-  state = this->sendReceive((uint8_t*)dataUp, strlen(dataUp), fPort, dataDown, &lenDown, isConfirmed, eventUp, eventDown);
+  state = this->sendReceive((const uint8_t*)dataUp, strlen(dataUp), fPort, dataDown, &lenDown, isConfirmed, eventUp, eventDown);
 
   if(state == RADIOLIB_ERR_NONE) {
     // add null terminator
@@ -55,7 +55,7 @@ int16_t LoRaWANNode::sendReceive(const char* strUp, uint8_t fPort, uint8_t* data
   return(this->sendReceive((uint8_t*)strUp, strlen(strUp), fPort, dataDown, lenDown, isConfirmed, eventUp, eventDown));
 }
 
-int16_t LoRaWANNode::sendReceive(uint8_t* dataUp, size_t lenUp, uint8_t fPort, bool isConfirmed, LoRaWANEvent_t* eventUp, LoRaWANEvent_t* eventDown) {
+int16_t LoRaWANNode::sendReceive(const uint8_t* dataUp, size_t lenUp, uint8_t fPort, bool isConfirmed, LoRaWANEvent_t* eventUp, LoRaWANEvent_t* eventDown) {
   // build a temporary buffer
   // LoRaWAN downlinks can have 250 bytes at most with 1 extra byte for NULL
   size_t lenDown = 0;
@@ -64,7 +64,7 @@ int16_t LoRaWANNode::sendReceive(uint8_t* dataUp, size_t lenUp, uint8_t fPort, b
   return(this->sendReceive(dataUp, lenUp, fPort, dataDown, &lenDown, isConfirmed, eventUp, eventDown));
 }
 
-int16_t LoRaWANNode::sendReceive(uint8_t* dataUp, size_t lenUp, uint8_t fPort, uint8_t* dataDown, size_t* lenDown, bool isConfirmed, LoRaWANEvent_t* eventUp, LoRaWANEvent_t* eventDown) {
+int16_t LoRaWANNode::sendReceive(const uint8_t* dataUp, size_t lenUp, uint8_t fPort, uint8_t* dataDown, size_t* lenDown, bool isConfirmed, LoRaWANEvent_t* eventUp, LoRaWANEvent_t* eventDown) {
   if(!dataUp || !dataDown || !lenDown) {
     return(RADIOLIB_ERR_NULL_POINTER);
   }
@@ -241,7 +241,7 @@ uint8_t* LoRaWANNode::getBufferNonces() {
   return(this->bufferNonces);
 }
 
-int16_t LoRaWANNode::setBufferNonces(uint8_t* persistentBuffer) {
+int16_t LoRaWANNode::setBufferNonces(const uint8_t* persistentBuffer) {
   if(this->isActivated()) {
     RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Did not update buffer: session already active");
     return(RADIOLIB_ERR_NONE);
@@ -464,7 +464,7 @@ uint8_t* LoRaWANNode::getBufferSession() {
   return(this->bufferSession);
 }
 
-int16_t LoRaWANNode::setBufferSession(uint8_t* persistentBuffer) {
+int16_t LoRaWANNode::setBufferSession(const uint8_t* persistentBuffer) {
   if(this->isActivated()) {
     RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Did not update buffer: session already active");
     return(RADIOLIB_ERR_NONE);
@@ -588,7 +588,7 @@ int16_t LoRaWANNode::setBufferSession(uint8_t* persistentBuffer) {
   return(state);
 }
 
-int16_t LoRaWANNode::beginOTAA(uint64_t joinEUI, uint64_t devEUI, uint8_t* nwkKey, uint8_t* appKey) {
+int16_t LoRaWANNode::beginOTAA(uint64_t joinEUI, uint64_t devEUI, const uint8_t* nwkKey, const uint8_t* appKey) {
   if(!appKey) {
     return(RADIOLIB_ERR_NULL_POINTER);
   }
@@ -617,7 +617,7 @@ int16_t LoRaWANNode::beginOTAA(uint64_t joinEUI, uint64_t devEUI, uint8_t* nwkKe
   return(RADIOLIB_ERR_NONE);
 }
 
-int16_t LoRaWANNode::beginABP(uint32_t addr, uint8_t* fNwkSIntKey, uint8_t* sNwkSIntKey, uint8_t* nwkSEncKey, uint8_t* appSKey) {
+int16_t LoRaWANNode::beginABP(uint32_t addr, const uint8_t* fNwkSIntKey, const uint8_t* sNwkSIntKey, const uint8_t* nwkSEncKey, const uint8_t* appSKey) {
   if(!nwkSEncKey || !appSKey) {
     return(RADIOLIB_ERR_NULL_POINTER);
   }
@@ -1159,7 +1159,7 @@ void LoRaWANNode::adrBackoff() {
   return;
 }
 
-void LoRaWANNode::composeUplink(uint8_t* in, uint8_t lenIn, uint8_t* out, uint8_t fPort, bool isConfirmed) {
+void LoRaWANNode::composeUplink(const uint8_t* in, uint8_t lenIn, uint8_t* out, uint8_t fPort, bool isConfirmed) {
   // set the packet fields
   if(isConfirmed) {
     out[RADIOLIB_LORAWAN_FHDR_LEN_START_OFFS] = RADIOLIB_LORAWAN_MHDR_MTYPE_CONF_DATA_UP;
@@ -3416,7 +3416,7 @@ void LoRaWANNode::processAES(const uint8_t* in, size_t len, uint8_t* key, uint8_
   }
 }
 
-int16_t LoRaWANNode::checkBufferCommon(uint8_t *buffer, uint16_t size) {
+int16_t LoRaWANNode::checkBufferCommon(const uint8_t *buffer, uint16_t size) {
   // check if there are actually values in the buffer
   size_t i = 0;
   for(; i < size; i++) {

--- a/src/protocols/LoRaWAN/LoRaWAN.h
+++ b/src/protocols/LoRaWAN/LoRaWAN.h
@@ -548,7 +548,7 @@ class LoRaWANNode {
       \param persistentBuffer Buffer that should match the internal format (previously extracted using getBufferNonces)
       \returns \ref status_codes
     */
-    int16_t setBufferNonces(uint8_t* persistentBuffer);
+    int16_t setBufferNonces(const uint8_t* persistentBuffer);
 
     /*!
       \brief Clear an active session, so that the device will have to rejoin the network.
@@ -566,7 +566,7 @@ class LoRaWANNode {
       \param persistentBuffer Buffer that should match the internal format (previously extracted using getBufferSession)
       \returns \ref status_codes
     */
-    int16_t setBufferSession(uint8_t* persistentBuffer);
+    int16_t setBufferSession(const uint8_t* persistentBuffer);
 
     /*!
       \brief Set the device credentials and activation configuration
@@ -576,7 +576,7 @@ class LoRaWANNode {
       \param appKey Pointer to the application AES-128 key.
       \returns \ref status_codes
     */
-    int16_t beginOTAA(uint64_t joinEUI, uint64_t devEUI, uint8_t* nwkKey, uint8_t* appKey);
+    int16_t beginOTAA(uint64_t joinEUI, uint64_t devEUI, const uint8_t* nwkKey, const uint8_t* appKey);
 
     /*!
       \brief Set the device credentials and activation configuration
@@ -588,7 +588,7 @@ class LoRaWANNode {
       \param appSKey Pointer to the application session AES-128 key.
       \returns \ref status_codes
     */
-    int16_t beginABP(uint32_t addr, uint8_t* fNwkSIntKey, uint8_t* sNwkSIntKey, uint8_t* nwkSEncKey, uint8_t* appSKey);
+    int16_t beginABP(uint32_t addr, const uint8_t* fNwkSIntKey, const uint8_t* sNwkSIntKey, const uint8_t* nwkSEncKey, const uint8_t* appSKey);
 
     /*!
       \brief Join network by restoring OTAA session or performing over-the-air activation. By this procedure,
@@ -622,7 +622,7 @@ class LoRaWANNode {
       (fPort, frame counter, etc.). If set to NULL, no extra information will be passed to the user.
       \returns Window number > 0 if downlink was received, 0 is no downlink was received, otherwise \ref status_codes
     */
-    virtual int16_t sendReceive(String& strUp, uint8_t fPort, String& strDown, bool isConfirmed = false, LoRaWANEvent_t* eventUp = NULL, LoRaWANEvent_t* eventDown = NULL);
+    virtual int16_t sendReceive(const String& strUp, uint8_t fPort, String& strDown, bool isConfirmed = false, LoRaWANEvent_t* eventUp = NULL, LoRaWANEvent_t* eventDown = NULL);
     #endif
 
     /*!
@@ -665,7 +665,7 @@ class LoRaWANNode {
       (fPort, frame counter, etc.). If set to NULL, no extra information will be passed to the user.
       \returns Window number > 0 if downlink was received, 0 is no downlink was received, otherwise \ref status_codes
     */
-    virtual int16_t sendReceive(uint8_t* dataUp, size_t lenUp, uint8_t fPort = 1, bool isConfirmed = false, LoRaWANEvent_t* eventUp = NULL, LoRaWANEvent_t* eventDown = NULL);
+    virtual int16_t sendReceive(const uint8_t* dataUp, size_t lenUp, uint8_t fPort = 1, bool isConfirmed = false, LoRaWANEvent_t* eventUp = NULL, LoRaWANEvent_t* eventDown = NULL);
 
     /*!
       \brief Send a message to the server and wait for a downlink during Rx1 and/or Rx2 window.
@@ -681,7 +681,7 @@ class LoRaWANNode {
       (fPort, frame counter, etc.). If set to NULL, no extra information will be passed to the user.
       \returns Window number > 0 if downlink was received, 0 is no downlink was received, otherwise \ref status_codes
     */
-    virtual int16_t sendReceive(uint8_t* dataUp, size_t lenUp, uint8_t fPort, uint8_t* dataDown, size_t* lenDown, bool isConfirmed = false, LoRaWANEvent_t* eventUp = NULL, LoRaWANEvent_t* eventDown = NULL);
+    virtual int16_t sendReceive(const uint8_t* dataUp, size_t lenUp, uint8_t fPort, uint8_t* dataDown, size_t* lenDown, bool isConfirmed = false, LoRaWANEvent_t* eventUp = NULL, LoRaWANEvent_t* eventDown = NULL);
 
     /*!
       \brief Add a MAC command to the uplink queue.
@@ -1002,7 +1002,7 @@ class LoRaWANNode {
     void adrBackoff();
 
     // create an encrypted uplink buffer, composing metadata, user data and MAC data
-    void composeUplink(uint8_t* in, uint8_t lenIn, uint8_t* out, uint8_t fPort, bool isConfirmed);
+    void composeUplink(const uint8_t* in, uint8_t lenIn, uint8_t* out, uint8_t fPort, bool isConfirmed);
 
     // generate and set the MIC of an uplink buffer (depends on selected channels)
     void micUplink(uint8_t* inOut, uint8_t lenInOut);
@@ -1112,11 +1112,11 @@ class LoRaWANNode {
     static uint16_t checkSum16(const uint8_t *key, uint16_t keyLen);
 
     // check the integrity of a buffer using a 16-bit checksum located in the last two bytes of the buffer
-    static int16_t checkBufferCommon(uint8_t *buffer, uint16_t size);
+    static int16_t checkBufferCommon(const uint8_t *buffer, uint16_t size);
 
     // network-to-host conversion method - takes data from network packet and converts it to the host endians
     template<typename T>
-    static T ntoh(uint8_t* buff, size_t size = 0);
+    static T ntoh(const uint8_t* buff, size_t size = 0);
 
     // host-to-network conversion method - takes data from host variable and and converts it to network packet endians
     template<typename T>
@@ -1124,8 +1124,8 @@ class LoRaWANNode {
 };
 
 template<typename T>
-T LoRaWANNode::ntoh(uint8_t* buff, size_t size) {
-  uint8_t* buffPtr = buff;
+T LoRaWANNode::ntoh(const uint8_t* buff, size_t size) {
+  const uint8_t* buffPtr = buff;
   size_t targetSize = sizeof(T);
   if(size != 0) {
     targetSize = size;

--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -13,7 +13,7 @@ uint32_t rlb_reflect(uint32_t in, uint8_t bits) {
   return(res);
 }
 
-void rlb_hexdump(const char* level, uint8_t* data, size_t len, uint32_t offset, uint8_t width, bool be) {
+void rlb_hexdump(const char* level, const uint8_t* data, size_t len, uint32_t offset, uint8_t width, bool be) {
   #if RADIOLIB_DEBUG
   size_t rem_len = len;
   for(size_t i = 0; i < len; i+=16) {

--- a/src/utils/Utils.h
+++ b/src/utils/Utils.h
@@ -33,7 +33,7 @@ uint32_t rlb_reflect(uint32_t in, uint8_t bits);
   \param width Word width (1 for uint8_t, 2 for uint16_t, 4 for uint32_t).
   \param be Print multi-byte data as big endian. Defaults to false.
 */
-void rlb_hexdump(const char* level, uint8_t* data, size_t len, uint32_t offset = 0, uint8_t width = 1, bool be = false);
+void rlb_hexdump(const char* level, const uint8_t* data, size_t len, uint32_t offset = 0, uint8_t width = 1, bool be = false);
 
 #if RADIOLIB_DEBUG && defined(RADIOLIB_BUILD_ARDUINO)
 size_t rlb_printf(const char* format, ...);


### PR DESCRIPTION
The goal of this PR is allowing the caller to pass `const uint8_t*` parameters to the public methods of `LoRaWANNode`.

Some `LoRaWANNode` methods, such as `beginOTAA`, take buffers as parameters (in this case, the AppKey and NwkKey) with type `uint8_t*`. However, in many cases, the buffers are not modified and could be specified as `const`. Not using `const` makes the caller unable to pass a `const uint8_t APP_KEY[16]`, for example, resulting in a compilation error such as:
```
error: invalid conversion from 'const uint8_t*' {aka 'const unsigned char*'} to 'uint8_t*' {aka 'unsigned char*'}
```

In this PR, I focused just on public methods, but there may be other opportunities to use pointers to `const` elsewhere in the file. Unfortunately, the change leaked into Utils.cpp, as `RADIOLIB_DEBUG_PROTOCOL_HEXDUMP` calls `rlb_hexdump`, which also takes a non-const parameter despite not modifying it. It should not change behavior, but if you'd rather avoid changing it, I can undo the `const` change in `setBufferNonces`.