### PR TITLE
hal: Tock: Re-enable pin after detaching interrupt

### DIFF
--- a/src/hal/Tock/libtockHal.h
+++ b/src/hal/Tock/libtockHal.h
@@ -154,6 +154,7 @@ class TockHal : public RadioLibHal {
 
       gpio_funcs[interruptNum - 1] = NULL;
       libtock_lora_phy_gpio_disable_interrupt(interruptNum);
+      libtock_lora_phy_gpio_enable_input(interruptNum, libtock_pull_down);
     }
 
     void delay(unsigned long ms) override {


### PR DESCRIPTION
The Tock libtock_lora_phy_gpio_disable_interrupt() syscall will disable interrupts for the pin, but also put the pin into a disabled low power state. This isn't what RadioLib expects and casues subsequent LoRaWAN transfers to fail [1].

So after we disable interrupts and send the pin to low power let's re-enable inputs as RadioLib expects.

1: https://github.com/jgromes/RadioLib/discussions/1303