### PR TITLE
make RadioLib build compatible with Arduino Core for CH32

### DIFF
--- a/src/hal/Arduino/ArduinoHal.cpp
+++ b/src/hal/Arduino/ArduinoHal.cpp
@@ -43,7 +43,14 @@ void inline ArduinoHal::attachInterrupt(uint32_t interruptNum, void (*interruptC
   if(interruptNum == RADIOLIB_NC) {
     return;
   }
+#if defined(ARDUINO_ARCH_CH32)
+  ::attachInterrupt(interruptNum, GPIO_Mode_IN_FLOATING, interruptCb, EXTI_Mode_Interrupt,
+                    mode == RISING  ? EXTI_Trigger_Rising  :
+                    mode == FALLING ? EXTI_Trigger_Falling :
+                    EXTI_Trigger_Rising_Falling /* CHANGE */ );
+#else
   ::attachInterrupt(interruptNum, interruptCb,  RADIOLIB_ARDUINOHAL_INTERRUPT_MODE_CAST mode);
+#endif /* ARDUINO_ARCH_CH32 */
 }
 
 void inline ArduinoHal::detachInterrupt(uint32_t interruptNum) {


### PR DESCRIPTION
Arduino Core for CH32 EVT Boards ( https://github.com/openwch/arduino_core_ch32 ) is very similar to other Arduino Cores except that it uses a different `attachInterrupt()` semantic:
https://github.com/openwch/arduino_core_ch32/blob/main/cores/arduino/WInterrupts.h#L27

Author of the CH32 Core has some objections against use of a standard `attachInterrupt()`
see this ticket for details: https://github.com/openwch/arduino_core_ch32/issues/15

This PR is intended to apply a workaround to the RadioLib _(if possible)_ to allow a build of the library together with Arduino CH32 Core.

I've tested the patch with a sketch for [**CH32V307**](https://www.wch-ic.com/products/CH32V307.html) that now builds successfully with RadioLib 7.1.0 and 'master' branch of Arduino Core for CH32.

![](https://raw.githubusercontent.com/yym36100/RISC-V_CH32V307VCT6/refs/heads/main/Capture.JPG)