### PR TITLE
fix build with Arduino Core for Silicon Labs EFR32 Series 2

### DIFF
--- a/src/BuildOpt.h
+++ b/src/BuildOpt.h
@@ -363,6 +363,13 @@
   #define RADIOLIB_ARDUINOHAL_PIN_STATUS_CAST         (PinStatus)
   #define RADIOLIB_ARDUINOHAL_INTERRUPT_MODE_CAST     (PinStatus)
 
+#elif defined(ARDUINO_ARCH_SILABS)
+  // Silicon Labs Arduino
+  #define RADIOLIB_PLATFORM                           "Arduino Silicon Labs"
+  #define RADIOLIB_ARDUINOHAL_PIN_MODE_CAST           (PinMode)
+  #define RADIOLIB_ARDUINOHAL_PIN_STATUS_CAST         (PinStatus)
+  #define RADIOLIB_ARDUINOHAL_INTERRUPT_MODE_CAST     (PinStatus)
+
 #else
   // other Arduino platforms not covered by the above list - this may or may not work
   #define RADIOLIB_PLATFORM                           "Unknown Arduino"


### PR DESCRIPTION
### The Core location

https://github.com/SiliconLabs/arduino

## Log of the issue this PR is intended to fix

```
/home/codespace/Arduino/libraries/RadioLib/src/hal/Arduino/ArduinoHal.cpp: In member function 'virtual void ArduinoHal::pinMode(uint32_t, uint32_t)':
/home/codespace/Arduino/libraries/RadioLib/src/hal/Arduino/ArduinoHal.cpp:25:52: error: invalid conversion from 'uint32_t' {aka 'long unsigned int'} to 'PinMode' [-fpermissive]
   25 |   ::pinMode(pin, RADIOLIB_ARDUINOHAL_PIN_MODE_CAST mode);
      |                                                    ^~~~
      |                                                    |
      |                                                    uint32_t {aka long unsigned int}
In file included from /home/codespace/.arduino15/packages/SiliconLabs/hardware/silabs/2.2.0/cores/silabs/api/Interrupts.h:8,
                 from /home/codespace/.arduino15/packages/SiliconLabs/hardware/silabs/2.2.0/cores/silabs/api/ArduinoAPI.h:29,
                 from /home/codespace/.arduino15/packages/SiliconLabs/hardware/silabs/2.2.0/cores/silabs/Arduino.h:30,
                 from /home/codespace/Arduino/libraries/RadioLib/src/hal/Arduino/../../BuildOpt.h:119,
                 from /home/codespace/Arduino/libraries/RadioLib/src/hal/Arduino/../../TypeDef.h:6,
                 from /home/codespace/Arduino/libraries/RadioLib/src/hal/Arduino/ArduinoHal.h:2,
                 from /home/codespace/Arduino/libraries/RadioLib/src/hal/Arduino/ArduinoHal.cpp:1:
/home/codespace/.arduino15/packages/SiliconLabs/hardware/silabs/2.2.0/cores/silabs/api/Common.h:96:44: note:   initializing argument 2 of 'void pinMode(pin_size_t, PinMode)'
   96 | void pinMode(pin_size_t pinNumber, PinMode pinMode);
      |                                    ~~~~~~~~^~~~~~~
/home/codespace/Arduino/libraries/RadioLib/src/hal/Arduino/ArduinoHal.cpp: In member function 'virtual void ArduinoHal::digitalWrite(uint32_t, uint32_t)':
/home/codespace/Arduino/libraries/RadioLib/src/hal/Arduino/ArduinoHal.cpp:32:59: error: invalid conversion from 'uint32_t' {aka 'long unsigned int'} to 'PinStatus' [-fpermissive]
   32 |   ::digitalWrite(pin, RADIOLIB_ARDUINOHAL_PIN_STATUS_CAST value);
      |                                                           ^~~~~
      |                                                           |
      |                                                           uint32_t {aka long unsigned int}
/home/codespace/.arduino15/packages/SiliconLabs/hardware/silabs/2.2.0/cores/silabs/api/Common.h:97:51: note:   initializing argument 2 of 'void digitalWrite(pin_size_t, PinStatus)'
   97 | void digitalWrite(pin_size_t pinNumber, PinStatus status);
      |                                         ~~~~~~~~~~^~~~~~
/home/codespace/Arduino/libraries/RadioLib/src/hal/Arduino/ArduinoHal.cpp: In member function 'virtual void ArduinoHal::attachInterrupt(uint32_t, void (*)(), uint32_t)':
/home/codespace/Arduino/libraries/RadioLib/src/hal/Arduino/ArduinoHal.cpp:52:89: error: invalid conversion from 'uint32_t' {aka 'long unsigned int'} to 'PinStatus' [-fpermissive]
   52 |   ::attachInterrupt(interruptNum, interruptCb,  RADIOLIB_ARDUINOHAL_INTERRUPT_MODE_CAST mode);
      |                                                                                         ^~~~
      |                                                                                         |
      |                                                                                         uint32_t {aka long unsigned int}
/home/codespace/.arduino15/packages/SiliconLabs/hardware/silabs/2.2.0/cores/silabs/api/Common.h:113:82: note:   initializing argument 3 of 'void attachInterrupt(pin_size_t, voidFuncPtr, PinStatus)'
  113 | void attachInterrupt(pin_size_t interruptNumber, voidFuncPtr callback, PinStatus mode);
      |                                                                        ~~~~~~~~~~^~~~
```
