### PR TITLE
[CI] Add size metrics

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -197,7 +197,7 @@ jobs:
       - name: Upload size report as artifact
         uses: actions/upload-artifact@v3
         with:
-          name: size-file-${{ steps.short-hash.outputs.short_sha }}-${{ steps.split.outputs._0 }}-${{ steps.split.outputs._1 }}-${{ steps.split.outputs._2 }}
+          name: size-file-${{ steps.split.outputs._0 }}-${{ steps.split.outputs._1 }}-${{ steps.split.outputs._2 }}
           path: extras/test/ci/size_${{ steps.short-hash.outputs.short_sha }}_${{ steps.split.outputs._0 }}-${{ steps.split.outputs._1 }}-${{ steps.split.outputs._2 }}.csv
 
   metrics:
@@ -224,8 +224,8 @@ jobs:
           ls -R aggregated-sizes
           mkdir -p radiolib-ci/l0
           cd radiolib-ci/l0
-          cp aggregated-sizes/size_*.csv radiolib-ci/l0/.
-          rm -r aggregated-sizes/size_*.csv
+          cp aggregated-sizes/*/size_*.csv radiolib-ci/l0/.
+          rm -r aggregated-sizes
           git add .
           git commit -m "Push artifacts from $GITHUB_REPOSITORY ${{ steps.short-hash.outputs.short_sha }}"
           git push origin main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -197,7 +197,7 @@ jobs:
       - name: Upload size report as artifact
         uses: actions/upload-artifact@v3
         with:
-          name: size-file-${{ steps.short-hash.outputs.short_sha }}-${{ matrix.id }}
+          name: size-file-${{ steps.short-hash.outputs.short_sha }}-${{ steps.split.outputs._0 }}-${{ steps.split.outputs._1 }}-${{ steps.split.outputs._2 }}
           path: extras/test/ci/size_${{ steps.short-hash.outputs.short_sha }}_${{ matrix.id }}.csv
 
   metrics:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -207,6 +207,7 @@ jobs:
       - name: Clone artifact repo
         run:
           |
+          echo "GIT_SHORT_HASH=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
           cd $PWD/..
           git clone https://${{ github.actor }}:${{ secrets.ACTIONS_METRICS_PUSH_TOKEN }}@github.com/radiolib-org/artifacts.git
           cd artifacts
@@ -224,7 +225,6 @@ jobs:
           ls -R aggregated-sizes
           mkdir -p $PWD/../artifacts/radiolib-ci/l0
           cp aggregated-sizes/*/size_*.csv $PWD/../artifacts/radiolib-ci/l0/.
-          echo "GIT_SHORT_HASH=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
           cd $PWD/../artifacts/radiolib-ci
           git add .
           git commit -m "Push artifacts https://github.com/jgromes/RadioLib/commit/$GIT_SHORT_HASH"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -190,11 +190,15 @@ jobs:
           cd $PWD/extras/test/ci
           ./parse_size.sh ${{ matrix.id }}
       
+      - name: Extract short commit hash
+        id: short-hash
+        run: echo "::set-output name=short_sha::${GITHUB_SHA:0:8}"
+      
       - name: Upload size report as artifact
         uses: actions/upload-artifact@v3
         with:
-          name: size-file-${{ matrix.id }}
-          path: extras/test/ci/size_${{ matrix.id }}.csv
+          name: size-file-${{ steps.short-hash.outputs.short_sha }}-${{ matrix.id }}
+          path: extras/test/ci/size_${{ steps.short-hash.outputs.short_sha }}_${{ matrix.id }}.csv
 
   metrics:
     runs-on: ubuntu-latest
@@ -223,7 +227,7 @@ jobs:
           cp aggregated-sizes/size_*.csv radiolib-ci/l0/.
           rm -r aggregated-sizes/size_*.csv
           git add .
-          git commit -m "Push artifacts from $GITHUB_REPOSITORY"
+          git commit -m "Push artifacts from $GITHUB_REPOSITORY ${{ steps.short-hash.outputs.short_sha }}"
           git push origin main
 
   esp-build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -227,7 +227,7 @@ jobs:
           cd $PWD/../artifacts/radiolib-ci
           git add .
           COMMIT_URL="https://github.com/jgromes/RadioLib/commit/$GITHUB_SHA"
-          git commit -m "Push artifacts from [${GITHUB_SHA:0:8}]($COMMIT_URL)"
+          git commit -m "Push artifacts from $COMMIT_URL"
           git push origin main
 
   esp-build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -187,6 +187,7 @@ jobs:
         if: ${{ env.run-build == 'true' }}
         run:
           |
+          cd $PWD/extras/test/ci
           ./parse_size.sh ${{ matrix.id }}
 
   metrics:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -224,9 +224,10 @@ jobs:
           ls -R aggregated-sizes
           mkdir -p $PWD/../artifacts/radiolib-ci/l0
           cp aggregated-sizes/*/size_*.csv $PWD/../artifacts/radiolib-ci/l0/.
+          echo "GIT_SHORT_HASH=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
           cd $PWD/../artifacts/radiolib-ci
           git add .
-          git commit -m "Push artifacts from $GITHUB_REPOSITORY $(git rev-parse --short HEAD)"
+          git commit -m "Push artifacts https://github.com/jgromes/RadioLib/commit/$GIT_SHORT_HASH"
           git push origin main
 
   esp-build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -226,7 +226,7 @@ jobs:
           cp aggregated-sizes/*/size_*.csv $PWD/../artifacts/radiolib-ci/l0/.
           cd $PWD/../artifacts/radiolib-ci
           git add .
-          git commit -m "Push artifacts from $GITHUB_REPOSITORY ${{ steps.short-hash.outputs.short_sha }}"
+          git commit -m "Push artifacts from $GITHUB_REPOSITORY $(git rev-parse --short HEAD)"
           git push origin main
 
   esp-build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -198,7 +198,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: size-file-${{ steps.short-hash.outputs.short_sha }}-${{ steps.split.outputs._0 }}-${{ steps.split.outputs._1 }}-${{ steps.split.outputs._2 }}
-          path: extras/test/ci/size_${{ steps.short-hash.outputs.short_sha }}_${{ matrix.id }}.csv
+          path: extras/test/ci/size_${{ steps.short-hash.outputs.short_sha }}_${{ steps.split.outputs._0 }}-${{ steps.split.outputs._1 }}-${{ steps.split.outputs._2 }}.csv
 
   metrics:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -180,28 +180,38 @@ jobs:
         if: ${{ env.run-build == 'true' }}
         run:
           |
-          for example in $(find $PWD/examples -name '*.ino' | sort); do
-            # check whether to skip this sketch
-            if [ ! -z '${{ steps.prep.outputs.skip-pattern }}' ] && [[ ${example} =~ ${{ steps.prep.outputs.skip-pattern }} ]]; then
-              # skip sketch
-              echo -e "\n\033[1;33mSkipped ${example##*/} (matched with ${{ steps.prep.outputs.skip-pattern }})\033[0m";
-            else
-              # apply special flags for LoRaWAN
-              if [[ ${example} =~ "LoRaWAN" ]]; then
-                flags="-DRADIOLIB_LORAWAN_DEV_ADDR=0 -DRADIOLIB_LORAWAN_FNWKSINT_KEY=0 -DRADIOLIB_LORAWAN_SNWKSINT_KEY=0 -DRADIOLIB_LORAWAN_NWKSENC_KEY=0 -DRADIOLIB_LORAWAN_APPS_KEY=0 -DRADIOLIB_LORAWAN_APP_KEY=0 -DRADIOLIB_LORAWAN_NWK_KEY=0 -DRADIOLIB_LORAWAN_DEV_EUI=0 -DARDUINO_TTGO_LORA32_V1"
-              fi
+          cd $PWD/extras/test/ci
+          ./build_examples.sh ${{ matrix.id }} "${{ steps.prep.outputs.skip-pattern }}" ${{ steps.prep.outputs.options }}
+      
+      - name: Parse sizes
+        if: ${{ env.run-build == 'true' }}
+        run:
+          |
+          ./parse_size.sh ${{ matrix.id }}
 
-              # build sketch
-              echo -e "\n\033[1;33mBuilding ${example##*/} ... \033[0m";
-              arduino-cli compile --libraries /home/runner/work/RadioLib --fqbn ${{ matrix.id }}${{ steps.prep.outputs.options }} --build-property compiler.cpp.extra_flags="$flags" $example --warnings=${{ steps.prep.outputs.warnings }}
-              if [ $? -ne 0 ]; then
-                echo -e "\033[1;31m${example##*/} build FAILED\033[0m\n";
-                exit 1;
-              else
-                echo -e "\033[1;32m${example##*/} build PASSED\033[0m\n";
-              fi
-            fi
-          done
+  metrics:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Clone artifact repo
+        run:
+          |
+          cd $PWD/..
+          git clone https://${{ github.actor }}:${{ secrets.TARGET_REPO_TOKEN }}@github.com/radiolib-org/artifacts.git
+          cd artifacts
+          git config --global user.name "${{ github.actor }}"
+          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+      
+      - name: Append sizes
+        run:
+          |
+          mkdir -p radiolib-ci/l0
+          cd radiolib-ci/l0
+          cp /tmp/size_*.csv radiolib-ci/l0/.
+          rm -r /tmp/size_*.csv
+          git add .
+          git commit -m "Push artifacts from $GITHUB_REPOSITORY"
+          git push origin main
 
   esp-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -207,7 +207,6 @@ jobs:
       - name: Clone artifact repo
         run:
           |
-          echo "GIT_SHORT_HASH=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
           cd $PWD/..
           git clone https://${{ github.actor }}:${{ secrets.ACTIONS_METRICS_PUSH_TOKEN }}@github.com/radiolib-org/artifacts.git
           cd artifacts
@@ -227,7 +226,8 @@ jobs:
           cp aggregated-sizes/*/size_*.csv $PWD/../artifacts/radiolib-ci/l0/.
           cd $PWD/../artifacts/radiolib-ci
           git add .
-          git commit -m "Push artifacts https://github.com/jgromes/RadioLib/commit/$GIT_SHORT_HASH"
+          COMMIT_URL="https://github.com/jgromes/RadioLib/commit/$GITHUB_SHA"
+          git commit -m "Push artifacts from [${GITHUB_SHA:0:8}]($COMMIT_URL)"
           git push origin main
 
   esp-build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -197,12 +197,12 @@ jobs:
         run:
           |
           cd $PWD/..
-          git clone https://${{ github.actor }}:${{ secrets.TARGET_REPO_TOKEN }}@github.com/radiolib-org/artifacts.git
+          git clone https://${{ github.actor }}:${{ secrets.ACTIONS_METRICS_PUSH_TOKEN }}@github.com/radiolib-org/artifacts.git
           cd artifacts
           git config --global user.name "${{ github.actor }}"
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"
       
-      - name: Append sizes
+      - name: Push size files
         run:
           |
           mkdir -p radiolib-ci/l0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -192,7 +192,7 @@ jobs:
       
       - name: Extract short commit hash
         id: short-hash
-        run: echo "::set-output name=short_sha::${GITHUB_SHA:0:8}"
+        run: echo "::set-output name=short_sha::$(git rev-parse --short HEAD)"
       
       - name: Upload size report as artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -223,7 +223,7 @@ jobs:
           |
           ls -R aggregated-sizes
           mkdir -p $PWD/../radiolib-ci/l0
-          cp aggregated-sizes/*/size_*.csv radiolib-ci/l0/.
+          cp aggregated-sizes/*/size_*.csv $PWD/../radiolib-ci/l0/.
           cd $PWD/../radiolib-ci
           git add .
           git commit -m "Push artifacts from $GITHUB_REPOSITORY ${{ steps.short-hash.outputs.short_sha }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -222,9 +222,9 @@ jobs:
         run:
           |
           ls -R aggregated-sizes
-          mkdir -p $PWD/../radiolib-ci/l0
-          cp aggregated-sizes/*/size_*.csv $PWD/../radiolib-ci/l0/.
-          cd $PWD/../radiolib-ci
+          mkdir -p $PWD/../artifacts/radiolib-ci/l0
+          cp aggregated-sizes/*/size_*.csv $PWD/../artifacts/radiolib-ci/l0/.
+          cd $PWD/../artifacts/radiolib-ci
           git add .
           git commit -m "Push artifacts from $GITHUB_REPOSITORY ${{ steps.short-hash.outputs.short_sha }}"
           git push origin main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -223,9 +223,7 @@ jobs:
           |
           ls -R aggregated-sizes
           mkdir -p radiolib-ci/l0
-          cd radiolib-ci/l0
           cp aggregated-sizes/*/size_*.csv radiolib-ci/l0/.
-          rm -r aggregated-sizes
           git add .
           git commit -m "Push artifacts from $GITHUB_REPOSITORY ${{ steps.short-hash.outputs.short_sha }}"
           git push origin main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -222,9 +222,9 @@ jobs:
         run:
           |
           ls -R aggregated-sizes
-          mkdir -p radiolib-ci/l0
+          mkdir -p $PWD/../radiolib-ci/l0
           cp aggregated-sizes/*/size_*.csv radiolib-ci/l0/.
-          cd radiolib-ci
+          cd $PWD/../radiolib-ci
           git add .
           git commit -m "Push artifacts from $GITHUB_REPOSITORY ${{ steps.short-hash.outputs.short_sha }}"
           git push origin main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -189,6 +189,12 @@ jobs:
           |
           cd $PWD/extras/test/ci
           ./parse_size.sh ${{ matrix.id }}
+      
+      - name: Upload size report as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: size-file-${{ matrix.id }}
+          path: size_${{ matrix.id }}.csv
 
   metrics:
     runs-on: ubuntu-latest
@@ -203,13 +209,19 @@ jobs:
           git config --global user.name "${{ github.actor }}"
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"
       
+      - name: Download size artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: aggregated-sizes
+      
       - name: Push size files
         run:
           |
+          ls -R aggregated-sizes
           mkdir -p radiolib-ci/l0
           cd radiolib-ci/l0
-          cp /tmp/size_*.csv radiolib-ci/l0/.
-          rm -r /tmp/size_*.csv
+          cp aggregated-sizes/size_*.csv radiolib-ci/l0/.
+          rm -r aggregated-sizes/size_*.csv
           git add .
           git commit -m "Push artifacts from $GITHUB_REPOSITORY"
           git push origin main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -194,7 +194,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: size-file-${{ matrix.id }}
-          path: size_${{ matrix.id }}.csv
+          path: extras/test/ci/size_${{ matrix.id }}.csv
 
   metrics:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -224,6 +224,7 @@ jobs:
           ls -R aggregated-sizes
           mkdir -p radiolib-ci/l0
           cp aggregated-sizes/*/size_*.csv radiolib-ci/l0/.
+          cd radiolib-ci
           git add .
           git commit -m "Push artifacts from $GITHUB_REPOSITORY ${{ steps.short-hash.outputs.short_sha }}"
           git push origin main

--- a/extras/test/ci/build_arduino.sh
+++ b/extras/test/ci/build_arduino.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+board=$1
+sketch=$2
+flags=$3
+warnings="all"
+
+arduino-cli compile \
+  --libraries ../../../../ \
+  --fqbn $board \
+  --build-property compiler.cpp.extra_flags="$flags" \
+  --warnings=$warnings \
+  $sketch --export-binaries

--- a/extras/test/ci/build_examples.sh
+++ b/extras/test/ci/build_examples.sh
@@ -8,7 +8,7 @@ skip="$2"
 options="$3"
 
 # file for saving the compiled binary size reports
-size_file="/tmp/size_$board.txt"
+size_file="size_$board.txt"
 rm -f $size_file
 
 path="../../../examples"

--- a/extras/test/ci/build_examples.sh
+++ b/extras/test/ci/build_examples.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+#board=arduino:avr:mega
+board="$1"
+#skip="(STM32WL|LR11x0_Firmware_Update|NonArduino)"
+skip="$2"
+#options=""
+options="$3"
+
+# file for saving the compiled binary size reports
+size_file="/tmp/size_$board.txt"
+rm -f $size_file
+
+path="../../../examples"
+for example in $(find $path -name '*.ino' | sort); do
+  # check whether to skip this sketch
+  if [ ! -z '$skip' ] && [[ ${example} =~ ${skip} ]]; then
+    # skip sketch
+    echo -e "\n\033[1;33mSkipped ${example##*/} (matched with $skip)\033[0m";
+  else
+    # apply special flags for LoRaWAN
+    if [[ ${example} =~ "LoRaWAN" ]]; then
+      flags="-DRADIOLIB_LORAWAN_DEV_ADDR=0 -DRADIOLIB_LORAWAN_FNWKSINT_KEY=0 -DRADIOLIB_LORAWAN_SNWKSINT_KEY=0 -DRADIOLIB_LORAWAN_NWKSENC_KEY=0 -DRADIOLIB_LORAWAN_APPS_KEY=0 -DRADIOLIB_LORAWAN_APP_KEY=0 -DRADIOLIB_LORAWAN_NWK_KEY=0 -DRADIOLIB_LORAWAN_DEV_EUI=0 -DARDUINO_TTGO_LORA32_V1"
+    fi
+
+    # build sketch
+    echo -e "\n\033[1;33mBuilding ${example##*/} ... \033[0m";
+    board_opts=$board$options
+    ./build_arduino.sh $board_opts $example "$flags"
+    if [ $? -ne 0 ]; then
+      echo -e "\033[1;31m${example##*/} build FAILED\033[0m\n";
+      exit 1;
+    else
+      echo -e "\033[1;32m${example##*/} build PASSED\033[0m\n";
+      dir="$(dirname -- "$example")"
+      file="$(basename -- "$example")"
+      size="$(size $dir/build/*/$file.elf)"
+      echo $size >> $size_file
+    fi
+  fi
+done

--- a/extras/test/ci/parse_size.sh
+++ b/extras/test/ci/parse_size.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+board=$1
+hash=$(git rev-parse --short HEAD)
+
+in_file="/tmp/size_$board.txt"
+out_file="/tmp/size_${hash}_$board.csv"
+rm -f $out_file
+
+# write the header
+echo "text,data,bss,dec,hex,filename" > "$out_file"
+
+# convert to CSV
+awk 'NR > 1 {print $7 "," $8 "," $9 "," $10 "," $11 "," $12}' "$in_file" >> "$out_file"
+
+# remove input file
+rm -f $in_file
+

--- a/extras/test/ci/parse_size.sh
+++ b/extras/test/ci/parse_size.sh
@@ -16,7 +16,7 @@ awk 'NR > 1 {
   filename_with_ext = path_parts[length(path_parts)];
   split(filename_with_ext, filename_parts, ".");
   filename = filename_parts[1];
-  print $17 "," $8 "," $9 "," $10 "," $11 "," filename
+  print $7 "," $8 "," $9 "," $10 "," $11 "," filename
 }' "$in_file" >> "$out_file"
 
 # remove input file

--- a/extras/test/ci/parse_size.sh
+++ b/extras/test/ci/parse_size.sh
@@ -3,8 +3,8 @@
 board=$1
 hash=$(git rev-parse --short HEAD)
 
-in_file="/tmp/size_$board.txt"
-out_file="/tmp/size_${hash}_$board.csv"
+in_file="size_$board.txt"
+out_file="size_${hash}_$board.csv"
 rm -f $out_file
 
 # write the header

--- a/extras/test/ci/parse_size.sh
+++ b/extras/test/ci/parse_size.sh
@@ -4,7 +4,7 @@ board=$1
 hash=$(git rev-parse --short HEAD)
 
 in_file="size_$board.txt"
-out_file="size_${hash}_$board.csv"
+out_file="size_${hash}_${board//:/-}.csv"
 rm -f $out_file
 
 # write the header

--- a/extras/test/ci/parse_size.sh
+++ b/extras/test/ci/parse_size.sh
@@ -11,7 +11,13 @@ rm -f $out_file
 echo "text,data,bss,dec,hex,filename" > "$out_file"
 
 # convert to CSV
-awk 'NR > 1 {print $7 "," $8 "," $9 "," $10 "," $11 "," $12}' "$in_file" >> "$out_file"
+awk 'NR > 1 {
+  split($12, path_parts, "/");
+  filename_with_ext = path_parts[length(path_parts)];
+  split(filename_with_ext, filename_parts, ".");
+  filename = filename_parts[1];
+  print $17 "," $8 "," $9 "," $10 "," $11 "," filename
+}' "$in_file" >> "$out_file"
 
 # remove input file
 rm -f $in_file


### PR DESCRIPTION
Since the codebase is constantly growing, it's going to be interesting to observe this with some metrics. This PR adds tracking of the memory section sizes of binary .elf files of Arduino examples.

Since artifacts are only retained for 90 days in GitHub Actions, the resulting size reports are uploaded to a separate respository (https://github.com/radiolib-org/artifacts) for further processing.