### PR TITLE
Fix frequency issue on SX127x (#1368)

### DIFF
--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -56,7 +56,7 @@ int16_t Module::SPIgetRegValue(uint32_t reg, uint8_t msb, uint8_t lsb) {
   return(maskedValue);
 }
 
-int16_t Module::SPIsetRegValue(uint32_t reg, uint8_t value, uint8_t msb, uint8_t lsb, uint8_t checkInterval, uint8_t checkMask) {
+int16_t Module::SPIsetRegValue(uint32_t reg, uint8_t value, uint8_t msb, uint8_t lsb, uint8_t checkInterval, uint8_t checkMask, bool force) {
   if((msb > 7) || (lsb > 7) || (lsb > msb)) {
     return(RADIOLIB_ERR_INVALID_BIT_RANGE);
   }
@@ -66,7 +66,7 @@ int16_t Module::SPIsetRegValue(uint32_t reg, uint8_t value, uint8_t msb, uint8_t
   uint8_t mask = ~((0b11111111 << (msb + 1)) | (0b11111111 >> (8 - lsb)));
 
   // check if we actually need to update the register
-  if((currentValue & mask) == (value & mask)) {
+  if((currentValue & mask) == (value & mask) && !force) {
     return(RADIOLIB_ERR_NONE);
   }
 

--- a/src/Module.h
+++ b/src/Module.h
@@ -272,9 +272,10 @@ class Module {
       \param lsb Least significant bit of the register variable. Bits below this one will not be affected by the write operation.
       \param checkInterval Number of milliseconds between register writing and verification reading. Some registers need up to 10ms to process the change.
       \param checkMask Mask of bits to check, only bits set to 1 will be verified.
+      \param force Write new value even if the old value is the same.
       \returns \ref status_codes
     */
-    int16_t SPIsetRegValue(uint32_t reg, uint8_t value, uint8_t msb = 7, uint8_t lsb = 0, uint8_t checkInterval = 2, uint8_t checkMask = 0xFF);
+    int16_t SPIsetRegValue(uint32_t reg, uint8_t value, uint8_t msb = 7, uint8_t lsb = 0, uint8_t checkInterval = 2, uint8_t checkMask = 0xFF, bool force = false);
 
     /*!
       \brief SPI burst read method.

--- a/src/modules/SX127x/SX127x.cpp
+++ b/src/modules/SX127x/SX127x.cpp
@@ -1204,7 +1204,13 @@ int16_t SX127x::setFrequencyRaw(float newFreq) {
   // write registers
   state |= this->mod->SPIsetRegValue(RADIOLIB_SX127X_REG_FRF_MSB, (FRF & 0xFF0000) >> 16);
   state |= this->mod->SPIsetRegValue(RADIOLIB_SX127X_REG_FRF_MID, (FRF & 0x00FF00) >> 8);
-  state |= this->mod->SPIsetRegValue(RADIOLIB_SX127X_REG_FRF_LSB, FRF & 0x0000FF);
+
+  // lsb needs to be written no matter what in order for the module to update the frequency
+  if(this->mod->SPIgetRegValue(RADIOLIB_SX127X_REG_FRF_LSB) == (FRF & 0x0000FF)) {
+    this->mod->SPIwriteRegister(RADIOLIB_SX127X_REG_FRF_LSB, FRF & 0x0000FF);
+  } else {
+    state |= this->mod->SPIsetRegValue(RADIOLIB_SX127X_REG_FRF_LSB, FRF & 0x0000FF);
+  }
   return(state);
 }
 

--- a/src/modules/SX127x/SX127x.cpp
+++ b/src/modules/SX127x/SX127x.cpp
@@ -1202,15 +1202,10 @@ int16_t SX127x::setFrequencyRaw(float newFreq) {
   uint32_t FRF = (newFreq * (uint32_t(1) << RADIOLIB_SX127X_DIV_EXPONENT)) / RADIOLIB_SX127X_CRYSTAL_FREQ;
 
   // write registers
+  // lsb needs to be written no matter what in order for the module to update the frequency
   state |= this->mod->SPIsetRegValue(RADIOLIB_SX127X_REG_FRF_MSB, (FRF & 0xFF0000) >> 16);
   state |= this->mod->SPIsetRegValue(RADIOLIB_SX127X_REG_FRF_MID, (FRF & 0x00FF00) >> 8);
-
-  // lsb needs to be written no matter what in order for the module to update the frequency
-  if(this->mod->SPIgetRegValue(RADIOLIB_SX127X_REG_FRF_LSB) == (FRF & 0x0000FF)) {
-    this->mod->SPIwriteRegister(RADIOLIB_SX127X_REG_FRF_LSB, FRF & 0x0000FF);
-  } else {
-    state |= this->mod->SPIsetRegValue(RADIOLIB_SX127X_REG_FRF_LSB, FRF & 0x0000FF);
-  }
+    state |= this->mod->SPIsetRegValue(RADIOLIB_SX127X_REG_FRF_LSB, FRF & 0x0000FF, 7U, 0U, 2U, 0xFF, true);
   return(state);
 }
 

--- a/src/modules/SX127x/SX127x.cpp
+++ b/src/modules/SX127x/SX127x.cpp
@@ -1205,7 +1205,7 @@ int16_t SX127x::setFrequencyRaw(float newFreq) {
   // lsb needs to be written no matter what in order for the module to update the frequency
   state |= this->mod->SPIsetRegValue(RADIOLIB_SX127X_REG_FRF_MSB, (FRF & 0xFF0000) >> 16);
   state |= this->mod->SPIsetRegValue(RADIOLIB_SX127X_REG_FRF_MID, (FRF & 0x00FF00) >> 8);
-    state |= this->mod->SPIsetRegValue(RADIOLIB_SX127X_REG_FRF_LSB, FRF & 0x0000FF, 7U, 0U, 2U, 0xFF, true);
+  state |= this->mod->SPIsetRegValue(RADIOLIB_SX127X_REG_FRF_LSB, FRF & 0x0000FF, 7U, 0U, 2U, 0xFF, true);
   return(state);
 }
 


### PR DESCRIPTION
The SX127x requires that the LSB of the frequency register (Frf) be written in order to change the frequency, but the library was using a SPI writing function that checked for overwrites. If the LSB did not change, the new frequency would be written in successfully, but the frequency would stay at the module's default.

I changed it to use the lower level SPI writing function with no overwrite protection if there was no difference between the old and new contents for the LSB.

I have this commit working on my RFM96W board connected to an Arduino Nano Every, but I have not tested on any other platforms.