### PR TITLE
fix implicit conversion from float to double warnings

### DIFF
--- a/src/modules/CC1101/CC1101.h
+++ b/src/modules/CC1101/CC1101.h
@@ -9,7 +9,7 @@
 // CC1101 physical layer properties
 #define RADIOLIB_CC1101_FREQUENCY_STEP_SIZE                     396.7285156
 #define RADIOLIB_CC1101_MAX_PACKET_LENGTH                       64
-#define RADIOLIB_CC1101_CRYSTAL_FREQ                            26.0
+#define RADIOLIB_CC1101_CRYSTAL_FREQ                            26.0f
 #define RADIOLIB_CC1101_DIV_EXPONENT                            16
 
 // CC1101 SPI commands

--- a/src/modules/LLCC68/LLCC68.cpp
+++ b/src/modules/LLCC68/LLCC68.cpp
@@ -38,7 +38,7 @@ int16_t LLCC68::begin(float freq, float bw, uint8_t sf, uint8_t cr, uint8_t sync
 }
 
 int16_t LLCC68::setBandwidth(float bw) {
-  RADIOLIB_CHECK_RANGE(bw, 100.0, 510.0, RADIOLIB_ERR_INVALID_BANDWIDTH);
+  RADIOLIB_CHECK_RANGE(bw, 100.0f, 510.0f, RADIOLIB_ERR_INVALID_BANDWIDTH);
   return(SX1262::setBandwidth(bw));
 }
 
@@ -95,14 +95,14 @@ int16_t LLCC68::checkDataRate(DataRate_t dr) {
   // select interpretation based on active modem
   uint8_t modem = this->getPacketType();
   if(modem == RADIOLIB_SX126X_PACKET_TYPE_GFSK) {
-    RADIOLIB_CHECK_RANGE(dr.fsk.bitRate, 0.6, 300.0, RADIOLIB_ERR_INVALID_BIT_RATE);
-    RADIOLIB_CHECK_RANGE(dr.fsk.freqDev, 0.6, 200.0, RADIOLIB_ERR_INVALID_FREQUENCY_DEVIATION);
+    RADIOLIB_CHECK_RANGE(dr.fsk.bitRate, 0.6f, 300.0f, RADIOLIB_ERR_INVALID_BIT_RATE);
+    RADIOLIB_CHECK_RANGE(dr.fsk.freqDev, 0.6f, 200.0f, RADIOLIB_ERR_INVALID_FREQUENCY_DEVIATION);
     return(RADIOLIB_ERR_NONE);
 
   } else if(modem == RADIOLIB_SX126X_PACKET_TYPE_LORA) {
-    RADIOLIB_CHECK_RANGE(dr.lora.bandwidth, 100.0, 510.0, RADIOLIB_ERR_INVALID_BANDWIDTH);
+    RADIOLIB_CHECK_RANGE(dr.lora.bandwidth, 100.0f, 510.0f, RADIOLIB_ERR_INVALID_BANDWIDTH);
     RADIOLIB_CHECK_RANGE(dr.lora.codingRate, 5, 8, RADIOLIB_ERR_INVALID_CODING_RATE);
-    uint8_t bw_div2 = dr.lora.bandwidth / 2 + 0.01;
+    uint8_t bw_div2 = dr.lora.bandwidth / 2 + 0.01f;
     switch (bw_div2)  {
       case 62: // 125.0:
         RADIOLIB_CHECK_RANGE(dr.lora.spreadingFactor, 5, 9, RADIOLIB_ERR_INVALID_SPREADING_FACTOR);

--- a/src/modules/LR11x0/LR1110.cpp
+++ b/src/modules/LR11x0/LR1110.cpp
@@ -51,7 +51,7 @@ int16_t LR1110::setFrequency(float freq) {
 }
 
 int16_t LR1110::setFrequency(float freq, bool skipCalibration, float band) {
-  RADIOLIB_CHECK_RANGE(freq, 150.0, 960.0, RADIOLIB_ERR_INVALID_FREQUENCY);
+  RADIOLIB_CHECK_RANGE(freq, 150.0f, 960.0f, RADIOLIB_ERR_INVALID_FREQUENCY);
   
   // check if we need to recalibrate image
   int16_t state;

--- a/src/modules/LR11x0/LR1120.cpp
+++ b/src/modules/LR11x0/LR1120.cpp
@@ -9,7 +9,7 @@ LR1120::LR1120(Module* mod) : LR11x0(mod) {
 
 int16_t LR1120::begin(float freq, float bw, uint8_t sf, uint8_t cr, uint8_t syncWord, int8_t power, uint16_t preambleLength, float tcxoVoltage) {
   // execute common part
-  int16_t state = LR11x0::begin(bw, sf, cr, syncWord, preambleLength, tcxoVoltage, freq > 1000.0);
+  int16_t state = LR11x0::begin(bw, sf, cr, syncWord, preambleLength, tcxoVoltage, freq > 1000.0f);
   RADIOLIB_ASSERT(state);
 
   // configure publicly accessible settings
@@ -52,9 +52,9 @@ int16_t LR1120::setFrequency(float freq) {
 
 int16_t LR1120::setFrequency(float freq, bool skipCalibration, float band) {
   #if RADIOLIB_CHECK_PARAMS
-  if(!(((freq >= 150.0) && (freq <= 960.0)) ||
-    ((freq >= 1900.0) && (freq <= 2200.0)) ||
-    ((freq >= 2400.0) && (freq <= 2500.0)))) {
+  if(!(((freq >= 150.0f) && (freq <= 960.0f)) ||
+    ((freq >= 1900.0f) && (freq <= 2200.0f)) ||
+    ((freq >= 2400.0f) && (freq <= 2500.0f)))) {
       return(RADIOLIB_ERR_INVALID_FREQUENCY);
   }
   #endif
@@ -70,7 +70,7 @@ int16_t LR1120::setFrequency(float freq, bool skipCalibration, float band) {
   state = LR11x0::setRfFrequency((uint32_t)(freq*1000000.0f));
   RADIOLIB_ASSERT(state);
   this->freqMHz = freq;
-  this->highFreq = (freq > 1000.0);
+  this->highFreq = (freq > 1000.0f);
   return(RADIOLIB_ERR_NONE);
 }
 

--- a/src/modules/LR11x0/LR11x0.cpp
+++ b/src/modules/LR11x0/LR11x0.cpp
@@ -219,7 +219,7 @@ int16_t LR11x0::transmit(const uint8_t* data, size_t len, uint8_t addr) {
   RadioLibTime_t elapsed = this->mod->hal->micros() - start;
 
   // update data rate
-  this->dataRateMeasured = (len*8.0)/((float)elapsed/1000000.0);
+  this->dataRateMeasured = (len*8.0f)/((float)elapsed/1000000.0f);
 
   return(finishTransmit());
 }
@@ -238,7 +238,7 @@ int16_t LR11x0::receive(uint8_t* data, size_t len) {
   if(modem == RADIOLIB_LR11X0_PACKET_TYPE_LORA) {
     // calculate timeout (100 LoRa symbols, the default for SX127x series)
     float symbolLength = (float)(uint32_t(1) << this->spreadingFactor) / (float)this->bandwidthKhz;
-    timeout = (RadioLibTime_t)(symbolLength * 100.0);
+    timeout = (RadioLibTime_t)(symbolLength * 100.0f);
   
   } else if(modem == RADIOLIB_LR11X0_PACKET_TYPE_GFSK) {
     // calculate timeout (500 % of expected time-one-air)
@@ -246,8 +246,8 @@ int16_t LR11x0::receive(uint8_t* data, size_t len) {
     if(len == 0) { 
       maxLen = 0xFF;
     }
-    float brBps = ((float)(RADIOLIB_LR11X0_CRYSTAL_FREQ) * 1000000.0 * 32.0) / (float)this->bitRate;
-    timeout = (RadioLibTime_t)(((maxLen * 8.0) / brBps) * 1000.0 * 5.0);
+    float brBps = ((float)(RADIOLIB_LR11X0_CRYSTAL_FREQ) * 1000000.0f * 32.0f) / (float)this->bitRate;
+    timeout = (RadioLibTime_t)(((maxLen * 8.0f) / brBps) * 1000.0f * 5.0f);
   
   } else if(modem == RADIOLIB_LR11X0_PACKET_TYPE_LR_FHSS) {
     // this modem cannot receive
@@ -261,7 +261,7 @@ int16_t LR11x0::receive(uint8_t* data, size_t len) {
   RADIOLIB_DEBUG_BASIC_PRINTLN("Timeout in %lu ms", timeout);
 
   // start reception
-  uint32_t timeoutValue = (uint32_t)(((float)timeout * 1000.0) / 30.52);
+  uint32_t timeoutValue = (uint32_t)(((float)timeout * 1000.0f) / 30.52f);
   state = startReceive(timeoutValue);
   RADIOLIB_ASSERT(state);
 
@@ -667,22 +667,22 @@ int16_t LR11x0::setBandwidth(float bw, bool high) {
 
   // ensure byte conversion doesn't overflow
   if (high) {
-    RADIOLIB_CHECK_RANGE(bw, 203.125, 815.0, RADIOLIB_ERR_INVALID_BANDWIDTH);
+    RADIOLIB_CHECK_RANGE(bw, 203.125f, 815.0f, RADIOLIB_ERR_INVALID_BANDWIDTH);
 
-    if(fabsf(bw - 203.125) <= 0.001) {
+    if(fabsf(bw - 203.125f) <= 0.001f) {
       this->bandwidth = RADIOLIB_LR11X0_LORA_BW_203_125;
-    } else if(fabsf(bw - 406.25) <= 0.001) {
+    } else if(fabsf(bw - 406.25f) <= 0.001f) {
       this->bandwidth = RADIOLIB_LR11X0_LORA_BW_406_25;
-    } else if(fabsf(bw - 812.5) <= 0.001) {
+    } else if(fabsf(bw - 812.5f) <= 0.001f) {
       this->bandwidth = RADIOLIB_LR11X0_LORA_BW_812_50;
     } else {
       return(RADIOLIB_ERR_INVALID_BANDWIDTH);
     }
   } else {
-    RADIOLIB_CHECK_RANGE(bw, 0.0, 510.0, RADIOLIB_ERR_INVALID_BANDWIDTH);
+    RADIOLIB_CHECK_RANGE(bw, 0.0f, 510.0f, RADIOLIB_ERR_INVALID_BANDWIDTH);
     
     // check allowed bandwidth values
-    uint8_t bw_div2 = bw / 2 + 0.01;
+    uint8_t bw_div2 = bw / 2 + 0.01f;
     switch (bw_div2)  {
       case 31: // 62.5:
         this->bandwidth = RADIOLIB_LR11X0_LORA_BW_62_5;
@@ -773,7 +773,7 @@ int16_t LR11x0::setSyncWord(uint8_t syncWord) {
 }
 
 int16_t LR11x0::setBitRate(float br) {
-  RADIOLIB_CHECK_RANGE(br, 0.6, 300.0, RADIOLIB_ERR_INVALID_BIT_RATE);
+  RADIOLIB_CHECK_RANGE(br, 0.6f, 300.0f, RADIOLIB_ERR_INVALID_BIT_RATE);
 
   // check active modem
   uint8_t type = RADIOLIB_LR11X0_PACKET_TYPE_NONE;
@@ -785,7 +785,7 @@ int16_t LR11x0::setBitRate(float br) {
 
   // set bit rate value
   // TODO implement fractional bit rate configuration
-  this->bitRate = br * 1000.0;
+  this->bitRate = br * 1000.0f;
   return(setModulationParamsGFSK(this->bitRate, this->pulseShape, this->rxBandwidth, this->frequencyDev));
 }
 
@@ -800,12 +800,12 @@ int16_t LR11x0::setFrequencyDeviation(float freqDev) {
 
   // set frequency deviation to lowest available setting (required for digimodes)
   float newFreqDev = freqDev;
-  if(freqDev < 0.0) {
-    newFreqDev = 0.6;
+  if(freqDev < 0.0f) {
+    newFreqDev = 0.6f;
   }
 
-  RADIOLIB_CHECK_RANGE(newFreqDev, 0.6, 200.0, RADIOLIB_ERR_INVALID_FREQUENCY_DEVIATION);
-  this->frequencyDev = newFreqDev * 1000.0;
+  RADIOLIB_CHECK_RANGE(newFreqDev, 0.6f, 200.0f, RADIOLIB_ERR_INVALID_FREQUENCY_DEVIATION);
+  this->frequencyDev = newFreqDev * 1000.0f;
   return(setModulationParamsGFSK(this->bitRate, this->pulseShape, this->rxBandwidth, this->frequencyDev));
 }
 
@@ -824,47 +824,47 @@ int16_t LR11x0::setRxBandwidth(float rxBw) {
   }*/
 
   // check allowed receiver bandwidth values
-  if(fabsf(rxBw - 4.8) <= 0.001) {
+  if(fabsf(rxBw - 4.8f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_LR11X0_GFSK_RX_BW_4_8;
-  } else if(fabsf(rxBw - 5.8) <= 0.001) {
+  } else if(fabsf(rxBw - 5.8f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_LR11X0_GFSK_RX_BW_5_8;
-  } else if(fabsf(rxBw - 7.3) <= 0.001) {
+  } else if(fabsf(rxBw - 7.3f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_LR11X0_GFSK_RX_BW_7_3;
-  } else if(fabsf(rxBw - 9.7) <= 0.001) {
+  } else if(fabsf(rxBw - 9.7f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_LR11X0_GFSK_RX_BW_9_7;
-  } else if(fabsf(rxBw - 11.7) <= 0.001) {
+  } else if(fabsf(rxBw - 11.7f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_LR11X0_GFSK_RX_BW_11_7;
-  } else if(fabsf(rxBw - 14.6) <= 0.001) {
+  } else if(fabsf(rxBw - 14.6f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_LR11X0_GFSK_RX_BW_14_6;
-  } else if(fabsf(rxBw - 19.5) <= 0.001) {
+  } else if(fabsf(rxBw - 19.5f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_LR11X0_GFSK_RX_BW_19_5;
-  } else if(fabsf(rxBw - 23.4) <= 0.001) {
+  } else if(fabsf(rxBw - 23.4f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_LR11X0_GFSK_RX_BW_23_4;
-  } else if(fabsf(rxBw - 29.3) <= 0.001) {
+  } else if(fabsf(rxBw - 29.3f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_LR11X0_GFSK_RX_BW_29_3;
-  } else if(fabsf(rxBw - 39.0) <= 0.001) {
+  } else if(fabsf(rxBw - 39.0f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_LR11X0_GFSK_RX_BW_39_0;
-  } else if(fabsf(rxBw - 46.9) <= 0.001) {
+  } else if(fabsf(rxBw - 46.9f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_LR11X0_GFSK_RX_BW_46_9;
-  } else if(fabsf(rxBw - 58.6) <= 0.001) {
+  } else if(fabsf(rxBw - 58.6f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_LR11X0_GFSK_RX_BW_58_6;
-  } else if(fabsf(rxBw - 78.2) <= 0.001) {
+  } else if(fabsf(rxBw - 78.2f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_LR11X0_GFSK_RX_BW_78_2;
-  } else if(fabsf(rxBw - 93.8) <= 0.001) {
+  } else if(fabsf(rxBw - 93.8f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_LR11X0_GFSK_RX_BW_93_8;
-  } else if(fabsf(rxBw - 117.3) <= 0.001) {
+  } else if(fabsf(rxBw - 117.3f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_LR11X0_GFSK_RX_BW_117_3;
-  } else if(fabsf(rxBw - 156.2) <= 0.001) {
+  } else if(fabsf(rxBw - 156.2f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_LR11X0_GFSK_RX_BW_156_2;
-  } else if(fabsf(rxBw - 187.2) <= 0.001) {
+  } else if(fabsf(rxBw - 187.2f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_LR11X0_GFSK_RX_BW_187_2;
-  } else if(fabsf(rxBw - 234.3) <= 0.001) {
+  } else if(fabsf(rxBw - 234.3f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_LR11X0_GFSK_RX_BW_234_3;
-  } else if(fabsf(rxBw - 312.0) <= 0.001) {
+  } else if(fabsf(rxBw - 312.0f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_LR11X0_GFSK_RX_BW_312_0;
-  } else if(fabsf(rxBw - 373.6) <= 0.001) {
+  } else if(fabsf(rxBw - 373.6f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_LR11X0_GFSK_RX_BW_373_6;
-  } else if(fabsf(rxBw - 467.0) <= 0.001) {
+  } else if(fabsf(rxBw - 467.0f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_LR11X0_GFSK_RX_BW_467_0;
   } else {
     return(RADIOLIB_ERR_INVALID_RX_BANDWIDTH);
@@ -1104,13 +1104,13 @@ int16_t LR11x0::checkDataRate(DataRate_t dr) {
   RADIOLIB_ASSERT(state);
 
   if(type == RADIOLIB_LR11X0_PACKET_TYPE_GFSK) {
-    RADIOLIB_CHECK_RANGE(dr.fsk.bitRate, 0.6, 300.0, RADIOLIB_ERR_INVALID_BIT_RATE);
-    RADIOLIB_CHECK_RANGE(dr.fsk.freqDev, 0.6, 200.0, RADIOLIB_ERR_INVALID_FREQUENCY_DEVIATION);
+    RADIOLIB_CHECK_RANGE(dr.fsk.bitRate, 0.6f, 300.0f, RADIOLIB_ERR_INVALID_BIT_RATE);
+    RADIOLIB_CHECK_RANGE(dr.fsk.freqDev, 0.6f, 200.0f, RADIOLIB_ERR_INVALID_FREQUENCY_DEVIATION);
     return(RADIOLIB_ERR_NONE);
 
   } else if(type == RADIOLIB_LR11X0_PACKET_TYPE_LORA) {
     RADIOLIB_CHECK_RANGE(dr.lora.spreadingFactor, 5, 12, RADIOLIB_ERR_INVALID_SPREADING_FACTOR);
-    RADIOLIB_CHECK_RANGE(dr.lora.bandwidth, 0.0, 510.0, RADIOLIB_ERR_INVALID_BANDWIDTH);
+    RADIOLIB_CHECK_RANGE(dr.lora.bandwidth, 0.0f, 510.0f, RADIOLIB_ERR_INVALID_BANDWIDTH);
     RADIOLIB_CHECK_RANGE(dr.lora.codingRate, 5, 8, RADIOLIB_ERR_INVALID_CODING_RATE);
     return(RADIOLIB_ERR_NONE);
   
@@ -1158,28 +1158,28 @@ int16_t LR11x0::setTCXO(float voltage, uint32_t delay) {
   }
 
   // check 0 V disable
-  if(fabsf(voltage - 0.0) <= 0.001) {
+  if(fabsf(voltage - 0.0f) <= 0.001f) {
     setTcxoMode(0, 0);
     return(reset());
   }
 
   // check allowed voltage values
   uint8_t tune = 0;
-  if(fabsf(voltage - 1.6) <= 0.001) {
+  if(fabsf(voltage - 1.6f) <= 0.001f) {
     tune = RADIOLIB_LR11X0_TCXO_VOLTAGE_1_6;
-  } else if(fabsf(voltage - 1.7) <= 0.001) {
+  } else if(fabsf(voltage - 1.7f) <= 0.001f) {
     tune = RADIOLIB_LR11X0_TCXO_VOLTAGE_1_7;
-  } else if(fabsf(voltage - 1.8) <= 0.001) {
+  } else if(fabsf(voltage - 1.8f) <= 0.001f) {
     tune = RADIOLIB_LR11X0_TCXO_VOLTAGE_1_8;
-  } else if(fabsf(voltage - 2.2) <= 0.001) {
+  } else if(fabsf(voltage - 2.2f) <= 0.001f) {
     tune = RADIOLIB_LR11X0_TCXO_VOLTAGE_2_2;
-  } else if(fabsf(voltage - 2.4) <= 0.001) {
+  } else if(fabsf(voltage - 2.4f) <= 0.001f) {
     tune = RADIOLIB_LR11X0_TCXO_VOLTAGE_2_4;
-  } else if(fabsf(voltage - 2.7) <= 0.001) {
+  } else if(fabsf(voltage - 2.7f) <= 0.001f) {
     tune = RADIOLIB_LR11X0_TCXO_VOLTAGE_2_7;
-  } else if(fabsf(voltage - 3.0) <= 0.001) {
+  } else if(fabsf(voltage - 3.0f) <= 0.001f) {
     tune = RADIOLIB_LR11X0_TCXO_VOLTAGE_3_0;
-  } else if(fabsf(voltage - 3.3) <= 0.001) {
+  } else if(fabsf(voltage - 3.3f) <= 0.001f) {
     tune = RADIOLIB_LR11X0_TCXO_VOLTAGE_3_3;
   } else {
     return(RADIOLIB_ERR_INVALID_TCXO_VOLTAGE);
@@ -1353,7 +1353,7 @@ RadioLibTime_t LR11x0::getTimeOnAir(size_t len) {
       uint32_t N_symbolPreamble = (this->preambleLengthLoRa & 0x0F) * (uint32_t(1) << ((this->preambleLengthLoRa & 0xF0) >> 4));
 
       // calculate the number of symbols
-      N_symbol = (float)N_symbolPreamble + coeff1 + 8.0 + ceilf((float)RADIOLIB_MAX((int16_t)(8 * len + N_bitCRC - coeff2 + N_symbolHeader), (int16_t)0) / (float)coeff3) * (float)(this->codingRate + 4);
+      N_symbol = (float)N_symbolPreamble + coeff1 + 8.0f + ceilf((float)RADIOLIB_MAX((int16_t)(8 * len + N_bitCRC - coeff2 + N_symbolHeader), (int16_t)0) / (float)coeff3) * (float)(this->codingRate + 4);
 
     } else {
       // long interleaving - abandon hope all ye who enter here
@@ -1362,7 +1362,7 @@ RadioLibTime_t LR11x0::getTimeOnAir(size_t len) {
     }
 
     // get time-on-air in us
-    return(((uint32_t(1) << this->spreadingFactor) / this->bandwidthKhz) * N_symbol * 1000.0);
+    return(((uint32_t(1) << this->spreadingFactor) / this->bandwidthKhz) * N_symbol * 1000.0f);
 
   } else if(type == RADIOLIB_LR11X0_PACKET_TYPE_GFSK) {
     return(((uint32_t)len * 8 * 1000000UL) / this->bitRate);
@@ -2082,7 +2082,7 @@ int16_t LR11x0::modSetup(float tcxoVoltage, uint8_t modem) {
   RADIOLIB_ASSERT(state);
 
   // set TCXO control, if requested
-  if(!this->XTAL && tcxoVoltage > 0.0) {
+  if(!this->XTAL && tcxoVoltage > 0.0f) {
     state = setTCXO(tcxoVoltage);
     RADIOLIB_ASSERT(state);
   }
@@ -2759,7 +2759,7 @@ int16_t LR11x0::setModulationParamsLoRa(uint8_t sf, uint8_t bw, uint8_t cr, uint
   // calculate symbol length and enable low data rate optimization, if auto-configuration is enabled
   if(this->ldroAuto) {
     float symbolLength = (float)(uint32_t(1) << this->spreadingFactor) / (float)this->bandwidthKhz;
-    if(symbolLength >= 16.0) {
+    if(symbolLength >= 16.0f) {
       this->ldrOptimize = RADIOLIB_LR11X0_LORA_LDRO_ENABLED;
     } else {
       this->ldrOptimize = RADIOLIB_LR11X0_LORA_LDRO_DISABLED;

--- a/src/modules/LR11x0/LR11x0.h
+++ b/src/modules/LR11x0/LR11x0.h
@@ -233,7 +233,7 @@
 #define RADIOLIB_LR11X0_CALIBRATE_HF_RC                         (0x01UL << 1)   //  1     1                high frequency RC
 #define RADIOLIB_LR11X0_CALIBRATE_LF_RC                         (0x01UL << 0)   //  0     0                low frequency RC
 #define RADIOLIB_LR11X0_CALIBRATE_ALL                           (0x3FUL << 0)   //  5     0                everything
-#define RADIOLIB_LR11X0_CAL_IMG_FREQ_TRIG_MHZ                   (20.0)
+#define RADIOLIB_LR11X0_CAL_IMG_FREQ_TRIG_MHZ                   (20.0f)
 
 // RADIOLIB_LR11X0_CMD_SET_REG_MODE
 #define RADIOLIB_LR11X0_REG_MODE_LDO                            (0x00UL << 0)   //  0     0     regulator mode: LDO in all modes
@@ -409,7 +409,7 @@
 #define RADIOLIB_LR11X0_GFSK_RX_BW_312_0                        (0x19UL << 0)   //  7     0                        312.0 kHz
 #define RADIOLIB_LR11X0_GFSK_RX_BW_373_6                        (0x11UL << 0)   //  7     0                        373.6 kHz
 #define RADIOLIB_LR11X0_GFSK_RX_BW_467_0                        (0x09UL << 0)   //  7     0                        467.0 kHz
-#define RADIOLIB_LR11X0_LR_FHSS_BIT_RATE                        (488.28215)     //  31    0     LR FHSS bit rate: 488.28215 bps
+#define RADIOLIB_LR11X0_LR_FHSS_BIT_RATE                        (488.28215f)    //  31    0     LR FHSS bit rate: 488.28215 bps
 #define RADIOLIB_LR11X0_LR_FHSS_BIT_RATE_RAW                    (0x8001E848UL)  //  31    0                       488.28215 bps in raw
 #define RADIOLIB_LR11X0_LR_FHSS_SHAPING_GAUSSIAN_BT_1_0         (0x0BUL << 0)   //  7     0     shaping filter: Gaussian, BT = 1.0
 #define RADIOLIB_LR11X0_SIGFOX_SHAPING_GAUSSIAN_BT_0_7          (0x16UL << 0)   //  7     0     shaping filter: Gaussian, BT = 0.7

--- a/src/modules/RF69/RF69.cpp
+++ b/src/modules/RF69/RF69.cpp
@@ -122,7 +122,7 @@ int16_t RF69::transmit(const uint8_t* data, size_t len, uint8_t addr) {
 
 int16_t RF69::receive(uint8_t* data, size_t len) {
   // calculate timeout (500 ms + 400 full 64-byte packets at current bit rate)
-  RadioLibTime_t timeout = 500 + (1.0/(this->bitRate))*(RADIOLIB_RF69_MAX_PACKET_LENGTH*400.0);
+  RadioLibTime_t timeout = 500 + (1.0f/(this->bitRate))*(RADIOLIB_RF69_MAX_PACKET_LENGTH*400.0f);
 
   // start reception
   int16_t state = startReceive();
@@ -523,9 +523,9 @@ int16_t RF69::setOokPeakThresholdDecrement(uint8_t value) {
 
 int16_t RF69::setFrequency(float freq) {
   // check allowed frequency range
-  if(!(((freq > 290.0) && (freq < 340.0)) ||
-       ((freq > 431.0) && (freq < 510.0)) ||
-       ((freq > 862.0) && (freq < 1020.0)))) {
+  if(!(((freq > 290.0f) && (freq < 340.0f)) ||
+       ((freq > 431.0f) && (freq < 510.0f)) ||
+       ((freq > 862.0f) && (freq < 1020.0f)))) {
     return(RADIOLIB_ERR_INVALID_FREQUENCY);
   }
 
@@ -559,7 +559,7 @@ int16_t RF69::getFrequency(float *freq) {
 
 int16_t RF69::setBitRate(float br) {
   // datasheet says 1.2 kbps should be the smallest possible, but 0.512 works fine
-  RADIOLIB_CHECK_RANGE(br, 0.5, 300.0, RADIOLIB_ERR_INVALID_BIT_RATE);
+  RADIOLIB_CHECK_RANGE(br, 0.5f, 300.0f, RADIOLIB_ERR_INVALID_BIT_RATE);
 
   // check bitrate-bandwidth ratio
   if(!(br < 2000 * this->rxBandwidth)) {
@@ -592,8 +592,8 @@ int16_t RF69::setRxBandwidth(float rxBw) {
   // calculate exponent and mantissa values for receiver bandwidth
   for(int8_t e = 7; e >= 0; e--) {
     for(int8_t m = 2; m >= 0; m--) {
-      float point = (RADIOLIB_RF69_CRYSTAL_FREQ * 1000000.0)/(((4 * m) + 16) * ((uint32_t)1 << (e + (this->ookEnabled ? 3 : 2))));
-      if(fabsf(rxBw - (point / 1000.0)) <= 0.1) {
+      float point = (RADIOLIB_RF69_CRYSTAL_FREQ * 1000000.0f)/(((4 * m) + 16) * ((uint32_t)1 << (e + (this->ookEnabled ? 3 : 2))));
+      if(fabsf(rxBw - (point / 1000.0f)) <= 0.1f) {
         // set Rx bandwidth
         state = this->mod->SPIsetRegValue(RADIOLIB_RF69_REG_RX_BW, (m << 3) | e, 4, 0);
         if(state == RADIOLIB_ERR_NONE) {
@@ -610,8 +610,8 @@ int16_t RF69::setRxBandwidth(float rxBw) {
 int16_t RF69::setFrequencyDeviation(float freqDev) {
   // set frequency deviation to lowest available setting (required for digimodes)
   float newFreqDev = freqDev;
-  if(freqDev < 0.0) {
-    newFreqDev = 0.6;
+  if(freqDev < 0.0f) {
+    newFreqDev = 0.6f;
   }
 
   // check frequency deviation range
@@ -648,7 +648,7 @@ int16_t RF69::getFrequencyDeviation(float *freqDev) {
 
   // calculate frequency deviation from raw value obtained from register 
   // Fdev = Fstep * Fdev(13:0) (pag. 20 of datasheet)
-  *freqDev = (1000.0 * fdev * RADIOLIB_RF69_CRYSTAL_FREQ) / 
+  *freqDev = (1000.0f * fdev * RADIOLIB_RF69_CRYSTAL_FREQ) / 
     (uint32_t(1) << RADIOLIB_RF69_DIV_EXPONENT);
 
   return(RADIOLIB_ERR_NONE);
@@ -928,9 +928,9 @@ float RF69::getRSSI() {
 }
 
 int16_t RF69::setRSSIThreshold(float dbm) {
-  RADIOLIB_CHECK_RANGE(dbm, -127.5, 0, RADIOLIB_ERR_INVALID_RSSI_THRESHOLD);
+  RADIOLIB_CHECK_RANGE(dbm, -127.5f, 0.0f, RADIOLIB_ERR_INVALID_RSSI_THRESHOLD);
 
-  return this->mod->SPIsetRegValue(RADIOLIB_RF69_REG_RSSI_THRESH, (uint8_t)(-2.0 * dbm), 7, 0);
+  return this->mod->SPIsetRegValue(RADIOLIB_RF69_REG_RSSI_THRESH, (uint8_t)(-2.0f * dbm), 7, 0);
 }
 
 void RF69::setRfSwitchPins(uint32_t rxEn, uint32_t txEn) {

--- a/src/modules/RF69/RF69.h
+++ b/src/modules/RF69/RF69.h
@@ -12,7 +12,7 @@
 // RF69 physical layer properties
 #define RADIOLIB_RF69_FREQUENCY_STEP_SIZE                       61.03515625
 #define RADIOLIB_RF69_MAX_PACKET_LENGTH                         64
-#define RADIOLIB_RF69_CRYSTAL_FREQ                              32.0
+#define RADIOLIB_RF69_CRYSTAL_FREQ                              32.0f
 #define RADIOLIB_RF69_DIV_EXPONENT                              19
 
 // RF69 register map

--- a/src/modules/SX123x/SX1233.cpp
+++ b/src/modules/SX123x/SX1233.cpp
@@ -93,11 +93,11 @@ int16_t SX1233::begin(float freq, float br, float freqDev, float rxBw, int8_t po
 int16_t SX1233::setBitRate(float br) {
   // check high bit-rate operation
   uint8_t pllBandwidth = RADIOLIB_SX1233_PLL_BW_LOW_BIT_RATE;
-  if((fabsf(br - 500.0f) < 0.1) || (fabsf(br - 600.0f) < 0.1)) {
+  if((fabsf(br - 500.0f) < 0.1f) || (fabsf(br - 600.0f) < 0.1f)) {
     pllBandwidth = RADIOLIB_SX1233_PLL_BW_HIGH_BIT_RATE;
   } else {
     // datasheet says 1.2 kbps should be the smallest possible, but 0.512 works fine
-    RADIOLIB_CHECK_RANGE(br, 0.5, 300.0, RADIOLIB_ERR_INVALID_BIT_RATE);
+    RADIOLIB_CHECK_RANGE(br, 0.5f, 300.0f, RADIOLIB_ERR_INVALID_BIT_RATE);
   }
   
 

--- a/src/modules/SX126x/SX1262.cpp
+++ b/src/modules/SX126x/SX1262.cpp
@@ -72,7 +72,7 @@ int16_t SX1262::setFrequency(float freq) {
 }
 
 int16_t SX1262::setFrequency(float freq, bool skipCalibration) {
-  RADIOLIB_CHECK_RANGE(freq, 150.0, 960.0, RADIOLIB_ERR_INVALID_FREQUENCY);
+  RADIOLIB_CHECK_RANGE(freq, 150.0f, 960.0f, RADIOLIB_ERR_INVALID_FREQUENCY);
 
   // check if we need to recalibrate image
   if(!skipCalibration && (fabsf(freq - this->freqMHz) >= RADIOLIB_SX126X_CAL_IMG_FREQ_TRIG_MHZ)) {

--- a/src/modules/SX126x/SX1268.cpp
+++ b/src/modules/SX126x/SX1268.cpp
@@ -73,7 +73,7 @@ int16_t SX1268::setFrequency(float freq) {
 
 /// \todo integers only (all modules - frequency, data rate, bandwidth etc.)
 int16_t SX1268::setFrequency(float freq, bool skipCalibration) {
-  RADIOLIB_CHECK_RANGE(freq, 410.0, 810.0, RADIOLIB_ERR_INVALID_FREQUENCY);
+  RADIOLIB_CHECK_RANGE(freq, 410.0f, 810.0f, RADIOLIB_ERR_INVALID_FREQUENCY);
 
   // check if we need to recalibrate image
   if(!skipCalibration && (fabsf(freq - this->freqMHz) >= RADIOLIB_SX126X_CAL_IMG_FREQ_TRIG_MHZ)) {

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -243,7 +243,7 @@ int16_t SX126x::transmit(const uint8_t* data, size_t len, uint8_t addr) {
 
   // update data rate
   RadioLibTime_t elapsed = this->mod->hal->millis() - start;
-  this->dataRateMeasured = (len*8.0)/((float)elapsed/1000.0);
+  this->dataRateMeasured = (len*8.0f)/((float)elapsed/1000.0f);
 
   return(finishTransmit());
 }
@@ -260,7 +260,7 @@ int16_t SX126x::receive(uint8_t* data, size_t len) {
   if(modem == RADIOLIB_SX126X_PACKET_TYPE_LORA) {
     // calculate timeout (100 LoRa symbols, the default for SX127x series)
     float symbolLength = (float)(uint32_t(1) << this->spreadingFactor) / (float)this->bandwidthKhz;
-    timeout = (RadioLibTime_t)(symbolLength * 100.0);
+    timeout = (RadioLibTime_t)(symbolLength * 100.0f);
   
   } else if(modem == RADIOLIB_SX126X_PACKET_TYPE_GFSK) {
     // calculate timeout (500 % of expected time-one-air)
@@ -268,8 +268,8 @@ int16_t SX126x::receive(uint8_t* data, size_t len) {
     if(len == 0) {
       maxLen = 0xFF;
     }
-    float brBps = ((float)(RADIOLIB_SX126X_CRYSTAL_FREQ) * 1000000.0 * 32.0) / (float)this->bitRate;
-    timeout = (RadioLibTime_t)(((maxLen * 8.0) / brBps) * 1000.0 * 5.0);
+    float brBps = (RADIOLIB_SX126X_CRYSTAL_FREQ * 1000000.0f * 32.0f) / (float)this->bitRate;
+    timeout = (RadioLibTime_t)(((maxLen * 8.0f) / brBps) * 1000.0f * 5.0f);
 
   } else {
     return(RADIOLIB_ERR_UNKNOWN);
@@ -279,7 +279,7 @@ int16_t SX126x::receive(uint8_t* data, size_t len) {
   RADIOLIB_DEBUG_BASIC_PRINTLN("Timeout in %lu ms", timeout);
 
   // start reception
-  uint32_t timeoutValue = (uint32_t)(((float)timeout * 1000.0) / 15.625);
+  uint32_t timeoutValue = (uint32_t)(((float)timeout * 1000.0f) / 15.625f);
   state = startReceive(timeoutValue);
   RADIOLIB_ASSERT(state);
 
@@ -854,10 +854,10 @@ int16_t SX126x::setBandwidth(float bw) {
   }
 
   // ensure byte conversion doesn't overflow
-  RADIOLIB_CHECK_RANGE(bw, 0.0, 510.0, RADIOLIB_ERR_INVALID_BANDWIDTH);
+  RADIOLIB_CHECK_RANGE(bw, 0.0f, 510.0f, RADIOLIB_ERR_INVALID_BANDWIDTH);
 
   // check allowed bandwidth values
-  uint8_t bw_div2 = bw / 2 + 0.01;
+  uint8_t bw_div2 = bw / 2 + 0.01f;
   switch (bw_div2)  {
     case 3: // 7.8:
       this->bandwidth = RADIOLIB_SX126X_LORA_BW_7_8;
@@ -942,7 +942,7 @@ int16_t SX126x::setCurrentLimit(float currentLimit) {
   }
 
   // calculate raw value
-  uint8_t rawLimit = (uint8_t)(currentLimit / 2.5);
+  uint8_t rawLimit = (uint8_t)(currentLimit / 2.5f);
 
   // update register
   return(writeRegister(RADIOLIB_SX126X_REG_OCP_CONFIGURATION, &rawLimit, 1));
@@ -954,7 +954,7 @@ float SX126x::getCurrentLimit() {
   readRegister(RADIOLIB_SX126X_REG_OCP_CONFIGURATION, &ocp, 1);
 
   // return the actual value
-  return((float)ocp * 2.5);
+  return((float)ocp * 2.5f);
 }
 
 int16_t SX126x::setPreambleLength(size_t preambleLength) {
@@ -986,14 +986,14 @@ int16_t SX126x::setFrequencyDeviation(float freqDev) {
 
   // set frequency deviation to lowest available setting (required for digimodes)
   float newFreqDev = freqDev;
-  if(freqDev < 0.0) {
-    newFreqDev = 0.6;
+  if(freqDev < 0.0f) {
+    newFreqDev = 0.6f;
   }
 
-  RADIOLIB_CHECK_RANGE(newFreqDev, 0.6, 200.0, RADIOLIB_ERR_INVALID_FREQUENCY_DEVIATION);
+  RADIOLIB_CHECK_RANGE(newFreqDev, 0.6f, 200.0f, RADIOLIB_ERR_INVALID_FREQUENCY_DEVIATION);
 
   // calculate raw frequency deviation value
-  uint32_t freqDevRaw = (uint32_t)(((newFreqDev * 1000.0) * (float)((uint32_t)(1) << 25)) / (RADIOLIB_SX126X_CRYSTAL_FREQ * 1000000.0));
+  uint32_t freqDevRaw = (uint32_t)(((newFreqDev * 1000.0f) * (float)((uint32_t)(1) << 25)) / (RADIOLIB_SX126X_CRYSTAL_FREQ * 1000000.0f));
 
   // check modulation parameters
   this->frequencyDev = freqDevRaw;
@@ -1010,11 +1010,11 @@ int16_t SX126x::setBitRate(float br) {
   }
 
   if(modem != RADIOLIB_SX126X_PACKET_TYPE_LR_FHSS) {
-    RADIOLIB_CHECK_RANGE(br, 0.6, 300.0, RADIOLIB_ERR_INVALID_BIT_RATE);
+    RADIOLIB_CHECK_RANGE(br, 0.6f, 300.0f, RADIOLIB_ERR_INVALID_BIT_RATE);
   }
 
   // calculate raw bit rate value
-  uint32_t brRaw = (uint32_t)((RADIOLIB_SX126X_CRYSTAL_FREQ * 1000000.0 * 32.0) / (br * 1000.0));
+  uint32_t brRaw = (uint32_t)((RADIOLIB_SX126X_CRYSTAL_FREQ * 1000000.0f * 32.0f) / (br * 1000.0f));
 
   // check modulation parameters
   this->bitRate = brRaw;
@@ -1067,13 +1067,13 @@ int16_t SX126x::checkDataRate(DataRate_t dr) {
   // select interpretation based on active modem
   uint8_t modem = this->getPacketType();
   if(modem == RADIOLIB_SX126X_PACKET_TYPE_GFSK) {
-    RADIOLIB_CHECK_RANGE(dr.fsk.bitRate, 0.6, 300.0, RADIOLIB_ERR_INVALID_BIT_RATE);
-    RADIOLIB_CHECK_RANGE(dr.fsk.freqDev, 0.6, 200.0, RADIOLIB_ERR_INVALID_FREQUENCY_DEVIATION);
+    RADIOLIB_CHECK_RANGE(dr.fsk.bitRate, 0.6f, 300.0f, RADIOLIB_ERR_INVALID_BIT_RATE);
+    RADIOLIB_CHECK_RANGE(dr.fsk.freqDev, 0.6f, 200.0f, RADIOLIB_ERR_INVALID_FREQUENCY_DEVIATION);
     return(RADIOLIB_ERR_NONE);
 
   } else if(modem == RADIOLIB_SX126X_PACKET_TYPE_LORA) {
     RADIOLIB_CHECK_RANGE(dr.lora.spreadingFactor, 5, 12, RADIOLIB_ERR_INVALID_SPREADING_FACTOR);
-    RADIOLIB_CHECK_RANGE(dr.lora.bandwidth, 0.0, 510.0, RADIOLIB_ERR_INVALID_BANDWIDTH);
+    RADIOLIB_CHECK_RANGE(dr.lora.bandwidth, 0.0f, 510.0f, RADIOLIB_ERR_INVALID_BANDWIDTH);
     RADIOLIB_CHECK_RANGE(dr.lora.codingRate, 5, 8, RADIOLIB_ERR_INVALID_CODING_RATE);
     return(RADIOLIB_ERR_NONE);
   
@@ -1095,47 +1095,47 @@ int16_t SX126x::setRxBandwidth(float rxBw) {
   this->rxBandwidthKhz = rxBw;
 
   // check allowed receiver bandwidth values
-  if(fabsf(rxBw - 4.8) <= 0.001) {
+  if(fabsf(rxBw - 4.8f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_SX126X_GFSK_RX_BW_4_8;
-  } else if(fabsf(rxBw - 5.8) <= 0.001) {
+  } else if(fabsf(rxBw - 5.8f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_SX126X_GFSK_RX_BW_5_8;
-  } else if(fabsf(rxBw - 7.3) <= 0.001) {
+  } else if(fabsf(rxBw - 7.3f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_SX126X_GFSK_RX_BW_7_3;
-  } else if(fabsf(rxBw - 9.7) <= 0.001) {
+  } else if(fabsf(rxBw - 9.7f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_SX126X_GFSK_RX_BW_9_7;
-  } else if(fabsf(rxBw - 11.7) <= 0.001) {
+  } else if(fabsf(rxBw - 11.7f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_SX126X_GFSK_RX_BW_11_7;
-  } else if(fabsf(rxBw - 14.6) <= 0.001) {
+  } else if(fabsf(rxBw - 14.6f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_SX126X_GFSK_RX_BW_14_6;
-  } else if(fabsf(rxBw - 19.5) <= 0.001) {
+  } else if(fabsf(rxBw - 19.5f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_SX126X_GFSK_RX_BW_19_5;
-  } else if(fabsf(rxBw - 23.4) <= 0.001) {
+  } else if(fabsf(rxBw - 23.4f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_SX126X_GFSK_RX_BW_23_4;
-  } else if(fabsf(rxBw - 29.3) <= 0.001) {
+  } else if(fabsf(rxBw - 29.3f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_SX126X_GFSK_RX_BW_29_3;
-  } else if(fabsf(rxBw - 39.0) <= 0.001) {
+  } else if(fabsf(rxBw - 39.0f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_SX126X_GFSK_RX_BW_39_0;
-  } else if(fabsf(rxBw - 46.9) <= 0.001) {
+  } else if(fabsf(rxBw - 46.9f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_SX126X_GFSK_RX_BW_46_9;
-  } else if(fabsf(rxBw - 58.6) <= 0.001) {
+  } else if(fabsf(rxBw - 58.6f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_SX126X_GFSK_RX_BW_58_6;
-  } else if(fabsf(rxBw - 78.2) <= 0.001) {
+  } else if(fabsf(rxBw - 78.2f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_SX126X_GFSK_RX_BW_78_2;
-  } else if(fabsf(rxBw - 93.8) <= 0.001) {
+  } else if(fabsf(rxBw - 93.8f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_SX126X_GFSK_RX_BW_93_8;
-  } else if(fabsf(rxBw - 117.3) <= 0.001) {
+  } else if(fabsf(rxBw - 117.3f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_SX126X_GFSK_RX_BW_117_3;
-  } else if(fabsf(rxBw - 156.2) <= 0.001) {
+  } else if(fabsf(rxBw - 156.2f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_SX126X_GFSK_RX_BW_156_2;
-  } else if(fabsf(rxBw - 187.2) <= 0.001) {
+  } else if(fabsf(rxBw - 187.2f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_SX126X_GFSK_RX_BW_187_2;
-  } else if(fabsf(rxBw - 234.3) <= 0.001) {
+  } else if(fabsf(rxBw - 234.3f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_SX126X_GFSK_RX_BW_234_3;
-  } else if(fabsf(rxBw - 312.0) <= 0.001) {
+  } else if(fabsf(rxBw - 312.0f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_SX126X_GFSK_RX_BW_312_0;
-  } else if(fabsf(rxBw - 373.6) <= 0.001) {
+  } else if(fabsf(rxBw - 373.6f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_SX126X_GFSK_RX_BW_373_6;
-  } else if(fabsf(rxBw - 467.0) <= 0.001) {
+  } else if(fabsf(rxBw - 467.0f) <= 0.001f) {
     this->rxBandwidth = RADIOLIB_SX126X_GFSK_RX_BW_467_0;
   } else {
     return(RADIOLIB_ERR_INVALID_RX_BANDWIDTH);
@@ -1373,7 +1373,7 @@ float SX126x::getRSSI(bool packet) {
     // get instantaneous RSSI value
     uint8_t rssiRaw = 0;
     this->mod->SPIreadStream(RADIOLIB_SX126X_CMD_GET_RSSI_INST, &rssiRaw, 1);
-    return((float)rssiRaw / (-2.0));
+    return((float)rssiRaw / (-2.0f));
   }
 }
 
@@ -1418,9 +1418,9 @@ float SX126x::getFrequencyError() {
     // frequency error is negative
     efe |= (uint32_t) 0xFFF00000;
     efe = ~efe + 1;
-    error = 1.55 * (float) efe / (1600.0 / (float) this->bandwidthKhz) * -1.0;
+    error = 1.55f * (float) efe / (1600.0f / (float) this->bandwidthKhz) * -1.0f;
   } else {
-    error = 1.55 * (float) efe / (1600.0 / (float) this->bandwidthKhz);
+    error = 1.55f * (float) efe / (1600.0f / (float) this->bandwidthKhz);
   }
 
   return(error);
@@ -1528,7 +1528,7 @@ RadioLibTime_t SX126x::getTimeOnAir(size_t len) {
 RadioLibTime_t SX126x::calculateRxTimeout(RadioLibTime_t timeoutUs) {
   // the timeout value is given in units of 15.625 microseconds
   // the calling function should provide some extra width, as this number of units is truncated to integer
-  RadioLibTime_t timeout = timeoutUs / 15.625;
+  RadioLibTime_t timeout = timeoutUs / 15.625f;
   return(timeout);
 }
 
@@ -1769,34 +1769,34 @@ int16_t SX126x::setTCXO(float voltage, uint32_t delay) {
   }
 
   // check 0 V disable
-  if(fabsf(voltage - 0.0) <= 0.001) {
+  if(fabsf(voltage - 0.0f) <= 0.001f) {
     return(reset(true));
   }
 
   // check alowed voltage values
   uint8_t data[4];
-  if(fabsf(voltage - 1.6) <= 0.001) {
+  if(fabsf(voltage - 1.6f) <= 0.001f) {
     data[0] = RADIOLIB_SX126X_DIO3_OUTPUT_1_6;
-  } else if(fabsf(voltage - 1.7) <= 0.001) {
+  } else if(fabsf(voltage - 1.7f) <= 0.001f) {
     data[0] = RADIOLIB_SX126X_DIO3_OUTPUT_1_7;
-  } else if(fabsf(voltage - 1.8) <= 0.001) {
+  } else if(fabsf(voltage - 1.8f) <= 0.001f) {
     data[0] = RADIOLIB_SX126X_DIO3_OUTPUT_1_8;
-  } else if(fabsf(voltage - 2.2) <= 0.001) {
+  } else if(fabsf(voltage - 2.2f) <= 0.001f) {
     data[0] = RADIOLIB_SX126X_DIO3_OUTPUT_2_2;
-  } else if(fabsf(voltage - 2.4) <= 0.001) {
+  } else if(fabsf(voltage - 2.4f) <= 0.001f) {
     data[0] = RADIOLIB_SX126X_DIO3_OUTPUT_2_4;
-  } else if(fabsf(voltage - 2.7) <= 0.001) {
+  } else if(fabsf(voltage - 2.7f) <= 0.001f) {
     data[0] = RADIOLIB_SX126X_DIO3_OUTPUT_2_7;
-  } else if(fabsf(voltage - 3.0) <= 0.001) {
+  } else if(fabsf(voltage - 3.0f) <= 0.001f) {
     data[0] = RADIOLIB_SX126X_DIO3_OUTPUT_3_0;
-  } else if(fabsf(voltage - 3.3) <= 0.001) {
+  } else if(fabsf(voltage - 3.3f) <= 0.001f) {
     data[0] = RADIOLIB_SX126X_DIO3_OUTPUT_3_3;
   } else {
     return(RADIOLIB_ERR_INVALID_TCXO_VOLTAGE);
   }
 
   // calculate delay
-  uint32_t delayValue = (float)delay / 15.625;
+  uint32_t delayValue = (float)delay / 15.625f;
   data[1] = (uint8_t)((delayValue >> 16) & 0xFF);
   data[2] = (uint8_t)((delayValue >> 8) & 0xFF);
   data[3] = (uint8_t)(delayValue & 0xFF);
@@ -2040,7 +2040,7 @@ int16_t SX126x::setModulationParams(uint8_t sf, uint8_t bw, uint8_t cr, uint8_t 
   // calculate symbol length and enable low data rate optimization, if auto-configuration is enabled
   if(this->ldroAuto) {
     float symbolLength = (float)(uint32_t(1) << this->spreadingFactor) / (float)this->bandwidthKhz;
-    if(symbolLength >= 16.0) {
+    if(symbolLength >= 16.0f) {
       this->ldrOptimize = RADIOLIB_SX126X_LORA_LOW_DATA_RATE_OPTIMIZE_ON;
     } else {
       this->ldrOptimize = RADIOLIB_SX126X_LORA_LOW_DATA_RATE_OPTIMIZE_OFF;
@@ -2126,7 +2126,7 @@ int16_t SX126x::fixSensitivity() {
   RADIOLIB_ASSERT(state);
 
   // fix the value for LoRa with 500 kHz bandwidth
-  if((getPacketType() == RADIOLIB_SX126X_PACKET_TYPE_LORA) && (fabsf(this->bandwidthKhz - 500.0) <= 0.001)) {
+  if((getPacketType() == RADIOLIB_SX126X_PACKET_TYPE_LORA) && (fabsf(this->bandwidthKhz - 500.0f) <= 0.001f)) {
     sensitivityConfig &= 0xFB;
   } else {
     sensitivityConfig |= 0x04;
@@ -2232,7 +2232,7 @@ int16_t SX126x::modSetup(float tcxoVoltage, bool useRegulatorLDO, uint8_t modem)
   RADIOLIB_ASSERT(state);
 
   // set TCXO control, if requested
-  if(!this->XTAL && tcxoVoltage > 0.0) {
+  if(!this->XTAL && tcxoVoltage > 0.0f) {
     state = setTCXO(tcxoVoltage);
     RADIOLIB_ASSERT(state);
   }

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -14,7 +14,7 @@
 // SX126X physical layer properties
 #define RADIOLIB_SX126X_FREQUENCY_STEP_SIZE                     0.9536743164
 #define RADIOLIB_SX126X_MAX_PACKET_LENGTH                       255
-#define RADIOLIB_SX126X_CRYSTAL_FREQ                            32.0
+#define RADIOLIB_SX126X_CRYSTAL_FREQ                            32.0f
 #define RADIOLIB_SX126X_DIV_EXPONENT                            25
 
 // SX126X SPI commands
@@ -201,7 +201,7 @@
 #define RADIOLIB_SX126X_CAL_IMG_863_MHZ_2                       0xDB
 #define RADIOLIB_SX126X_CAL_IMG_902_MHZ_1                       0xE1
 #define RADIOLIB_SX126X_CAL_IMG_902_MHZ_2                       0xE9
-#define RADIOLIB_SX126X_CAL_IMG_FREQ_TRIG_MHZ                   (20.0)
+#define RADIOLIB_SX126X_CAL_IMG_FREQ_TRIG_MHZ                   (20.0f)
 
 //RADIOLIB_SX126X_CMD_SET_PA_CONFIG
 #define RADIOLIB_SX126X_PA_CONFIG_HP_MAX                        0x07

--- a/src/modules/SX127x/SX1272.cpp
+++ b/src/modules/SX127x/SX1272.cpp
@@ -83,7 +83,7 @@ void SX1272::reset() {
 }
 
 int16_t SX1272::setFrequency(float freq) {
-  RADIOLIB_CHECK_RANGE(freq, 860.0, 1020.0, RADIOLIB_ERR_INVALID_FREQUENCY);
+  RADIOLIB_CHECK_RANGE(freq, 860.0f, 1020.0f, RADIOLIB_ERR_INVALID_FREQUENCY);
 
   // set frequency and if successful, save the new setting
   int16_t state = SX127x::setFrequencyRaw(freq);
@@ -102,11 +102,11 @@ int16_t SX1272::setBandwidth(float bw) {
   uint8_t newBandwidth;
 
   // check allowed bandwidth values
-  if(fabsf(bw - 125.0) <= 0.001) {
+  if(fabsf(bw - 125.0f) <= 0.001f) {
     newBandwidth = RADIOLIB_SX1272_BW_125_00_KHZ;
-  } else if(fabsf(bw - 250.0) <= 0.001) {
+  } else if(fabsf(bw - 250.0f) <= 0.001f) {
     newBandwidth = RADIOLIB_SX1272_BW_250_00_KHZ;
-  } else if(fabsf(bw - 500.0) <= 0.001) {
+  } else if(fabsf(bw - 500.0f) <= 0.001f) {
     newBandwidth = RADIOLIB_SX1272_BW_500_00_KHZ;
   } else {
     return(RADIOLIB_ERR_INVALID_BANDWIDTH);
@@ -121,7 +121,7 @@ int16_t SX1272::setBandwidth(float bw) {
     if(this->ldroAuto) {
       float symbolLength = (float)(uint32_t(1) << SX127x::spreadingFactor) / (float)SX127x::bandwidth;
       Module* mod = this->getMod();
-      if(symbolLength >= 16.0) {
+      if(symbolLength >= 16.0f) {
         state = mod->SPIsetRegValue(RADIOLIB_SX127X_REG_MODEM_CONFIG_1, RADIOLIB_SX1272_LOW_DATA_RATE_OPT_ON, 0, 0);
       } else {
         state = mod->SPIsetRegValue(RADIOLIB_SX127X_REG_MODEM_CONFIG_1, RADIOLIB_SX1272_LOW_DATA_RATE_OPT_OFF, 0, 0);
@@ -175,7 +175,7 @@ int16_t SX1272::setSpreadingFactor(uint8_t sf) {
     if(this->ldroAuto) {
       float symbolLength = (float)(uint32_t(1) << SX127x::spreadingFactor) / (float)SX127x::bandwidth;
       Module* mod = this->getMod();
-      if(symbolLength >= 16.0) {
+      if(symbolLength >= 16.0f) {
         state = mod->SPIsetRegValue(RADIOLIB_SX127X_REG_MODEM_CONFIG_1, RADIOLIB_SX1272_LOW_DATA_RATE_OPT_ON, 0, 0);
       } else {
         state = mod->SPIsetRegValue(RADIOLIB_SX127X_REG_MODEM_CONFIG_1, RADIOLIB_SX1272_LOW_DATA_RATE_OPT_OFF, 0, 0);
@@ -258,15 +258,15 @@ int16_t SX1272::checkDataRate(DataRate_t dr) {
   // select interpretation based on active modem
   int16_t modem = getActiveModem();
   if(modem == RADIOLIB_SX127X_FSK_OOK) {
-    RADIOLIB_CHECK_RANGE(dr.fsk.bitRate, 0.5, 300.0, RADIOLIB_ERR_INVALID_BIT_RATE);
-    if(!((dr.fsk.freqDev + dr.fsk.bitRate/2.0 <= 250.0) && (dr.fsk.freqDev <= 200.0))) {
+    RADIOLIB_CHECK_RANGE(dr.fsk.bitRate, 0.5f, 300.0f, RADIOLIB_ERR_INVALID_BIT_RATE);
+    if(!((dr.fsk.freqDev + dr.fsk.bitRate/2.0f <= 250.0f) && (dr.fsk.freqDev <= 200.0f))) {
       return(RADIOLIB_ERR_INVALID_FREQUENCY_DEVIATION);
     }
     return(RADIOLIB_ERR_NONE);
 
   } else if(modem == RADIOLIB_SX127X_LORA) {
     RADIOLIB_CHECK_RANGE(dr.lora.spreadingFactor, 6, 12, RADIOLIB_ERR_INVALID_SPREADING_FACTOR);
-    RADIOLIB_CHECK_RANGE(dr.lora.bandwidth, 100.0, 510.0, RADIOLIB_ERR_INVALID_BANDWIDTH);
+    RADIOLIB_CHECK_RANGE(dr.lora.bandwidth, 100.0f, 510.0f, RADIOLIB_ERR_INVALID_BANDWIDTH);
     RADIOLIB_CHECK_RANGE(dr.lora.codingRate, 5, 8, RADIOLIB_ERR_INVALID_CODING_RATE);
     return(RADIOLIB_ERR_NONE);
   

--- a/src/modules/SX127x/SX1273.cpp
+++ b/src/modules/SX127x/SX1273.cpp
@@ -98,15 +98,15 @@ int16_t SX1273::checkDataRate(DataRate_t dr) {
   // select interpretation based on active modem
   int16_t modem = getActiveModem();
   if(modem == RADIOLIB_SX127X_FSK_OOK) {
-    RADIOLIB_CHECK_RANGE(dr.fsk.bitRate, 0.5, 300.0, RADIOLIB_ERR_INVALID_BIT_RATE);
-    if(!((dr.fsk.freqDev + dr.fsk.bitRate/2.0 <= 250.0) && (dr.fsk.freqDev <= 200.0))) {
+    RADIOLIB_CHECK_RANGE(dr.fsk.bitRate, 0.5f, 300.0f, RADIOLIB_ERR_INVALID_BIT_RATE);
+    if(!((dr.fsk.freqDev + dr.fsk.bitRate/2.0f <= 250.0f) && (dr.fsk.freqDev <= 200.0f))) {
       return(RADIOLIB_ERR_INVALID_FREQUENCY_DEVIATION);
     }
     return(RADIOLIB_ERR_NONE);
 
   } else if(modem == RADIOLIB_SX127X_LORA) {
     RADIOLIB_CHECK_RANGE(dr.lora.spreadingFactor, 6, 9, RADIOLIB_ERR_INVALID_SPREADING_FACTOR);
-    RADIOLIB_CHECK_RANGE(dr.lora.bandwidth, 100.0, 510.0, RADIOLIB_ERR_INVALID_BANDWIDTH);
+    RADIOLIB_CHECK_RANGE(dr.lora.bandwidth, 100.0f, 510.0f, RADIOLIB_ERR_INVALID_BANDWIDTH);
     RADIOLIB_CHECK_RANGE(dr.lora.codingRate, 5, 8, RADIOLIB_ERR_INVALID_CODING_RATE);
     return(RADIOLIB_ERR_NONE);
   

--- a/src/modules/SX127x/SX1276.cpp
+++ b/src/modules/SX127x/SX1276.cpp
@@ -69,7 +69,7 @@ int16_t SX1276::beginFSK(float freq, float br, float freqDev, float rxBw, int8_t
 }
 
 int16_t SX1276::setFrequency(float freq) {
-  RADIOLIB_CHECK_RANGE(freq, 137.0, 1020.0, RADIOLIB_ERR_INVALID_FREQUENCY);
+  RADIOLIB_CHECK_RANGE(freq, 137.0f, 1020.0f, RADIOLIB_ERR_INVALID_FREQUENCY);
 
   // set frequency and if successful, save the new setting
   int16_t state = SX127x::setFrequencyRaw(freq);

--- a/src/modules/SX127x/SX1277.cpp
+++ b/src/modules/SX127x/SX1277.cpp
@@ -69,7 +69,7 @@ int16_t SX1277::beginFSK(float freq, float br, float freqDev, float rxBw, int8_t
 }
 
 int16_t SX1277::setFrequency(float freq) {
-  RADIOLIB_CHECK_RANGE(freq, 137.0, 1020.0, RADIOLIB_ERR_INVALID_FREQUENCY);
+  RADIOLIB_CHECK_RANGE(freq, 137.0f, 1020.0f, RADIOLIB_ERR_INVALID_FREQUENCY);
 
   // set frequency and if successful, save the new setting
   int16_t state = SX127x::setFrequencyRaw(freq);
@@ -140,15 +140,15 @@ int16_t SX1277::checkDataRate(DataRate_t dr) {
   // select interpretation based on active modem
   int16_t modem = getActiveModem();
   if(modem == RADIOLIB_SX127X_FSK_OOK) {
-    RADIOLIB_CHECK_RANGE(dr.fsk.bitRate, 0.5, 300.0, RADIOLIB_ERR_INVALID_BIT_RATE);
-    if(!((dr.fsk.freqDev + dr.fsk.bitRate/2.0 <= 250.0) && (dr.fsk.freqDev <= 200.0))) {
+    RADIOLIB_CHECK_RANGE(dr.fsk.bitRate, 0.5f, 300.0f, RADIOLIB_ERR_INVALID_BIT_RATE);
+    if(!((dr.fsk.freqDev + dr.fsk.bitRate/2.0f <= 250.0f) && (dr.fsk.freqDev <= 200.0f))) {
       return(RADIOLIB_ERR_INVALID_FREQUENCY_DEVIATION);
     }
     return(RADIOLIB_ERR_NONE);
 
   } else if(modem == RADIOLIB_SX127X_LORA) {
     RADIOLIB_CHECK_RANGE(dr.lora.spreadingFactor, 6, 9, RADIOLIB_ERR_INVALID_SPREADING_FACTOR);
-    RADIOLIB_CHECK_RANGE(dr.lora.bandwidth, 0.0, 510.0, RADIOLIB_ERR_INVALID_BANDWIDTH);
+    RADIOLIB_CHECK_RANGE(dr.lora.bandwidth, 0.0f, 510.0f, RADIOLIB_ERR_INVALID_BANDWIDTH);
     RADIOLIB_CHECK_RANGE(dr.lora.codingRate, 5, 8, RADIOLIB_ERR_INVALID_CODING_RATE);
     return(RADIOLIB_ERR_NONE);
   

--- a/src/modules/SX127x/SX1278.cpp
+++ b/src/modules/SX127x/SX1278.cpp
@@ -83,7 +83,7 @@ void SX1278::reset() {
 }
 
 int16_t SX1278::setFrequency(float freq) {
-  RADIOLIB_CHECK_RANGE(freq, 137.0, 525.0, RADIOLIB_ERR_INVALID_FREQUENCY);
+  RADIOLIB_CHECK_RANGE(freq, 137.0f, 525.0f, RADIOLIB_ERR_INVALID_FREQUENCY);
 
   // set frequency and if successful, save the new setting
   int16_t state = SX127x::setFrequencyRaw(freq);
@@ -102,25 +102,25 @@ int16_t SX1278::setBandwidth(float bw) {
   uint8_t newBandwidth;
 
   // check allowed bandwidth values
-  if(fabsf(bw - 7.8) <= 0.001) {
+  if(fabsf(bw - 7.8f) <= 0.001f) {
     newBandwidth = RADIOLIB_SX1278_BW_7_80_KHZ;
-  } else if(fabsf(bw - 10.4) <= 0.001) {
+  } else if(fabsf(bw - 10.4f) <= 0.001f) {
     newBandwidth = RADIOLIB_SX1278_BW_10_40_KHZ;
-  } else if(fabsf(bw - 15.6) <= 0.001) {
+  } else if(fabsf(bw - 15.6f) <= 0.001f) {
     newBandwidth = RADIOLIB_SX1278_BW_15_60_KHZ;
-  } else if(fabsf(bw - 20.8) <= 0.001) {
+  } else if(fabsf(bw - 20.8f) <= 0.001f) {
     newBandwidth = RADIOLIB_SX1278_BW_20_80_KHZ;
-  } else if(fabsf(bw - 31.25) <= 0.001) {
+  } else if(fabsf(bw - 31.25f) <= 0.001f) {
     newBandwidth = RADIOLIB_SX1278_BW_31_25_KHZ;
-  } else if(fabsf(bw - 41.7) <= 0.001) {
+  } else if(fabsf(bw - 41.7f) <= 0.001f) {
     newBandwidth = RADIOLIB_SX1278_BW_41_70_KHZ;
-  } else if(fabsf(bw - 62.5) <= 0.001) {
+  } else if(fabsf(bw - 62.5f) <= 0.001f) {
     newBandwidth = RADIOLIB_SX1278_BW_62_50_KHZ;
-  } else if(fabsf(bw - 125.0) <= 0.001) {
+  } else if(fabsf(bw - 125.0f) <= 0.001f) {
     newBandwidth = RADIOLIB_SX1278_BW_125_00_KHZ;
-  } else if(fabsf(bw - 250.0) <= 0.001) {
+  } else if(fabsf(bw - 250.0f) <= 0.001f) {
     newBandwidth = RADIOLIB_SX1278_BW_250_00_KHZ;
-  } else if(fabsf(bw - 500.0) <= 0.001) {
+  } else if(fabsf(bw - 500.0f) <= 0.001f) {
     newBandwidth = RADIOLIB_SX1278_BW_500_00_KHZ;
   } else {
     return(RADIOLIB_ERR_INVALID_BANDWIDTH);
@@ -135,7 +135,7 @@ int16_t SX1278::setBandwidth(float bw) {
     if(this->ldroAuto) {
       float symbolLength = (float)(uint32_t(1) << SX127x::spreadingFactor) / (float)SX127x::bandwidth;
       Module* mod = this->getMod();
-      if(symbolLength >= 16.0) {
+      if(symbolLength >= 16.0f) {
         state = mod->SPIsetRegValue(RADIOLIB_SX1278_REG_MODEM_CONFIG_3, RADIOLIB_SX1278_LOW_DATA_RATE_OPT_ON, 3, 3);
       } else {
         state = mod->SPIsetRegValue(RADIOLIB_SX1278_REG_MODEM_CONFIG_3, RADIOLIB_SX1278_LOW_DATA_RATE_OPT_OFF, 3, 3);
@@ -189,7 +189,7 @@ int16_t SX1278::setSpreadingFactor(uint8_t sf) {
     if(this->ldroAuto) {
       float symbolLength = (float)(uint32_t(1) << SX127x::spreadingFactor) / (float)SX127x::bandwidth;
       Module* mod = this->getMod();
-      if(symbolLength >= 16.0) {
+      if(symbolLength >= 16.0f) {
         state = mod->SPIsetRegValue(RADIOLIB_SX1278_REG_MODEM_CONFIG_3, RADIOLIB_SX1278_LOW_DATA_RATE_OPT_ON, 3, 3);
       } else {
         state = mod->SPIsetRegValue(RADIOLIB_SX1278_REG_MODEM_CONFIG_3, RADIOLIB_SX1278_LOW_DATA_RATE_OPT_OFF, 3, 3);
@@ -272,15 +272,15 @@ int16_t SX1278::checkDataRate(DataRate_t dr) {
   // select interpretation based on active modem
   int16_t modem = getActiveModem();
   if(modem == RADIOLIB_SX127X_FSK_OOK) {
-    RADIOLIB_CHECK_RANGE(dr.fsk.bitRate, 0.5, 300.0, RADIOLIB_ERR_INVALID_BIT_RATE);
-    if(!((dr.fsk.freqDev + dr.fsk.bitRate/2.0 <= 250.0) && (dr.fsk.freqDev <= 200.0))) {
+    RADIOLIB_CHECK_RANGE(dr.fsk.bitRate, 0.5f, 300.0f, RADIOLIB_ERR_INVALID_BIT_RATE);
+    if(!((dr.fsk.freqDev + dr.fsk.bitRate/2.0f <= 250.0f) && (dr.fsk.freqDev <= 200.0f))) {
       return(RADIOLIB_ERR_INVALID_FREQUENCY_DEVIATION);
     }
     return(RADIOLIB_ERR_NONE);
 
   } else if(modem == RADIOLIB_SX127X_LORA) {
     RADIOLIB_CHECK_RANGE(dr.lora.spreadingFactor, 6, 12, RADIOLIB_ERR_INVALID_SPREADING_FACTOR);
-    RADIOLIB_CHECK_RANGE(dr.lora.bandwidth, 0.0, 510.0, RADIOLIB_ERR_INVALID_BANDWIDTH);
+    RADIOLIB_CHECK_RANGE(dr.lora.bandwidth, 0.0f, 510.0f, RADIOLIB_ERR_INVALID_BANDWIDTH);
     RADIOLIB_CHECK_RANGE(dr.lora.codingRate, 5, 8, RADIOLIB_ERR_INVALID_CODING_RATE);
     return(RADIOLIB_ERR_NONE);
   
@@ -476,7 +476,7 @@ float SX1278::getRSSI() {
 
 float SX1278::getRSSI(bool packet, bool skipReceive) {
   int16_t offset = -157;
-  if(frequency < 868.0) {
+  if(frequency < 868.0f) {
     offset = -164;
   }
   return(SX127x::getRSSI(packet, skipReceive, offset));
@@ -606,11 +606,11 @@ void SX1278::errataFix(bool rx) {
   // sensitivity optimization for 500kHz bandwidth
   // see SX1276/77/78 Errata, section 2.1 for details
   Module* mod = this->getMod();
-  if(fabsf(SX127x::bandwidth - 500.0) <= 0.001) {
-    if((frequency >= 862.0) && (frequency <= 1020.0)) {
+  if(fabsf(SX127x::bandwidth - 500.0f) <= 0.001f) {
+    if((frequency >= 862.0f) && (frequency <= 1020.0f)) {
       mod->SPIwriteRegister(0x36, 0x02);
       mod->SPIwriteRegister(0x3a, 0x64);
-    } else if((frequency >= 410.0) && (frequency <= 525.0)) {
+    } else if((frequency >= 410.0f) && (frequency <= 525.0f)) {
       mod->SPIwriteRegister(0x36, 0x02);
       mod->SPIwriteRegister(0x3a, 0x7F);
     }
@@ -622,49 +622,49 @@ void SX1278::errataFix(bool rx) {
   // figure out what we need to set
   uint8_t fixedRegs[3] = { 0x00, 0x00, 0x00 };
   float rxFreq = frequency;
-  if(fabsf(SX127x::bandwidth - 7.8) <= 0.001) {
+  if(fabsf(SX127x::bandwidth - 7.8f) <= 0.001f) {
     fixedRegs[0] = 0b00000000;
     fixedRegs[1] = 0x48;
     fixedRegs[2] = 0x00;
-    rxFreq += 0.00781;
-  } else if(fabsf(SX127x::bandwidth - 10.4) <= 0.001) {
+    rxFreq += 0.00781f;
+  } else if(fabsf(SX127x::bandwidth - 10.4f) <= 0.001f) {
     fixedRegs[0] = 0b00000000;
     fixedRegs[1] = 0x44;
     fixedRegs[2] = 0x00;
-    rxFreq += 0.01042;
-  } else if(fabsf(SX127x::bandwidth - 15.6) <= 0.001) {
+    rxFreq += 0.01042f;
+  } else if(fabsf(SX127x::bandwidth - 15.6f) <= 0.001f) {
     fixedRegs[0] = 0b00000000;
     fixedRegs[1] = 0x44;
     fixedRegs[2] = 0x00;
-    rxFreq += 0.01562;
-  } else if(fabsf(SX127x::bandwidth - 20.8) <= 0.001) {
+    rxFreq += 0.01562f;
+  } else if(fabsf(SX127x::bandwidth - 20.8f) <= 0.001f) {
     fixedRegs[0] = 0b00000000;
     fixedRegs[1] = 0x44;
     fixedRegs[2] = 0x00;
-    rxFreq += 0.02083;
-  } else if(fabsf(SX127x::bandwidth - 31.25) <= 0.001) {
+    rxFreq += 0.02083f;
+  } else if(fabsf(SX127x::bandwidth - 31.25f) <= 0.001f) {
     fixedRegs[0] = 0b00000000;
     fixedRegs[1] = 0x44;
     fixedRegs[2] = 0x00;
-    rxFreq += 0.03125;
-  } else if(fabsf(SX127x::bandwidth - 41.7) <= 0.001) {
+    rxFreq += 0.03125f;
+  } else if(fabsf(SX127x::bandwidth - 41.7f) <= 0.001f) {
     fixedRegs[0] = 0b00000000;
     fixedRegs[1] = 0x44;
     fixedRegs[2] = 0x00;
-    rxFreq += 0.04167;
-  } else if(fabsf(SX127x::bandwidth - 62.5) <= 0.001) {
+    rxFreq += 0.04167f;
+  } else if(fabsf(SX127x::bandwidth - 62.5f) <= 0.001f) {
     fixedRegs[0] = 0b00000000;
     fixedRegs[1] = 0x40;
     fixedRegs[2] = 0x00;
-  } else if(fabsf(SX127x::bandwidth - 125.0) <= 0.001) {
+  } else if(fabsf(SX127x::bandwidth - 125.0f) <= 0.001f) {
     fixedRegs[0] = 0b00000000;
     fixedRegs[1] = 0x40;
     fixedRegs[2] = 0x00;
-  } else if(fabsf(SX127x::bandwidth - 250.0) <= 0.001) {
+  } else if(fabsf(SX127x::bandwidth - 250.0f) <= 0.001f) {
     fixedRegs[0] = 0b00000000;
     fixedRegs[1] = 0x40;
     fixedRegs[2] = 0x00;
-  } else if(fabsf(SX127x::bandwidth - 500.0) <= 0.001) {
+  } else if(fabsf(SX127x::bandwidth - 500.0f) <= 0.001f) {
     fixedRegs[0] = 0b10000000;
     fixedRegs[1] = mod->SPIreadRegister(0x2F);
     fixedRegs[2] = mod->SPIreadRegister(0x30);

--- a/src/modules/SX127x/SX1279.cpp
+++ b/src/modules/SX127x/SX1279.cpp
@@ -69,7 +69,7 @@ int16_t SX1279::beginFSK(float freq, float br, float freqDev, float rxBw, int8_t
 }
 
 int16_t SX1279::setFrequency(float freq) {
-  RADIOLIB_CHECK_RANGE(freq, 137.0, 960.0, RADIOLIB_ERR_INVALID_FREQUENCY);
+  RADIOLIB_CHECK_RANGE(freq, 137.0f, 960.0f, RADIOLIB_ERR_INVALID_FREQUENCY);
 
   // set frequency and if successful, save the new setting
   int16_t state = SX127x::setFrequencyRaw(freq);

--- a/src/modules/SX127x/SX127x.h
+++ b/src/modules/SX127x/SX127x.h
@@ -13,7 +13,7 @@
 #define RADIOLIB_SX127X_FREQUENCY_STEP_SIZE                     61.03515625
 #define RADIOLIB_SX127X_MAX_PACKET_LENGTH                       255
 #define RADIOLIB_SX127X_MAX_PACKET_LENGTH_FSK                   64
-#define RADIOLIB_SX127X_CRYSTAL_FREQ                            32.0
+#define RADIOLIB_SX127X_CRYSTAL_FREQ                            32.0f
 #define RADIOLIB_SX127X_DIV_EXPONENT                            19
 
 // SX127x series common LoRa registers

--- a/src/modules/SX128x/SX1280.cpp
+++ b/src/modules/SX128x/SX1280.cpp
@@ -178,7 +178,7 @@ float SX1280::getRangingResult() {
   // calculate the real result
   uint32_t uraw = ((uint32_t)data[0] << 16) | ((uint32_t)data[1] << 8) | data[2];
   int32_t raw = (uraw & ((1UL << 23) - 1)) | (uraw >> 23 << 31);
-  return((float)raw * 150.0 / (4.096 * this->bandwidthKhz));
+  return((float)raw * 150.0f / (4.096f * this->bandwidthKhz));
 }
 
 #endif

--- a/src/modules/SX128x/SX128x.cpp
+++ b/src/modules/SX128x/SX128x.cpp
@@ -364,7 +364,7 @@ int16_t SX128x::receive(uint8_t* data, size_t len) {
   RADIOLIB_DEBUG_BASIC_PRINTLN("Timeout in %lu ms", timeout);
 
   // start reception
-  uint32_t timeoutValue = (uint32_t)((float)timeout / 15.625);
+  uint32_t timeoutValue = (uint32_t)((float)timeout / 15.625f);
   state = startReceive(timeoutValue);
   RADIOLIB_ASSERT(state);
 
@@ -745,7 +745,7 @@ int16_t SX128x::getChannelScanResult() {
 }
 
 int16_t SX128x::setFrequency(float freq) {
-  RADIOLIB_CHECK_RANGE(freq, 2400.0, 2500.0, RADIOLIB_ERR_INVALID_FREQUENCY);
+  RADIOLIB_CHECK_RANGE(freq, 2400.0f, 2500.0f, RADIOLIB_ERR_INVALID_FREQUENCY);
 
   // calculate raw value
   uint32_t frf = (freq * (uint32_t(1) << RADIOLIB_SX128X_DIV_EXPONENT)) / RADIOLIB_SX128X_CRYSTAL_FREQ;
@@ -757,21 +757,21 @@ int16_t SX128x::setBandwidth(float bw) {
   uint8_t modem = getPacketType();
   if(modem == RADIOLIB_SX128X_PACKET_TYPE_LORA) {
     // check range for LoRa
-    RADIOLIB_CHECK_RANGE(bw, 203.125, 1625.0, RADIOLIB_ERR_INVALID_BANDWIDTH);
+    RADIOLIB_CHECK_RANGE(bw, 203.125f, 1625.0f, RADIOLIB_ERR_INVALID_BANDWIDTH);
   } else if(modem == RADIOLIB_SX128X_PACKET_TYPE_RANGING) {
     // check range for ranging
-    RADIOLIB_CHECK_RANGE(bw, 406.25, 1625.0, RADIOLIB_ERR_INVALID_BANDWIDTH);
+    RADIOLIB_CHECK_RANGE(bw, 406.25f, 1625.0f, RADIOLIB_ERR_INVALID_BANDWIDTH);
   } else {
     return(RADIOLIB_ERR_WRONG_MODEM);
   }
 
-  if(fabsf(bw - 203.125) <= 0.001) {
+  if(fabsf(bw - 203.125f) <= 0.001f) {
     this->bandwidth = RADIOLIB_SX128X_LORA_BW_203_125;
-  } else if(fabsf(bw - 406.25) <= 0.001) {
+  } else if(fabsf(bw - 406.25f) <= 0.001f) {
     this->bandwidth = RADIOLIB_SX128X_LORA_BW_406_25;
-  } else if(fabsf(bw - 812.5) <= 0.001) {
+  } else if(fabsf(bw - 812.5f) <= 0.001f) {
     this->bandwidth = RADIOLIB_SX128X_LORA_BW_812_50;
-  } else if(fabsf(bw - 1625.0) <= 0.001) {
+  } else if(fabsf(bw - 1625.0f) <= 0.001f) {
     this->bandwidth = RADIOLIB_SX128X_LORA_BW_1625_00;
   } else {
     return(RADIOLIB_ERR_INVALID_BANDWIDTH);
@@ -1020,21 +1020,21 @@ int16_t SX128x::setFrequencyDeviation(float freqDev) {
 
   // set frequency deviation to lowest available setting (required for digimodes)
   float newFreqDev = freqDev;
-  if(freqDev < 0.0) {
-    newFreqDev = 62.5;
+  if(freqDev < 0.0f) {
+    newFreqDev = 62.5f;
   }
 
-  RADIOLIB_CHECK_RANGE(newFreqDev, 62.5, 1000.0, RADIOLIB_ERR_INVALID_FREQUENCY_DEVIATION);
+  RADIOLIB_CHECK_RANGE(newFreqDev, 62.5f, 1000.0f, RADIOLIB_ERR_INVALID_FREQUENCY_DEVIATION);
 
   // override for the lowest possible frequency deviation - required for some PhysicalLayer protocols
-  if(newFreqDev == 0.0) {
+  if(newFreqDev == 0.0f) {
     this->modIndex = RADIOLIB_SX128X_BLE_GFSK_MOD_IND_0_35;
     this->bitRate = RADIOLIB_SX128X_BLE_GFSK_BR_0_125_BW_0_3;
     return(setModulationParams(this->bitRate, this->modIndex, this->shaping));
   }
 
   // update modulation parameters
-  uint8_t modInd = (uint8_t)((8.0 * (newFreqDev / (float)this->bitRateKbps)) - 1.0);
+  uint8_t modInd = (uint8_t)((8.0f * (newFreqDev / (float)this->bitRateKbps)) - 1.0f);
   if(modInd > RADIOLIB_SX128X_BLE_GFSK_MOD_IND_4_00) {
     return(RADIOLIB_ERR_INVALID_MODULATION_PARAMETERS);
   }
@@ -1293,7 +1293,7 @@ float SX128x::getRSSI() {
     uint8_t rssiSync = packetStatus[0];
     float rssiMeasured = -1.0 * rssiSync/2.0;
     float snr = getSNR();
-    if(snr <= 0.0) {
+    if(snr <= 0.0f) {
       return(rssiMeasured - snr);
     } else {
       return(rssiMeasured);
@@ -1310,7 +1310,7 @@ float SX128x::getRSSI(bool packet) {
         // get instantaneous RSSI value
         uint8_t data[3] = {0, 0, 0}; // RssiInst, Status, RFU
         this->mod->SPIreadStream(RADIOLIB_SX128X_CMD_GET_RSSI_INST, data, 3);
-        return ((float)data[0] / (-2.0));
+        return ((float)data[0] / (-2.0f));
     } else {
         return this->getRSSI();
     }
@@ -1332,7 +1332,7 @@ float SX128x::getSNR() {
   if(snr < 128) {
     return(snr/4.0);
   } else {
-    return((snr - 256)/4.0);
+    return((snr - 256)/4.0f);
   }
 }
 
@@ -1361,9 +1361,9 @@ float SX128x::getFrequencyError() {
     // frequency error is negative
     efe |= (uint32_t) 0xFFF00000;
     efe = ~efe + 1;
-    error = 1.55 * (float) efe / (1600.0 / (float) this->bandwidthKhz) * -1.0;
+    error = 1.55f * (float) efe / (1600.0f / this->bandwidthKhz) * -1.0f;
   } else {
-    error = 1.55 * (float) efe / (1600.0 / (float) this->bandwidthKhz);
+    error = 1.55f * (float) efe / (1600.0f / this->bandwidthKhz);
   }
 
   return(error);
@@ -1436,7 +1436,7 @@ RadioLibTime_t SX128x::getTimeOnAir(size_t len) {
       uint32_t N_symbolPreamble = (this->preambleLengthLoRa & 0x0F) * (uint32_t(1) << ((this->preambleLengthLoRa & 0xF0) >> 4));
 
       // calculate the number of symbols
-      N_symbol = (float)N_symbolPreamble + coeff1 + 8.0 + ceilf((float)RADIOLIB_MAX((int16_t)(8 * len + N_bitCRC - coeff2 + N_symbolHeader), (int16_t)0) / (float)coeff3) * (float)(this->codingRateLoRa + 4);
+      N_symbol = (float)N_symbolPreamble + coeff1 + 8.0f + ceilf((float)RADIOLIB_MAX((int16_t)(8 * len + N_bitCRC - coeff2 + N_symbolHeader), (int16_t)0) / (float)coeff3) * (float)(this->codingRateLoRa + 4);
 
     } else {
       // long interleaving - abandon hope all ye who enter here
@@ -1445,7 +1445,7 @@ RadioLibTime_t SX128x::getTimeOnAir(size_t len) {
     }
 
     // get time-on-air in us
-    return(((uint32_t(1) << sf) / this->bandwidthKhz) * N_symbol * 1000.0);
+    return(((uint32_t(1) << sf) / this->bandwidthKhz) * N_symbol * 1000.0f);
 
   } else {
     return(((uint32_t)len * 8 * 1000) / this->bitRateKbps);

--- a/src/modules/SX128x/SX128x.h
+++ b/src/modules/SX128x/SX128x.h
@@ -12,7 +12,7 @@
 // SX128X physical layer properties
 #define RADIOLIB_SX128X_FREQUENCY_STEP_SIZE                     198.3642578
 #define RADIOLIB_SX128X_MAX_PACKET_LENGTH                       255
-#define RADIOLIB_SX128X_CRYSTAL_FREQ                            52.0
+#define RADIOLIB_SX128X_CRYSTAL_FREQ                            52.0f
 #define RADIOLIB_SX128X_DIV_EXPONENT                            18
 
 // SX128X SPI commands

--- a/src/modules/Si443x/Si4430.cpp
+++ b/src/modules/Si443x/Si4430.cpp
@@ -22,7 +22,7 @@ int16_t Si4430::begin(float freq, float br, float freqDev, float rxBw, int8_t po
 }
 
 int16_t Si4430::setFrequency(float freq) {
-  RADIOLIB_CHECK_RANGE(freq, 900.0, 960.0, RADIOLIB_ERR_INVALID_FREQUENCY);
+  RADIOLIB_CHECK_RANGE(freq, 900.0f, 960.0f, RADIOLIB_ERR_INVALID_FREQUENCY);
 
   // set frequency
   return(Si443x::setFrequencyRaw(freq));

--- a/src/modules/Si443x/Si4432.cpp
+++ b/src/modules/Si443x/Si4432.cpp
@@ -22,7 +22,7 @@ int16_t Si4432::begin(float freq, float br, float freqDev, float rxBw, int8_t po
 }
 
 int16_t Si4432::setFrequency(float freq) {
-  RADIOLIB_CHECK_RANGE(freq, 240.0, 930.0, RADIOLIB_ERR_INVALID_FREQUENCY);
+  RADIOLIB_CHECK_RANGE(freq, 240.0f, 930.0f, RADIOLIB_ERR_INVALID_FREQUENCY);
 
   // set frequency
   return(Si443x::setFrequencyRaw(freq));

--- a/src/modules/Si443x/Si443x.cpp
+++ b/src/modules/Si443x/Si443x.cpp
@@ -94,7 +94,7 @@ int16_t Si443x::transmit(const uint8_t* data, size_t len, uint8_t addr) {
 
 int16_t Si443x::receive(uint8_t* data, size_t len) {
   // calculate timeout (500 ms + 400 full 64-byte packets at current bit rate)
-  RadioLibTime_t timeout = 500 + (1.0/(this->bitRate))*(RADIOLIB_SI443X_MAX_PACKET_LENGTH*400.0);
+  RadioLibTime_t timeout = 500 + (1.0f/(this->bitRate))*(RADIOLIB_SI443X_MAX_PACKET_LENGTH*400.0f);
 
   // start reception
   int16_t state = startReceive();
@@ -153,7 +153,7 @@ int16_t Si443x::transmitDirect(uint32_t frf) {
     // check high/low band
     uint8_t bandSelect = RADIOLIB_SI443X_BAND_SELECT_LOW;
     uint8_t freqBand = (newFreq / 10) - 24;
-    if(newFreq >= 480.0) {
+    if(newFreq >= 480.0f) {
       bandSelect = RADIOLIB_SI443X_BAND_SELECT_HIGH;
       freqBand = (newFreq / 20) - 24;
     }
@@ -343,19 +343,19 @@ int16_t Si443x::readData(uint8_t* data, size_t len) {
 }
 
 int16_t Si443x::setBitRate(float br) {
-  RADIOLIB_CHECK_RANGE(br, 0.123, 256.0, RADIOLIB_ERR_INVALID_BIT_RATE);
+  RADIOLIB_CHECK_RANGE(br, 0.123f, 256.0f, RADIOLIB_ERR_INVALID_BIT_RATE);
 
   // check high data rate
   uint8_t dataRateMode = RADIOLIB_SI443X_LOW_DATA_RATE_MODE;
   uint8_t exp = 21;
-  if(br >= 30.0) {
+  if(br >= 30.0f) {
     // bit rate above 30 kbps
     dataRateMode = RADIOLIB_SI443X_HIGH_DATA_RATE_MODE;
     exp = 16;
   }
 
   // calculate raw data rate value
-  uint16_t txDr = (br * ((uint32_t)1 << exp)) / 1000.0;
+  uint16_t txDr = (br * ((uint32_t)1 << exp)) / 1000.0f;
 
   // update registers
   int16_t state = this->mod->SPIsetRegValue(RADIOLIB_SI443X_REG_MODULATION_MODE_CONTROL_1, dataRateMode, 5, 5);
@@ -376,14 +376,14 @@ int16_t Si443x::setBitRate(float br) {
 int16_t Si443x::setFrequencyDeviation(float freqDev) {
   // set frequency deviation to lowest available setting (required for digimodes)
   float newFreqDev = freqDev;
-  if(freqDev < 0.0) {
-    newFreqDev = 0.625;
+  if(freqDev < 0.0f) {
+    newFreqDev = 0.625f;
   }
 
-  RADIOLIB_CHECK_RANGE(newFreqDev, 0.625, 320.0, RADIOLIB_ERR_INVALID_FREQUENCY_DEVIATION);
+  RADIOLIB_CHECK_RANGE(newFreqDev, 0.625f, 320.0f, RADIOLIB_ERR_INVALID_FREQUENCY_DEVIATION);
 
   // calculate raw frequency deviation value
-  uint16_t fdev = (uint16_t)(newFreqDev / 0.625);
+  uint16_t fdev = (uint16_t)(newFreqDev / 0.625f);
 
   // update registers
   int16_t state = this->mod->SPIsetRegValue(RADIOLIB_SI443X_REG_MODULATION_MODE_CONTROL_2, (uint8_t)((fdev & 0x0100) >> 6), 2, 2);
@@ -397,7 +397,7 @@ int16_t Si443x::setFrequencyDeviation(float freqDev) {
 }
 
 int16_t Si443x::setRxBandwidth(float rxBw) {
-  RADIOLIB_CHECK_RANGE(rxBw, 2.6, 620.7, RADIOLIB_ERR_INVALID_RX_BANDWIDTH);
+  RADIOLIB_CHECK_RANGE(rxBw, 2.6f, 620.7f, RADIOLIB_ERR_INVALID_RX_BANDWIDTH);
 
   // decide which approximation to use for decimation rate and filter tap calculation
   uint8_t bypass = RADIOLIB_SI443X_BYPASS_DEC_BY_3_OFF;
@@ -405,84 +405,84 @@ int16_t Si443x::setRxBandwidth(float rxBw) {
   uint8_t filterSet = RADIOLIB_SI443X_IF_FILTER_COEFF_SET;
 
   // this is the "well-behaved" section - can be linearly approximated
-  if((rxBw >= 2.6) && (rxBw <= 4.5)) {
+  if((rxBw >= 2.6f) && (rxBw <= 4.5f)) {
     decRate = 5;
-    filterSet = ((rxBw - 2.1429)/0.3250 + 0.5);
-  } else if((rxBw > 4.5) && (rxBw <= 8.8)) {
+    filterSet = ((rxBw - 2.1429f)/0.3250f + 0.5f);
+  } else if((rxBw > 4.5f) && (rxBw <= 8.8f)) {
     decRate = 4;
-    filterSet = ((rxBw - 3.9857)/0.6643 + 0.5);
-  } else if((rxBw > 8.8) && (rxBw <= 17.5)) {
+    filterSet = ((rxBw - 3.9857f)/0.6643f + 0.5f);
+  } else if((rxBw > 8.8f) && (rxBw <= 17.5f)) {
     decRate = 3;
-    filterSet = ((rxBw - 7.6714)/1.3536 + 0.5);
-  } else if((rxBw > 17.5) && (rxBw <= 34.7)) {
+    filterSet = ((rxBw - 7.6714f)/1.3536f + 0.5f);
+  } else if((rxBw > 17.5f) && (rxBw <= 34.7f)) {
     decRate = 2;
-    filterSet = ((rxBw - 15.2000)/2.6893 + 0.5);
-  } else if((rxBw > 34.7) && (rxBw <= 69.2)) {
+    filterSet = ((rxBw - 15.2000f)/2.6893f + 0.5f);
+  } else if((rxBw > 34.7f) && (rxBw <= 69.2f)) {
     decRate = 1;
-    filterSet = ((rxBw - 30.2430)/5.3679 + 0.5);
-  } else if((rxBw > 69.2) && (rxBw <= 137.9)) {
+    filterSet = ((rxBw - 30.2430f)/5.3679f + 0.5f);
+  } else if((rxBw > 69.2f) && (rxBw <= 137.9f)) {
     decRate = 0;
-    filterSet = ((rxBw - 60.286)/10.7000 + 0.5);
+    filterSet = ((rxBw - 60.286f)/10.7000f + 0.5f);
 
   // this is the "Lord help thee who tread 'ere" section - no way to approximate this mess
   /// \todo float tolerance equality as macro?
-  } else if(fabsf(rxBw - 142.8) <= 0.001) {
+  } else if(fabsf(rxBw - 142.8f) <= 0.001f) {
     bypass = RADIOLIB_SI443X_BYPASS_DEC_BY_3_ON;
     decRate = 1;
     filterSet = 4;
-  } else if(fabsf(rxBw - 167.8) <= 0.001) {
+  } else if(fabsf(rxBw - 167.8f) <= 0.001f) {
     bypass = RADIOLIB_SI443X_BYPASS_DEC_BY_3_ON;
     decRate = 1;
     filterSet = 5;
-  } else if(fabsf(rxBw - 181.1) <= 0.001) {
+  } else if(fabsf(rxBw - 181.1f) <= 0.001f) {
     bypass = RADIOLIB_SI443X_BYPASS_DEC_BY_3_ON;
     decRate = 1;
     filterSet = 6;
-  } else if(fabsf(rxBw - 191.5) <= 0.001) {
+  } else if(fabsf(rxBw - 191.5f) <= 0.001f) {
     bypass = RADIOLIB_SI443X_BYPASS_DEC_BY_3_ON;
     decRate = 0;
     filterSet = 15;
-  } else if(fabsf(rxBw - 225.1) <= 0.001) {
+  } else if(fabsf(rxBw - 225.1f) <= 0.001f) {
     bypass = RADIOLIB_SI443X_BYPASS_DEC_BY_3_ON;
     decRate = 0;
     filterSet = 1;
-  } else if(fabsf(rxBw - 248.8) <= 0.001) {
+  } else if(fabsf(rxBw - 248.8f) <= 0.001f) {
     bypass = RADIOLIB_SI443X_BYPASS_DEC_BY_3_ON;
     decRate = 0;
     filterSet = 2;
-  } else if(fabsf(rxBw - 269.3) <= 0.001) {
+  } else if(fabsf(rxBw - 269.3f) <= 0.001f) {
     bypass = RADIOLIB_SI443X_BYPASS_DEC_BY_3_ON;
     decRate = 0;
     filterSet = 3;
-  } else if(fabsf(rxBw - 284.8) <= 0.001) {
+  } else if(fabsf(rxBw - 284.8f) <= 0.001f) {
     bypass = RADIOLIB_SI443X_BYPASS_DEC_BY_3_ON;
     decRate = 0;
     filterSet = 4;
-  } else if(fabsf(rxBw -335.5) <= 0.001) {
+  } else if(fabsf(rxBw -335.5f) <= 0.001f) {
     bypass = RADIOLIB_SI443X_BYPASS_DEC_BY_3_ON;
     decRate = 0;
     filterSet = 8;
-  } else if(fabsf(rxBw - 391.8) <= 0.001) {
+  } else if(fabsf(rxBw - 391.8f) <= 0.001f) {
     bypass = RADIOLIB_SI443X_BYPASS_DEC_BY_3_ON;
     decRate = 0;
     filterSet = 9;
-  } else if(fabsf(rxBw - 420.2) <= 0.001) {
+  } else if(fabsf(rxBw - 420.2f) <= 0.001f) {
     bypass = RADIOLIB_SI443X_BYPASS_DEC_BY_3_ON;
     decRate = 0;
     filterSet = 10;
-  } else if(fabsf(rxBw - 468.4) <= 0.001) {
+  } else if(fabsf(rxBw - 468.4f) <= 0.001f) {
     bypass = RADIOLIB_SI443X_BYPASS_DEC_BY_3_ON;
     decRate = 0;
     filterSet = 11;
-  } else if(fabsf(rxBw - 518.8) <= 0.001) {
+  } else if(fabsf(rxBw - 518.8f) <= 0.001f) {
     bypass = RADIOLIB_SI443X_BYPASS_DEC_BY_3_ON;
     decRate = 0;
     filterSet = 12;
-  } else if(fabsf(rxBw - 577.0) <= 0.001) {
+  } else if(fabsf(rxBw - 577.0f) <= 0.001f) {
     bypass = RADIOLIB_SI443X_BYPASS_DEC_BY_3_ON;
     decRate = 0;
     filterSet = 13;
-  } else if(fabsf(rxBw - 620.7) <= 0.001) {
+  } else if(fabsf(rxBw - 620.7f) <= 0.001f) {
     bypass = RADIOLIB_SI443X_BYPASS_DEC_BY_3_ON;
     decRate = 0;
     filterSet = 14;
@@ -647,7 +647,7 @@ int16_t Si443x::setFrequencyRaw(float newFreq) {
   uint8_t freqBand = (newFreq / 10) - 24;
   uint8_t afcLimiter = 80;
   this->frequency = newFreq;
-  if(newFreq >= 480.0) {
+  if(newFreq >= 480.0f) {
     bandSelect = RADIOLIB_SI443X_BAND_SELECT_HIGH;
     freqBand = (newFreq / 20) - 24;
     afcLimiter = 40;
@@ -757,11 +757,11 @@ int16_t Si443x::updateClockRecovery() {
     ndec = (uint16_t)1 << ndecExp;
   } else {
     ndecExp *= -1;
-    ndec = 1.0/(float)((uint16_t)1 << ndecExp);
+    ndec = 1.0f/(float)((uint16_t)1 << ndecExp);
   }
   float rxOsr = ((float)(500 * (1 + 2*bypass))) / (ndec * this->bitRate * ((float)(1 + manch)));
   uint32_t ncoOff = (this->bitRate * (1 + manch) * ((uint32_t)(1) << (20 + decRate))) / (500 * (1 + 2*bypass));
-  uint16_t crGain = 2 + (((float)(65536.0 * (1 + manch)) * this->bitRate) / (rxOsr * (this->frequencyDev / 0.625)));
+  uint16_t crGain = 2 + (((float)(65536.0f * (1 + manch)) * this->bitRate) / (rxOsr * (this->frequencyDev / 0.625f)));
   uint16_t rxOsr_fixed = (uint16_t)rxOsr;
 
   // print that whole mess

--- a/src/protocols/BellModem/BellModem.cpp
+++ b/src/protocols/BellModem/BellModem.cpp
@@ -43,7 +43,7 @@ int16_t BellClient::begin(const BellModem_t& modem) {
 
 int16_t BellClient::setModem(const BellModem_t& modem) {
   this->modemType = modem;
-  this->toneLen = (1000000.0/(float)this->modemType.baudRate)*this->correction;
+  this->toneLen = (1000000.0f/(float)this->modemType.baudRate)*this->correction;
   return(RADIOLIB_ERR_NONE);
 }
 

--- a/src/protocols/FSK4/FSK4.cpp
+++ b/src/protocols/FSK4/FSK4.cpp
@@ -34,7 +34,7 @@ int16_t FSK4Client::begin(float base, uint32_t shift, uint16_t rate) {
   }
 
   // calculate 24-bit frequency
-  baseFreq = (base * 1000000.0) / phyLayer->getFreqStep();
+  baseFreq = (base * 1000000.0f) / phyLayer->getFreqStep();
 
   // configure for direct mode
   return(phyLayer->startDirect());

--- a/src/protocols/Hellschreiber/Hellschreiber.cpp
+++ b/src/protocols/Hellschreiber/Hellschreiber.cpp
@@ -21,10 +21,10 @@ HellClient::HellClient(AFSKClient* audio) {
 int16_t HellClient::begin(float base, float rate) {
   // calculate 24-bit frequency
   baseFreqHz = base;
-  baseFreq = (base * 1000000.0) / phyLayer->getFreqStep();
+  baseFreq = (base * 1000000.0f) / phyLayer->getFreqStep();
 
   // calculate "pixel" duration
-  pixelDuration = 1000000.0/rate;
+  pixelDuration = 1000000.0f/rate;
 
   // configure for direct mode
   return(phyLayer->startDirect());

--- a/src/protocols/LoRaWAN/LoRaWAN.cpp
+++ b/src/protocols/LoRaWAN/LoRaWAN.cpp
@@ -2112,7 +2112,7 @@ bool LoRaWANNode::execMacCommand(uint8_t cid, uint8_t* optIn, uint8_t lenIn, uin
 
       // check if the frequency is allowed and possible
       if(macFreq >= this->band->freqMin && macFreq <= this->band->freqMax) {
-        if(this->phyLayer->setFrequency((float)macFreq / 10000.0) == RADIOLIB_ERR_NONE) {
+        if(this->phyLayer->setFrequency((float)macFreq / 10000.0f) == RADIOLIB_ERR_NONE) {
           freqAck = 1;
         }
       // otherwise, if frequency is 0, disable the channel which is also a valid option
@@ -2172,7 +2172,7 @@ bool LoRaWANNode::execMacCommand(uint8_t cid, uint8_t* optIn, uint8_t lenIn, uin
       // get the configuration
       uint8_t macChIndex = optIn[0];
       uint32_t macFreq = LoRaWANNode::ntoh<uint32_t>(&optIn[1], 3);
-      RADIOLIB_DEBUG_PROTOCOL_PRINTLN("DlChannelReq: index = %d, freq = %7.3f MHz", macChIndex, macFreq / 10000.0);
+      RADIOLIB_DEBUG_PROTOCOL_PRINTLN("DlChannelReq: index = %d, freq = %7.3f MHz", macChIndex, macFreq / 10000.0f);
       uint8_t freqDlAck = 0;
       uint8_t freqUlAck = 0;
       

--- a/src/protocols/Morse/Morse.cpp
+++ b/src/protocols/Morse/Morse.cpp
@@ -23,7 +23,7 @@ MorseClient::MorseClient(AFSKClient* audio) {
 int16_t MorseClient::begin(float base, uint8_t speed) {
   // calculate 24-bit frequency
   baseFreqHz = base;
-  baseFreq = (base * 1000000.0) / phyLayer->getFreqStep();
+  baseFreq = (base * 1000000.0f) / phyLayer->getFreqStep();
 
   // calculate tone period for decoding
   basePeriod = (1000000.0f/base)/2.0f;

--- a/src/protocols/Pager/Pager.cpp
+++ b/src/protocols/Pager/Pager.cpp
@@ -39,7 +39,7 @@ int16_t PagerClient::begin(float base, uint16_t speed, bool invert, uint16_t shi
 
   // calculate 24-bit frequency
   baseFreq = base;
-  baseFreqRaw = (baseFreq * 1000000.0) / phyLayer->getFreqStep();
+  baseFreqRaw = (baseFreq * 1000000.0f) / phyLayer->getFreqStep();
 
   // calculate module carrier frequency resolution
   uint16_t step = round(phyLayer->getFreqStep());

--- a/src/protocols/RTTY/RTTY.cpp
+++ b/src/protocols/RTTY/RTTY.cpp
@@ -46,7 +46,7 @@ int16_t RTTYClient::begin(float base, uint32_t shift, uint16_t rate, uint8_t enc
   }
 
   // calculate 24-bit frequency
-  baseFreq = (base * 1000000.0) / phyLayer->getFreqStep();
+  baseFreq = (base * 1000000.0f) / phyLayer->getFreqStep();
 
   // configure for direct mode
   return(phyLayer->startDirect());

--- a/src/protocols/SSTV/SSTV.cpp
+++ b/src/protocols/SSTV/SSTV.cpp
@@ -219,7 +219,7 @@ int16_t SSTVClient::begin(float base, const SSTVMode_t& mode) {
   txMode = mode;
 
   // calculate 24-bit frequency
-  baseFreq = (base * 1000000.0) / phyLayer->getFreqStep();
+  baseFreq = (base * 1000000.0f) / phyLayer->getFreqStep();
 
   // configure for direct mode
   return(phyLayer->startDirect());
@@ -345,7 +345,7 @@ void SSTVClient::sendLine(const uint32_t* imgLine) {
           case(tone_t::GENERIC):
             break;
         }
-        this->tone(RADIOLIB_SSTV_TONE_BRIGHTNESS_MIN + ((float)color * 3.1372549), len);
+        this->tone(RADIOLIB_SSTV_TONE_BRIGHTNESS_MIN + ((float)color * 3.1372549f), len);
       }
     }
   }


### PR DESCRIPTION
Converted constants from double to float to avoid compiler "warning: implicit conversion from 'float' to 'double'".