### PR TITLE
[LR11x0] Skip frequency range verification

### DIFF
--- a/src/modules/LR11x0/LR1120.cpp
+++ b/src/modules/LR11x0/LR1120.cpp
@@ -51,13 +51,13 @@ int16_t LR1120::setFrequency(float freq) {
 }
 
 int16_t LR1120::setFrequency(float freq, bool skipCalibration, float band) {
-#if RADIOLIB_CHECK_PARAMS
+  #if RADIOLIB_CHECK_PARAMS
   if(!(((freq >= 150.0) && (freq <= 960.0)) ||
     ((freq >= 1900.0) && (freq <= 2200.0)) ||
     ((freq >= 2400.0) && (freq <= 2500.0)))) {
       return(RADIOLIB_ERR_INVALID_FREQUENCY);
   }
-#endif
+  #endif
 
   // check if we need to recalibrate image
   int16_t state;

--- a/src/modules/LR11x0/LR1120.cpp
+++ b/src/modules/LR11x0/LR1120.cpp
@@ -50,8 +50,8 @@ int16_t LR1120::setFrequency(float freq) {
   return(this->setFrequency(freq, false));
 }
 
-int16_t LR1120::setFrequency(float freq, bool skipCalibration, float band) {
-  if(!(((freq >= 150.0) && (freq <= 960.0)) ||
+int16_t LR1120::setFrequency(float freq, bool skipCalibration, float band, bool skipRfValidation) {
+  if(!skipRfValidation && !(((freq >= 150.0) && (freq <= 960.0)) ||
     ((freq >= 1900.0) && (freq <= 2200.0)) ||
     ((freq >= 2400.0) && (freq <= 2500.0)))) {
       return(RADIOLIB_ERR_INVALID_FREQUENCY);

--- a/src/modules/LR11x0/LR1120.cpp
+++ b/src/modules/LR11x0/LR1120.cpp
@@ -50,12 +50,14 @@ int16_t LR1120::setFrequency(float freq) {
   return(this->setFrequency(freq, false));
 }
 
-int16_t LR1120::setFrequency(float freq, bool skipCalibration, float band, bool skipRfValidation) {
-  if(!skipRfValidation && !(((freq >= 150.0) && (freq <= 960.0)) ||
+int16_t LR1120::setFrequency(float freq, bool skipCalibration, float band) {
+#if RADIOLIB_CHECK_PARAMS
+  if(!(((freq >= 150.0) && (freq <= 960.0)) ||
     ((freq >= 1900.0) && (freq <= 2200.0)) ||
     ((freq >= 2400.0) && (freq <= 2500.0)))) {
       return(RADIOLIB_ERR_INVALID_FREQUENCY);
   }
+#endif
 
   // check if we need to recalibrate image
   int16_t state;

--- a/src/modules/LR11x0/LR1120.h
+++ b/src/modules/LR11x0/LR1120.h
@@ -93,10 +93,9 @@ class LR1120: public LR11x0 {
       \param band Half bandwidth for image calibration. For example,
       if carrier is 434 MHz and band is set to 4 MHz, then the image will be calibrate
       for band 430 - 438 MHz. Unused if calibrate is set to false, defaults to 4 MHz
-      \param skipRfValidation Skip frequency range validation 
       \returns \ref status_codes
     */
-    int16_t setFrequency(float freq, bool skipCalibration, float band = 4, bool skipRfValidation = false);
+    int16_t setFrequency(float freq, bool skipCalibration, float band = 4);
 
     /*!
       \brief Sets output power. Allowed values are in range from -9 to 22 dBm (high-power PA) or -17 to 14 dBm (low-power PA).

--- a/src/modules/LR11x0/LR1120.h
+++ b/src/modules/LR11x0/LR1120.h
@@ -93,9 +93,10 @@ class LR1120: public LR11x0 {
       \param band Half bandwidth for image calibration. For example,
       if carrier is 434 MHz and band is set to 4 MHz, then the image will be calibrate
       for band 430 - 438 MHz. Unused if calibrate is set to false, defaults to 4 MHz
+      \param skipRfValidation Skip frequency range validation 
       \returns \ref status_codes
     */
-    int16_t setFrequency(float freq, bool skipCalibration, float band = 4);
+    int16_t setFrequency(float freq, bool skipCalibration, float band = 4, bool skipRfValidation = false);
 
     /*!
       \brief Sets output power. Allowed values are in range from -9 to 22 dBm (high-power PA) or -17 to 14 dBm (low-power PA).


### PR DESCRIPTION
LR1120 can set the frequency of the documented range. So, allowing another frequency was tested with the LR1121 Lyligo board, which works. It doesn't impact any other code, just an additional feature. Thanks!

## Pull request template
Thank you for taking the time to contribute to RadioLib development!
To keep this library organized, please follow these rules.

1. Make sure the the code in your PR is tested and that you understand all its impacts.
2. Ensure that all CI actions pass - PRs with failed CI will not be merged. CI actions run automatically for every commit pushed to the PR and test the following:
  a. Compilation for Arduino, ESP-IDF and on Raspberry Pi
  b. Runtime test on Raspberry Pi
  c. GitHub CodeQL check
  d. Cppcheck static code scan
3. Follow code style guidelines in [CONTRIBUTING.md](https://github.com/jgromes/RadioLib/blob/master/CONTRIBUTING.md)
4. Heads up - all PRs undergo review, during which you may be asked to correct or change some things. The purpose of this review is to keep regressions and bugs at the minimum, and to keep consistent coding style. Please take them as constructive criticism from people who may have a different point-of-view than you do.

After addressing/accepting the points above, delete the contents of this template and replace it with text explaining what is the goal of your PR, why you want to add it to the upstream and what are the foreseen impacts. Once again, thank you for taking the time to contribute!
