### PR TITLE
[LR11XX] Add missing override specifiers

### DIFF
--- a/src/modules/LR11x0/LR1110.h
+++ b/src/modules/LR11x0/LR1110.h
@@ -105,7 +105,7 @@ class LR1110: public LR11x0 {
       based on configured output power, preferring the low-power PA. If set to true, only high-power PA will be used.
       \returns \ref status_codes
     */
-    int16_t setOutputPower(int8_t power, bool forceHighPower);
+    int16_t setOutputPower(int8_t power, bool forceHighPower) override;
 
     /*!
       \brief Check if output power is configurable.
@@ -124,7 +124,7 @@ class LR1110: public LR11x0 {
       based on configured output power, preferring the low-power PA. If set to true, only high-power PA will be used.
       \returns \ref status_codes
     */
-    int16_t checkOutputPower(int8_t power, int8_t* clipped, bool forceHighPower);
+    int16_t checkOutputPower(int8_t power, int8_t* clipped, bool forceHighPower) override;
 
     /*!
       \brief Set modem for the radio to use. Will perform full reset and reconfigure the radio

--- a/src/modules/LR11x0/LR1120.h
+++ b/src/modules/LR11x0/LR1120.h
@@ -114,7 +114,7 @@ class LR1120: public LR11x0 {
       Ignored when operating in 2.4 GHz band.
       \returns \ref status_codes
     */
-    int16_t setOutputPower(int8_t power, bool forceHighPower);
+    int16_t setOutputPower(int8_t power, bool forceHighPower) override;
 
     /*!
       \brief Check if output power is configurable.
@@ -134,7 +134,7 @@ class LR1120: public LR11x0 {
       Ignored when operating in 2.4 GHz band.
       \returns \ref status_codes
     */
-    int16_t checkOutputPower(int8_t power, int8_t* clipped, bool forceHighPower);
+    int16_t checkOutputPower(int8_t power, int8_t* clipped, bool forceHighPower) override;
 
     /*!
       \brief Set modem for the radio to use. Will perform full reset and reconfigure the radio

--- a/src/modules/SX127x/SX1272.h
+++ b/src/modules/SX127x/SX1272.h
@@ -204,7 +204,7 @@ class SX1272: public SX127x {
       \param useRfo Whether to use the RFO (true) or the PA_BOOST (false) pin for the RF output.
       \returns \ref status_codes
     */
-    int16_t setOutputPower(int8_t power, bool useRfo);
+    int16_t setOutputPower(int8_t power, bool useRfo) override;
 
     /*!
       \brief Check if output power is configurable.
@@ -222,7 +222,7 @@ class SX1272: public SX127x {
       \param useRfo Whether to use the RFO (true) or the PA_BOOST (false) pin for the RF output.
       \returns \ref status_codes
     */
-    int16_t checkOutputPower(int8_t power, int8_t* clipped, bool useRfo);
+    int16_t checkOutputPower(int8_t power, int8_t* clipped, bool useRfo) override;
 
     /*!
       \brief Sets gain of receiver LNA (low-noise amplifier). Can be set to any integer in range 1 to 6 where 1 is the highest gain.

--- a/src/modules/SX127x/SX1278.h
+++ b/src/modules/SX127x/SX1278.h
@@ -216,7 +216,7 @@ class SX1278: public SX127x {
       \param useRfo Whether to use the RFO (true) or the PA_BOOST (false) pin for the RF output.
       \returns \ref status_codes
     */
-    int16_t setOutputPower(int8_t power, bool useRfo);
+    int16_t setOutputPower(int8_t power, bool useRfo) override;
 
     /*!
       \brief Check if output power is configurable.
@@ -234,7 +234,7 @@ class SX1278: public SX127x {
       \param useRfo Whether to use the RFO (true) or the PA_BOOST (false) pin for the RF output.
       \returns \ref status_codes
     */
-    int16_t checkOutputPower(int8_t power, int8_t* clipped, bool useRfo);
+    int16_t checkOutputPower(int8_t power, int8_t* clipped, bool useRfo) override;
 
     /*!
       \brief Sets gain of receiver LNA (low-noise amplifier). Can be set to any integer in range 1 to 6 where 1 is the highest gain.

--- a/src/protocols/PhysicalLayer/PhysicalLayer.cpp
+++ b/src/protocols/PhysicalLayer/PhysicalLayer.cpp
@@ -253,9 +253,22 @@ int16_t PhysicalLayer::setOutputPower(int8_t power) {
   return(RADIOLIB_ERR_UNSUPPORTED);
 }
 
+int16_t PhysicalLayer::setOutputPower(int8_t power, bool forceHighPower) {
+  (void)power;
+  (void)forceHighPower;
+  return(RADIOLIB_ERR_UNSUPPORTED);
+}
+
 int16_t PhysicalLayer::checkOutputPower(int8_t power, int8_t* clipped) {
   (void)power;
   (void)clipped;
+  return(RADIOLIB_ERR_UNSUPPORTED);
+}
+
+int16_t PhysicalLayer::checkOutputPower(int8_t power, int8_t* clipped, bool forceHighPower) {
+  (void)power;
+  (void)clipped;
+  (void)forceHighPower;
   return(RADIOLIB_ERR_UNSUPPORTED);
 }
 

--- a/src/protocols/PhysicalLayer/PhysicalLayer.h
+++ b/src/protocols/PhysicalLayer/PhysicalLayer.h
@@ -372,6 +372,7 @@ class PhysicalLayer {
       \returns \ref status_codes
     */
     virtual int16_t setOutputPower(int8_t power);
+    virtual int16_t setOutputPower(int8_t power, bool forceHighPower);
 
     /*!
       \brief Check if output power is configurable. Must be implemented in module class if the module supports it.
@@ -380,6 +381,7 @@ class PhysicalLayer {
       \returns \ref status_codes
     */
     virtual int16_t checkOutputPower(int8_t power, int8_t* clipped);
+    virtual int16_t checkOutputPower(int8_t power, int8_t* clipped, bool forceHighPower);
 
     /*!
       \brief Set sync word. Must be implemented in module class if the module supports it.


### PR DESCRIPTION
Build of an MCVE sketch like that:

```
#include <RadioLib.h>

Module *mod;
LR11x0  *radio_semtech;

void setup()
{
    int probed_radio = 1;

    mod = new Module(RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC);

    switch (probed_radio)
    {
      case 0:
        radio_semtech = new LR1110(mod);
        break;

      case 1:
      default:
        radio_semtech = new LR1121(mod);
        break;
    }

    radio_semtech->begin(125.0, 9, 7, RADIOLIB_LR11X0_LORA_SYNC_WORD_PRIVATE, 8, 1.6);
    radio_semtech->setOutputPower(0, true);
}

void loop()
{

}
```

causes a failure:

```
/tmp/7/hp/hp.ino: In function 'void setup()':
hp:27:42: error: no matching function for call to 'LR11x0::setOutputPower(int, bool)'
     radio_semtech->setOutputPower(0, true);
                                          ^
In file included from /home/user/Arduino/libraries/RadioLib/src/modules/CC1101/CC1101.h:7,
                 from /home/user/Arduino/libraries/RadioLib/src/RadioLib.h:69,
                 from /tmp/7/hp/hp.ino:1:
/home/user/Arduino/libraries/RadioLib/src/modules/CC1101/../../protocols/PhysicalLayer/PhysicalLayer.h:374:21: note: candidate: 'virtual int16_t PhysicalLayer::setOutputPower(int8_t)'
     virtual int16_t setOutputPower(int8_t power);
                     ^~~~~~~~~~~~~~
/home/user/Arduino/libraries/RadioLib/src/modules/CC1101/../../protocols/PhysicalLayer/PhysicalLayer.h:374:21: note:   candidate expects 1 argument, 2 provided
```

This PR is intended to fix the issue.
