### PR TITLE
[PHY] Staged modes

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -343,6 +343,8 @@ setDataRate	KEYWORD2
 checkDataRate	KEYWORD2
 setModem	KEYWORD2
 getModem	KEYWORD2
+stageMode	KEYWORD2
+launchMode	KEYWORD2
 
 # LoRaWAN
 getBufferNonces	KEYWORD2

--- a/src/modules/LR11x0/LR11x0.h
+++ b/src/modules/LR11x0/LR11x0.h
@@ -877,6 +877,7 @@ class LR11x0: public PhysicalLayer {
     using PhysicalLayer::transmit;
     using PhysicalLayer::receive;
     using PhysicalLayer::startTransmit;
+    using PhysicalLayer::startReceive;
     using PhysicalLayer::readData;
 
     /*!
@@ -1074,16 +1075,6 @@ class LR11x0: public PhysicalLayer {
     void clearPacketSentAction() override;
 
     /*!
-      \brief Interrupt-driven binary transmit method.
-      Overloads for string-based transmissions are implemented in PhysicalLayer.
-      \param data Binary data to be sent.
-      \param len Number of bytes to send.
-      \param addr Address to send the data to. Will only be added if address filtering was enabled.
-      \returns \ref status_codes
-    */
-    int16_t startTransmit(const uint8_t* data, size_t len, uint8_t addr = 0) override;
-
-    /*!
       \brief Clean up after transmission is done.
       \returns \ref status_codes
     */
@@ -1096,20 +1087,6 @@ class LR11x0: public PhysicalLayer {
       \returns \ref status_codes
     */
     int16_t startReceive() override;
-
-    /*!
-      \brief Interrupt-driven receive method. IRQ1 will be activated when full packet is received.
-      \param timeout Raw timeout value, expressed as multiples of 1/32.768 kHz (approximately 30.52 us).
-      Defaults to RADIOLIB_LR11X0_RX_TIMEOUT_INF for infinite timeout (Rx continuous mode),
-      set to RADIOLIB_LR11X0_RX_TIMEOUT_NONE for no timeout (Rx single mode).
-      If timeout other than infinite is set, signal will be generated on IRQ1.
-
-      \param irqFlags Sets the IRQ flags that will trigger IRQ1, defaults to RADIOLIB_LR11X0_IRQ_RX_DONE.
-      \param irqMask Only for PhysicalLayer compatibility, not used.
-      \param len Only for PhysicalLayer compatibility, not used.
-      \returns \ref status_codes
-    */
-    int16_t startReceive(uint32_t timeout, uint32_t irqFlags = RADIOLIB_LR11X0_IRQ_RX_DONE, uint32_t irqMask = 0, size_t len = 0);
 
     /*!
       \brief Reads the current IRQ status.
@@ -1622,6 +1599,12 @@ class LR11x0: public PhysicalLayer {
     */
     int16_t calibrateImageRejection(float freqMin, float freqMax);
     
+    /*! \copydoc PhysicalLayer::stageMode */
+    int16_t stageMode(RadioModeType_t mode, RadioModeConfig_t* cfg) override;
+
+    /*! \copydoc PhysicalLayer::launchMode */
+    int16_t launchMode() override;
+    
 #if !RADIOLIB_GODMODE && !RADIOLIB_LOW_LEVEL
   protected:
 #endif
@@ -1630,7 +1613,7 @@ class LR11x0: public PhysicalLayer {
     // LR11x0 SPI command implementations
     int16_t writeRegMem32(uint32_t addr, const uint32_t* data, size_t len);
     int16_t readRegMem32(uint32_t addr, uint32_t* data, size_t len);
-    int16_t writeBuffer8(uint8_t* data, size_t len);
+    int16_t writeBuffer8(const uint8_t* data, size_t len);
     int16_t readBuffer8(uint8_t* data, size_t len, size_t offset);
     int16_t clearRxBuffer(void);
     int16_t writeRegMemMask32(uint32_t addr, uint32_t mask, uint32_t data);
@@ -1829,6 +1812,7 @@ class LR11x0: public PhysicalLayer {
 
     uint8_t wifiScanMode = 0;
     bool gnss = false;
+    uint32_t rxTimeout = 0;
 
     int16_t modSetup(float tcxoVoltage, uint8_t modem);
     static int16_t SPIparseStatus(uint8_t in);

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -519,112 +519,18 @@ void SX126x::clearChannelScanAction() {
 }
 
 int16_t SX126x::startTransmit(const uint8_t* data, size_t len, uint8_t addr) {
-  (void)addr;
-  
-  // check packet length
-  if(len > RADIOLIB_SX126X_MAX_PACKET_LENGTH) {
-    return(RADIOLIB_ERR_PACKET_TOO_LONG);
-  }
-
-  // maximum packet length is decreased by 1 when address filtering is active
-  if((RADIOLIB_SX126X_GFSK_ADDRESS_FILT_OFF != RADIOLIB_SX126X_GFSK_ADDRESS_FILT_OFF) && (len > RADIOLIB_SX126X_MAX_PACKET_LENGTH - 1)) {
-    return(RADIOLIB_ERR_PACKET_TOO_LONG);
-  }
-
-  // set packet Length
-  int16_t state = RADIOLIB_ERR_NONE;
-  uint8_t modem = getPacketType();
-  if(modem == RADIOLIB_SX126X_PACKET_TYPE_LORA) {
-    state = setPacketParams(this->preambleLengthLoRa, this->crcTypeLoRa, len, this->headerType, this->invertIQEnabled);
-  
-  } else if(modem == RADIOLIB_SX126X_PACKET_TYPE_GFSK) {
-    state = setPacketParamsFSK(this->preambleLengthFSK, this->preambleDetLength, this->crcTypeFSK, this->syncWordLength, RADIOLIB_SX126X_GFSK_ADDRESS_FILT_OFF, this->whitening, this->packetType, len);
-
-  } else if(modem != RADIOLIB_SX126X_PACKET_TYPE_LR_FHSS) {
-    return(RADIOLIB_ERR_UNKNOWN);
-  
-  }
-  RADIOLIB_ASSERT(state);
-
-  // set DIO mapping
-  if(modem != RADIOLIB_SX126X_PACKET_TYPE_LR_FHSS) {
-    state = setDioIrqParams(RADIOLIB_SX126X_IRQ_TX_DONE | RADIOLIB_SX126X_IRQ_TIMEOUT, RADIOLIB_SX126X_IRQ_TX_DONE);
-  } else {
-    state = setDioIrqParams(RADIOLIB_SX126X_IRQ_TX_DONE | RADIOLIB_SX126X_IRQ_LR_FHSS_HOP, RADIOLIB_SX126X_IRQ_TX_DONE | RADIOLIB_SX126X_IRQ_LR_FHSS_HOP);
-  }
-  RADIOLIB_ASSERT(state);
-
-  // set buffer pointers
-  state = setBufferBaseAddress();
-  RADIOLIB_ASSERT(state);
-
-  // write packet to buffer
-  if(modem != RADIOLIB_SX126X_PACKET_TYPE_LR_FHSS) {
-    state = writeBuffer(const_cast<uint8_t*>(data), len);
-  
-  } else {
-    // first, reset the LR-FHSS state machine
-    state = resetLRFHSS();
-    RADIOLIB_ASSERT(state);
-
-    // skip hopping for the first 4 - lrFhssHdrCount blocks
-    for(int i = 0; i < 4 - this->lrFhssHdrCount; ++i ) {
-      stepLRFHSS();
+  RadioModeConfig_t cfg = {
+    .transmit = {
+      .data = const_cast<uint8_t*>(data),
+      .len = len,
+      .addr = addr,
     }
+  };
 
-    // in LR-FHSS mode, we need to build the entire packet manually
-    uint8_t frame[RADIOLIB_SX126X_MAX_PACKET_LENGTH] = { 0 };
-    size_t frameLen = 0;
-    this->lrFhssFrameBitsRem = 0;
-    this->lrFhssFrameHopsRem = 0;
-    this->lrFhssHopNum = 0;
-    state = buildLRFHSSPacket(const_cast<uint8_t*>(data), len, frame, &frameLen, &this->lrFhssFrameBitsRem, &this->lrFhssFrameHopsRem);
-    RADIOLIB_ASSERT(state);
-
-    // FIXME check max len for FHSS
-    state = writeBuffer(frame, frameLen);
-    RADIOLIB_ASSERT(state);
-
-    // activate hopping
-    uint8_t hopCfg[] = { RADIOLIB_SX126X_HOPPING_ENABLED, (uint8_t)frameLen, (uint8_t)this->lrFhssFrameHopsRem };
-    state = writeRegister(RADIOLIB_SX126X_REG_HOPPING_ENABLE, hopCfg, 3);
-    RADIOLIB_ASSERT(state);
-
-    // write the initial hopping table
-    uint8_t initHops = this->lrFhssFrameHopsRem;
-    if(initHops > 16) {
-      initHops = 16;
-    };
-    for(size_t i = 0; i < initHops; i++) {
-      // set the hop frequency and symbols
-      state = this->setLRFHSSHop(i);
-      RADIOLIB_ASSERT(state);
-    }
-  
-  }
+  int16_t state = this->stageMode(RADIOLIB_RADIO_MODE_TX, cfg);
   RADIOLIB_ASSERT(state);
 
-  // clear interrupt flags
-  state = clearIrqStatus();
-  RADIOLIB_ASSERT(state);
-
-  // fix sensitivity
-  state = fixSensitivity();
-  RADIOLIB_ASSERT(state);
-
-  // set RF switch (if present)
-  this->mod->setRfSwitchState(this->txMode);
-
-  // start transmission
-  state = setTx(RADIOLIB_SX126X_TX_TIMEOUT_NONE);
-  RADIOLIB_ASSERT(state);
-
-  // wait for BUSY to go low (= PA ramp up done)
-  while(this->mod->hal->digitalRead(this->mod->getGpio())) {
-    this->mod->hal->yield();
-  }
-
-  return(state);
+  return(this->launchMode());
 }
 
 int16_t SX126x::finishTransmit() {
@@ -641,22 +547,18 @@ int16_t SX126x::startReceive() {
 }
 
 int16_t SX126x::startReceive(uint32_t timeout, RadioLibIrqFlags_t irqFlags, RadioLibIrqFlags_t irqMask, size_t len) {
-  // in implicit header mode, use the provided length if it is nonzero
-  // otherwise we trust the user has previously set the payload length manually
-  if((this->headerType == RADIOLIB_SX126X_LORA_HEADER_IMPLICIT) && (len != 0)) {
-    this->implicitLen = len;
-  }
+  RadioModeConfig_t cfg = {
+    .receive = {
+      .timeout = timeout,
+      .irqFlags = irqFlags,
+      .irqMask = irqMask,
+      .len = len,
+    }
+  };
 
-  int16_t state = startReceiveCommon(timeout, irqFlags, irqMask);
+  int16_t state = this->stageMode(RADIOLIB_RADIO_MODE_RX, cfg);
   RADIOLIB_ASSERT(state);
-
-  // set RF switch (if present)
-  this->mod->setRfSwitchState(Module::MODE_RX);
-
-  // set mode to receive
-  state = setRx(timeout);
-
-  return(state);
+  return(this->launchMode());
 }
 
 int16_t SX126x::startReceiveDutyCycle(uint32_t rxPeriod, uint32_t sleepPeriod, RadioLibIrqFlags_t irqFlags, RadioLibIrqFlags_t irqMask) {
@@ -1664,6 +1566,156 @@ int16_t SX126x::getModem(ModemType_t* modem) {
   }
   
   return(RADIOLIB_ERR_WRONG_MODEM);
+}
+
+int16_t SX126x::stageMode(RadioModeType_t mode, RadioModeConfig_t cfg) {
+  int16_t state;
+
+  switch(mode) {
+    case(RADIOLIB_RADIO_MODE_RX): {
+      // in implicit header mode, use the provided length if it is nonzero
+      // otherwise we trust the user has previously set the payload length manually
+      if((this->headerType == RADIOLIB_SX126X_LORA_HEADER_IMPLICIT) && (cfg.receive.len != 0)) {
+        this->implicitLen = cfg.receive.len;
+      }
+
+      state = startReceiveCommon(cfg.receive.timeout, cfg.receive.irqFlags, cfg.receive.irqMask);
+      RADIOLIB_ASSERT(state);
+
+      // set RF switch (if present)
+      this->mod->setRfSwitchState(Module::MODE_RX);
+    } break;
+  
+    case(RADIOLIB_RADIO_MODE_TX): {
+      // check packet length
+      if(cfg.transmit.len > RADIOLIB_SX126X_MAX_PACKET_LENGTH) {
+        return(RADIOLIB_ERR_PACKET_TOO_LONG);
+      }
+
+      // maximum packet length is decreased by 1 when address filtering is active
+      if((RADIOLIB_SX126X_GFSK_ADDRESS_FILT_OFF != RADIOLIB_SX126X_GFSK_ADDRESS_FILT_OFF) && 
+        (cfg.transmit.len > RADIOLIB_SX126X_MAX_PACKET_LENGTH - 1)) {
+        return(RADIOLIB_ERR_PACKET_TOO_LONG);
+      }
+
+      // set packet Length
+      int16_t state = RADIOLIB_ERR_NONE;
+      uint8_t modem = getPacketType();
+      if(modem == RADIOLIB_SX126X_PACKET_TYPE_LORA) {
+        state = setPacketParams(this->preambleLengthLoRa, this->crcTypeLoRa, cfg.transmit.len, this->headerType, this->invertIQEnabled);
+      
+      } else if(modem == RADIOLIB_SX126X_PACKET_TYPE_GFSK) {
+        state = setPacketParamsFSK(this->preambleLengthFSK, this->preambleDetLength, this->crcTypeFSK, this->syncWordLength, RADIOLIB_SX126X_GFSK_ADDRESS_FILT_OFF, this->whitening, this->packetType, cfg.transmit.len);
+
+      } else if(modem != RADIOLIB_SX126X_PACKET_TYPE_LR_FHSS) {
+        return(RADIOLIB_ERR_UNKNOWN);
+      
+      }
+      RADIOLIB_ASSERT(state);
+
+      // set DIO mapping
+      if(modem != RADIOLIB_SX126X_PACKET_TYPE_LR_FHSS) {
+        state = setDioIrqParams(RADIOLIB_SX126X_IRQ_TX_DONE | RADIOLIB_SX126X_IRQ_TIMEOUT, RADIOLIB_SX126X_IRQ_TX_DONE);
+      } else {
+        state = setDioIrqParams(RADIOLIB_SX126X_IRQ_TX_DONE | RADIOLIB_SX126X_IRQ_LR_FHSS_HOP, RADIOLIB_SX126X_IRQ_TX_DONE | RADIOLIB_SX126X_IRQ_LR_FHSS_HOP);
+      }
+      RADIOLIB_ASSERT(state);
+
+      // set buffer pointers
+      state = setBufferBaseAddress();
+      RADIOLIB_ASSERT(state);
+
+      // write packet to buffer
+      if(modem != RADIOLIB_SX126X_PACKET_TYPE_LR_FHSS) {
+        state = writeBuffer(const_cast<uint8_t*>(cfg.transmit.data), cfg.transmit.len);
+      
+      } else {
+        // first, reset the LR-FHSS state machine
+        state = resetLRFHSS();
+        RADIOLIB_ASSERT(state);
+
+        // skip hopping for the first 4 - lrFhssHdrCount blocks
+        for(int i = 0; i < 4 - this->lrFhssHdrCount; ++i ) {
+          stepLRFHSS();
+        }
+
+        // in LR-FHSS mode, we need to build the entire packet manually
+        uint8_t frame[RADIOLIB_SX126X_MAX_PACKET_LENGTH] = { 0 };
+        size_t frameLen = 0;
+        this->lrFhssFrameBitsRem = 0;
+        this->lrFhssFrameHopsRem = 0;
+        this->lrFhssHopNum = 0;
+        state = buildLRFHSSPacket(const_cast<uint8_t*>(cfg.transmit.data), cfg.transmit.len, frame, &frameLen, &this->lrFhssFrameBitsRem, &this->lrFhssFrameHopsRem);
+        RADIOLIB_ASSERT(state);
+
+        // FIXME check max len for FHSS
+        state = writeBuffer(frame, frameLen);
+        RADIOLIB_ASSERT(state);
+
+        // activate hopping
+        uint8_t hopCfg[] = { RADIOLIB_SX126X_HOPPING_ENABLED, (uint8_t)frameLen, (uint8_t)this->lrFhssFrameHopsRem };
+        state = writeRegister(RADIOLIB_SX126X_REG_HOPPING_ENABLE, hopCfg, 3);
+        RADIOLIB_ASSERT(state);
+
+        // write the initial hopping table
+        uint8_t initHops = this->lrFhssFrameHopsRem;
+        if(initHops > 16) {
+          initHops = 16;
+        };
+        for(size_t i = 0; i < initHops; i++) {
+          // set the hop frequency and symbols
+          state = this->setLRFHSSHop(i);
+          RADIOLIB_ASSERT(state);
+        }
+      
+      }
+      RADIOLIB_ASSERT(state);
+
+      // clear interrupt flags
+      state = clearIrqStatus();
+      RADIOLIB_ASSERT(state);
+
+      // fix sensitivity
+      state = fixSensitivity();
+      RADIOLIB_ASSERT(state);
+
+      // set RF switch (if present)
+      this->mod->setRfSwitchState(this->txMode);
+    } break;
+    
+    default:
+      return(RADIOLIB_ERR_UNSUPPORTED);
+  }
+
+  this->stagedMode = mode;
+  this->stagedConfig = cfg;
+
+  return(state);
+}
+
+int16_t SX126x::launchMode() {
+  int16_t state;
+  switch(this->stagedMode) {
+    case(RADIOLIB_RADIO_MODE_RX): {
+      state = setRx(this->stagedConfig.receive.timeout);
+    } break;
+  
+    case(RADIOLIB_RADIO_MODE_TX): {
+      state = setTx(RADIOLIB_SX126X_TX_TIMEOUT_NONE);
+      RADIOLIB_ASSERT(state);
+
+      // wait for BUSY to go low (= PA ramp up done)
+      while(this->mod->hal->digitalRead(this->mod->getGpio())) {
+        this->mod->hal->yield();
+      }
+    } break;
+    
+    default:
+      return(RADIOLIB_ERR_UNSUPPORTED);
+  }
+
+  this->stagedMode = RADIOLIB_RADIO_MODE_NONE;
+  return(state);
 }
 
 #if !RADIOLIB_EXCLUDE_DIRECT_RECEIVE

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -1622,7 +1622,7 @@ int16_t SX126x::stageMode(RadioModeType_t mode, RadioModeConfig_t* cfg) {
         RADIOLIB_ASSERT(state);
 
         // activate hopping
-        uint8_t hopCfg[] = { RADIOLIB_SX126X_HOPPING_ENABLED, (uint8_t)frameLen, (uint8_t)this->lrFhssFrameHopsRem };
+        const uint8_t hopCfg[] = { RADIOLIB_SX126X_HOPPING_ENABLED, (uint8_t)frameLen, (uint8_t)this->lrFhssFrameHopsRem };
         state = writeRegister(RADIOLIB_SX126X_REG_HOPPING_ENABLE, hopCfg, 3);
         RADIOLIB_ASSERT(state);
 

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -478,6 +478,7 @@ class SX126x: public PhysicalLayer {
     using PhysicalLayer::transmit;
     using PhysicalLayer::receive;
     using PhysicalLayer::startTransmit;
+    using PhysicalLayer::startReceive;
     using PhysicalLayer::readData;
 
     /*!
@@ -682,16 +683,6 @@ class SX126x: public PhysicalLayer {
     void clearChannelScanAction() override;
 
     /*!
-      \brief Interrupt-driven binary transmit method.
-      Overloads for string-based transmissions are implemented in PhysicalLayer.
-      \param data Binary data to be sent.
-      \param len Number of bytes to send.
-      \param addr Address to send the data to. Will only be added if address filtering was enabled.
-      \returns \ref status_codes
-    */
-    int16_t startTransmit(const uint8_t* data, size_t len, uint8_t addr = 0) override;
-
-    /*!
       \brief Clean up after transmission is done.
       \returns \ref status_codes
     */
@@ -704,23 +695,6 @@ class SX126x: public PhysicalLayer {
       \returns \ref status_codes
     */
     int16_t startReceive() override;
-
-    /*!
-      \brief Interrupt-driven receive method. DIO1 will be activated when full packet is received.
-      \param timeout Receive mode type and/or raw timeout value, expressed as multiples of 15.625 us.
-      When set to RADIOLIB_SX126X_RX_TIMEOUT_INF, the timeout will be infinite and the device will remain
-      in Rx mode until explicitly commanded to stop (Rx continuous mode).
-      When set to RADIOLIB_SX126X_RX_TIMEOUT_NONE, there will be no timeout and the device will return
-      to standby when a packet is received (Rx single mode).
-      For any other value, timeout will be applied and signal will be generated on DIO1 for conditions
-      defined by irqFlags and irqMask.
-
-      \param irqFlags Sets the IRQ flags, defaults to RX done, RX timeout, CRC error and header error.
-      \param irqMask Sets the mask of IRQ flags that will trigger DIO1, defaults to RX done.
-      \param len Only for PhysicalLayer compatibility, not used.
-      \returns \ref status_codes
-    */
-    int16_t startReceive(uint32_t timeout, RadioLibIrqFlags_t irqFlags = RADIOLIB_IRQ_RX_DEFAULT_FLAGS, RadioLibIrqFlags_t irqMask = RADIOLIB_IRQ_RX_DEFAULT_MASK, size_t len = 0);
 
     /*!
       \brief Interrupt-driven receive method where the device mostly sleeps and periodically wakes to listen.
@@ -1147,7 +1121,7 @@ class SX126x: public PhysicalLayer {
     int16_t getModem(ModemType_t* modem) override;
     
     /*! \copydoc PhysicalLayer::stageMode */
-    int16_t stageMode(RadioModeType_t mode, RadioModeConfig_t cfg) override;
+    int16_t stageMode(RadioModeType_t mode, RadioModeConfig_t* cfg) override;
 
     /*! \copydoc PhysicalLayer::launchMode */
     int16_t launchMode() override;
@@ -1310,6 +1284,7 @@ class SX126x: public PhysicalLayer {
 
     size_t implicitLen = 0;
     uint8_t invertIQEnabled = RADIOLIB_SX126X_LORA_IQ_STANDARD;
+    uint32_t rxTimeout = 0;
 
     // LR-FHSS stuff - there's a lot of it because all the encoding happens in software
     uint8_t lrFhssCr = RADIOLIB_SX126X_LR_FHSS_CR_2_3;

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -1145,6 +1145,12 @@ class SX126x: public PhysicalLayer {
       \returns \ref status_codes
     */
     int16_t getModem(ModemType_t* modem) override;
+    
+    /*! \copydoc PhysicalLayer::stageMode */
+    int16_t stageMode(RadioModeType_t mode, RadioModeConfig_t cfg);
+
+    /*! \copydoc PhysicalLayer::launchMode */
+    int16_t launchMode();
 
     #if !RADIOLIB_EXCLUDE_DIRECT_RECEIVE
     /*!

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -1147,10 +1147,10 @@ class SX126x: public PhysicalLayer {
     int16_t getModem(ModemType_t* modem) override;
     
     /*! \copydoc PhysicalLayer::stageMode */
-    int16_t stageMode(RadioModeType_t mode, RadioModeConfig_t cfg);
+    int16_t stageMode(RadioModeType_t mode, RadioModeConfig_t cfg) override;
 
     /*! \copydoc PhysicalLayer::launchMode */
-    int16_t launchMode();
+    int16_t launchMode() override;
 
     #if !RADIOLIB_EXCLUDE_DIRECT_RECEIVE
     /*!

--- a/src/modules/SX127x/SX127x.h
+++ b/src/modules/SX127x/SX127x.h
@@ -586,6 +586,7 @@ class SX127x: public PhysicalLayer {
     using PhysicalLayer::transmit;
     using PhysicalLayer::receive;
     using PhysicalLayer::startTransmit;
+    using PhysicalLayer::startReceive;
     using PhysicalLayer::readData;
 
     // constructor
@@ -819,19 +820,6 @@ class SX127x: public PhysicalLayer {
       \returns \ref status_codes
     */
     int16_t startReceive() override;
-
-    /*!
-      \brief Interrupt-driven receive method, implemented for compatibility with PhysicalLayer.
-      \param timeout Receive mode type and/or raw timeout value in symbols.
-      When set to 0, the timeout will be infinite and the device will remain
-      in Rx mode until explicitly commanded to stop (Rx continuous mode).
-      When non-zero (maximum 1023), the device will be set to Rx single mode and timeout will be set.
-      \param irqFlags Sets the IRQ flags, defaults to RX done, RX timeout, CRC error and header error. 
-      \param irqMask Sets the mask of IRQ flags that will trigger DIO1, defaults to RX done.
-      \param len Expected length of packet to be received. Required for LoRa spreading factor 6.
-      \returns \ref status_codes
-    */
-    int16_t startReceive(uint32_t timeout, RadioLibIrqFlags_t irqFlags = RADIOLIB_IRQ_RX_DEFAULT_FLAGS, RadioLibIrqFlags_t irqMask = RADIOLIB_IRQ_RX_DEFAULT_MASK, size_t len = 0) override;
 
     /*!
       \brief Reads data that was received after calling startReceive method. When the packet length is not known in advance,
@@ -1163,6 +1151,12 @@ class SX127x: public PhysicalLayer {
       \returns \ref status_codes
     */
     int16_t getModem(ModemType_t* modem) override;
+    
+    /*! \copydoc PhysicalLayer::stageMode */
+    int16_t stageMode(RadioModeType_t mode, RadioModeConfig_t* cfg) override;
+
+    /*! \copydoc PhysicalLayer::launchMode */
+    int16_t launchMode() override;
 
     #if !RADIOLIB_EXCLUDE_DIRECT_RECEIVE
     /*!
@@ -1268,6 +1262,7 @@ class SX127x: public PhysicalLayer {
     float dataRate = 0;
     bool packetLengthQueried = false; // FSK packet length is the first byte in FIFO, length can only be queried once
     uint8_t packetLengthConfig = RADIOLIB_SX127X_PACKET_VARIABLE;
+    uint8_t rxMode = RADIOLIB_SX127X_RXCONTINUOUS;
 
     int16_t config();
     int16_t directMode();

--- a/src/modules/SX127x/SX127x.h
+++ b/src/modules/SX127x/SX127x.h
@@ -800,15 +800,6 @@ class SX127x: public PhysicalLayer {
     bool fifoGet(volatile uint8_t* data, int totalLen, volatile int* rcvLen);
 
     /*!
-      \brief Interrupt-driven binary transmit method. Will start transmitting arbitrary binary data up to 255 bytes long using %LoRa or up to 63 bytes using FSK modem.
-      \param data Binary data that will be transmitted.
-      \param len Length of binary data to transmit (in bytes).
-      \param addr Node address to transmit the packet to. Only used in FSK mode.
-      \returns \ref status_codes
-    */
-    int16_t startTransmit(const uint8_t* data, size_t len, uint8_t addr = 0) override;
-
-    /*!
       \brief Clean up after transmission is done.
       \returns \ref status_codes
     */

--- a/src/modules/SX128x/SX128x.h
+++ b/src/modules/SX128x/SX128x.h
@@ -354,6 +354,7 @@ class SX128x: public PhysicalLayer {
     using PhysicalLayer::transmit;
     using PhysicalLayer::receive;
     using PhysicalLayer::startTransmit;
+    using PhysicalLayer::startReceive;
     using PhysicalLayer::readData;
 
     /*!
@@ -531,16 +532,6 @@ class SX128x: public PhysicalLayer {
     void clearPacketSentAction() override;
 
     /*!
-      \brief Interrupt-driven binary transmit method.
-      Overloads for string-based transmissions are implemented in PhysicalLayer.
-      \param data Binary data to be sent.
-      \param len Number of bytes to send.
-      \param addr Address to send the data to. Unsupported, compatibility only.
-      \returns \ref status_codes
-    */
-    int16_t startTransmit(const uint8_t* data, size_t len, uint8_t addr = 0) override;
-
-    /*!
       \brief Clean up after transmission is done.
       \returns \ref status_codes
     */
@@ -553,20 +544,6 @@ class SX128x: public PhysicalLayer {
       \returns \ref status_codes
     */
     int16_t startReceive() override;
-
-    /*!
-      \brief Interrupt-driven receive method. DIO1 will be activated when full packet is received.
-      \param timeout Raw timeout value, expressed as multiples of 15.625 us. Defaults to
-      RADIOLIB_SX128X_RX_TIMEOUT_INF for infinite timeout (Rx continuous mode),
-      set to RADIOLIB_SX128X_RX_TIMEOUT_NONE for no timeout (Rx single mode).
-      If timeout other than infinite is set, signal will be generated on DIO1.
-
-      \param irqFlags Sets the IRQ flags, defaults to RX done, RX timeout, CRC error and header error. 
-      \param irqMask Sets the mask of IRQ flags that will trigger DIO1, defaults to RX done.
-      \param len Only for PhysicalLayer compatibility, not used.
-      \returns \ref status_codes
-    */
-    int16_t startReceive(uint16_t timeout, RadioLibIrqFlags_t irqFlags = RADIOLIB_IRQ_RX_DEFAULT_FLAGS, RadioLibIrqFlags_t irqMask = RADIOLIB_IRQ_RX_DEFAULT_MASK, size_t len = 0);
 
     /*!
       \brief Reads the current IRQ status.
@@ -863,6 +840,12 @@ class SX128x: public PhysicalLayer {
       \returns \ref status_codes
     */
     int16_t invertIQ(bool enable) override;
+    
+    /*! \copydoc PhysicalLayer::stageMode */
+    int16_t stageMode(RadioModeType_t mode, RadioModeConfig_t* cfg) override;
+
+    /*! \copydoc PhysicalLayer::launchMode */
+    int16_t launchMode() override;
 
     #if !RADIOLIB_EXCLUDE_DIRECT_RECEIVE
     /*!
@@ -920,6 +903,7 @@ class SX128x: public PhysicalLayer {
 
     // common parameters
     uint8_t power = 0;
+    uint32_t rxTimeout = 0;
 
     // cached LoRa parameters
     uint8_t invertIQEnabled = RADIOLIB_SX128X_LORA_IQ_STANDARD;

--- a/src/protocols/LoRaWAN/LoRaWAN.cpp
+++ b/src/protocols/LoRaWAN/LoRaWAN.cpp
@@ -919,7 +919,7 @@ int16_t LoRaWANNode::activateOTAA(uint8_t joinDr, LoRaWANJoinEvent_t *joinEvent)
   modeCfg.transmit.data = joinRequestMsg;
   modeCfg.transmit.len = RADIOLIB_LORAWAN_JOIN_REQUEST_LEN;
   modeCfg.transmit.addr = 0;
-  state = this->phyLayer->stageMode(RADIOLIB_RADIO_MODE_TX, modeCfg);
+  state = this->phyLayer->stageMode(RADIOLIB_RADIO_MODE_TX, &modeCfg);
   RADIOLIB_ASSERT(state);
 
   // if requested, delay until transmitting JoinRequest
@@ -1334,7 +1334,7 @@ int16_t LoRaWANNode::transmitUplink(const LoRaWANChannel_t* chnl, uint8_t* in, u
   modeCfg.transmit.data = in;
   modeCfg.transmit.len = len;
   modeCfg.transmit.addr = 0;
-  state = this->phyLayer->stageMode(RADIOLIB_RADIO_MODE_TX, modeCfg);
+  state = this->phyLayer->stageMode(RADIOLIB_RADIO_MODE_TX, &modeCfg);
   RADIOLIB_ASSERT(state);
   
   // if requested, wait until transmitting uplink
@@ -1431,7 +1431,7 @@ int16_t LoRaWANNode::receiveCommon(uint8_t dir, const LoRaWANChannel_t* dlChanne
     modeCfg.receive.irqFlags = RADIOLIB_IRQ_RX_DEFAULT_FLAGS;
     modeCfg.receive.irqMask = RADIOLIB_IRQ_RX_DEFAULT_MASK;
     modeCfg.receive.len = 0;
-    state = this->phyLayer->stageMode(RADIOLIB_RADIO_MODE_RX, modeCfg);
+    state = this->phyLayer->stageMode(RADIOLIB_RADIO_MODE_RX, &modeCfg);
     RADIOLIB_ASSERT(state);
 
     // wait for the start of the Rx window

--- a/src/protocols/LoRaWAN/LoRaWAN.h
+++ b/src/protocols/LoRaWAN/LoRaWAN.h
@@ -850,7 +850,7 @@ class LoRaWANNode {
       500 is the **maximum** value, but it is not a good idea to go anywhere near that.
       If you have to go above 50 you probably have a bug somewhere. Check your device timing.
     */
-    RadioLibTime_t scanGuard = 4;
+    RadioLibTime_t scanGuard = 5;
 
 #if !RADIOLIB_GODMODE
   protected:

--- a/src/protocols/LoRaWAN/LoRaWAN.h
+++ b/src/protocols/LoRaWAN/LoRaWAN.h
@@ -850,7 +850,7 @@ class LoRaWANNode {
       500 is the **maximum** value, but it is not a good idea to go anywhere near that.
       If you have to go above 50 you probably have a bug somewhere. Check your device timing.
     */
-    RadioLibTime_t scanGuard = 10;
+    RadioLibTime_t scanGuard = 4;
 
 #if !RADIOLIB_GODMODE
   protected:

--- a/src/protocols/PhysicalLayer/PhysicalLayer.cpp
+++ b/src/protocols/PhysicalLayer/PhysicalLayer.cpp
@@ -132,11 +132,18 @@ int16_t PhysicalLayer::startReceive() {
 }
 
 int16_t PhysicalLayer::startReceive(uint32_t timeout, RadioLibIrqFlags_t irqFlags, RadioLibIrqFlags_t irqMask, size_t len) {
-  (void)timeout;
-  (void)irqFlags;
-  (void)irqMask;
-  (void)len;
-  return(RADIOLIB_ERR_UNSUPPORTED);
+  RadioModeConfig_t cfg = {
+    .receive = {
+      .timeout = timeout,
+      .irqFlags = irqFlags,
+      .irqMask = irqMask,
+      .len = len,
+    }
+  };
+
+  int16_t state = this->stageMode(RADIOLIB_RADIO_MODE_RX, &cfg);
+  RADIOLIB_ASSERT(state);
+  return(this->launchMode());
 }
 
 #if defined(RADIOLIB_BUILD_ARDUINO)
@@ -150,10 +157,17 @@ int16_t PhysicalLayer::startTransmit(const char* str, uint8_t addr) {
 }
 
 int16_t PhysicalLayer::startTransmit(const uint8_t* data, size_t len, uint8_t addr) {
-  (void)data;
-  (void)len;
-  (void)addr;
-  return(RADIOLIB_ERR_UNSUPPORTED);
+  RadioModeConfig_t cfg = {
+    .transmit = {
+      .data = data,
+      .len = len,
+      .addr = addr,
+    }
+  };
+
+  int16_t state = this->stageMode(RADIOLIB_RADIO_MODE_TX, &cfg);
+  RADIOLIB_ASSERT(state);
+  return(this->launchMode());
 }
 
 int16_t PhysicalLayer::finishTransmit() {

--- a/src/protocols/PhysicalLayer/PhysicalLayer.cpp
+++ b/src/protocols/PhysicalLayer/PhysicalLayer.cpp
@@ -537,6 +537,16 @@ int16_t PhysicalLayer::getModem(ModemType_t* modem) {
   return(RADIOLIB_ERR_UNSUPPORTED);
 }
 
+int16_t PhysicalLayer::stageMode(RadioModeType_t mode, RadioModeConfig_t cfg) {
+  (void)mode;
+  (void)cfg;
+  return(RADIOLIB_ERR_UNSUPPORTED);
+}
+
+int16_t PhysicalLayer::launchMode() {
+  return(RADIOLIB_ERR_UNSUPPORTED);
+}
+
 #if RADIOLIB_INTERRUPT_TIMING
 void PhysicalLayer::setInterruptSetup(void (*func)(uint32_t)) {
   Module* mod = getMod();

--- a/src/protocols/PhysicalLayer/PhysicalLayer.cpp
+++ b/src/protocols/PhysicalLayer/PhysicalLayer.cpp
@@ -537,7 +537,7 @@ int16_t PhysicalLayer::getModem(ModemType_t* modem) {
   return(RADIOLIB_ERR_UNSUPPORTED);
 }
 
-int16_t PhysicalLayer::stageMode(RadioModeType_t mode, RadioModeConfig_t cfg) {
+int16_t PhysicalLayer::stageMode(RadioModeType_t mode, RadioModeConfig_t* cfg) {
   (void)mode;
   (void)cfg;
   return(RADIOLIB_ERR_UNSUPPORTED);

--- a/src/protocols/PhysicalLayer/PhysicalLayer.h
+++ b/src/protocols/PhysicalLayer/PhysicalLayer.h
@@ -151,7 +151,7 @@ struct ReceiveConfig_t {
 
 struct TransmitConfig_t {
   /*! \brief Binary data that will be transmitted. */
-  uint8_t* data;
+  const uint8_t* data;
 
   /*! \brief Length of binary data to transmit (in bytes). */
   size_t len;
@@ -306,7 +306,7 @@ class PhysicalLayer {
       \param len Packet length, needed for some modules under special circumstances (e.g. LoRa implicit header mode).
       \returns \ref status_codes
     */
-    virtual int16_t startReceive(uint32_t timeout, RadioLibIrqFlags_t irqFlags, RadioLibIrqFlags_t irqMask, size_t len);
+    virtual int16_t startReceive(uint32_t timeout, RadioLibIrqFlags_t irqFlags = RADIOLIB_IRQ_RX_DEFAULT_FLAGS, RadioLibIrqFlags_t irqMask = RADIOLIB_IRQ_RX_DEFAULT_MASK, size_t len = 0);
 
     /*!
       \brief Binary receive method. Must be implemented in module class.

--- a/src/protocols/PhysicalLayer/PhysicalLayer.h
+++ b/src/protocols/PhysicalLayer/PhysicalLayer.h
@@ -737,10 +737,10 @@ class PhysicalLayer {
     /*!
       \brief Stage mode of the radio to be launched later using launchMode.
       \param mode Radio mode to prepare.
-      \param cfg Confioguration of this mode (mode-dependent).
+      \param cfg Configuration of this mode (mode-dependent).
       \returns \ref status_codes
     */
-    virtual int16_t stageMode(RadioModeType_t mode, RadioModeConfig_t cfg);
+    virtual int16_t stageMode(RadioModeType_t mode, RadioModeConfig_t* cfg);
 
     /*!
       \brief Launch previously staged mode.
@@ -770,7 +770,6 @@ class PhysicalLayer {
 #endif
     uint32_t irqMap[10] = { 0 };
     RadioModeType_t stagedMode = RADIOLIB_RADIO_MODE_NONE;
-    RadioModeConfig_t stagedConfig = { .standby = { .mode = 0 } };
 
 #if !RADIOLIB_EXCLUDE_DIRECT_RECEIVE
     void updateDirectBuffer(uint8_t bit);

--- a/src/protocols/PhysicalLayer/PhysicalLayer.h
+++ b/src/protocols/PhysicalLayer/PhysicalLayer.h
@@ -740,13 +740,13 @@ class PhysicalLayer {
       \param cfg Confioguration of this mode (mode-dependent).
       \returns \ref status_codes
     */
-    int16_t stageMode(RadioModeType_t mode, RadioModeConfig_t cfg);
+    virtual int16_t stageMode(RadioModeType_t mode, RadioModeConfig_t cfg);
 
     /*!
       \brief Launch previously staged mode.
       \returns \ref status_codes
     */
-    int16_t launchMode();
+    virtual int16_t launchMode();
 
     #if RADIOLIB_INTERRUPT_TIMING
 


### PR DESCRIPTION
Background: When switching between modes (e.g. from standby to receive) there is a significant overhead of commands that must be sent to the device to configure it. Such overhead adds timing uncertainty, because there is a not-insignificant delay between calling the appropriate method (e.g. `startReceive`) and the device actually starting being able to receive packets. The issue becomes more significant at low clock/SPI speeds typically used in battery-powered devices. This causes problems especially for LoRaWAN.

This PR adds support for "staged modes". This is an API of the `PhysicalLayer` class that allow to "stage" a mode to be set by calling `stageMode` method, and then "launching" this mode with `launchMode` that only performs a couple of SPI transactions.

Marking as draft for now since there is still some cleanup left to be done.