### PR TITLE
a fix for build with Arduino Core over Zephyr OS for Nano 33 BLE and Portenta H7 targets

### DIFF
--- a/src/BuildOpt.h
+++ b/src/BuildOpt.h
@@ -264,20 +264,24 @@
   #define RADIOLIB_ARDUINOHAL_PIN_STATUS_CAST         (PinStatus)
   #define RADIOLIB_ARDUINOHAL_INTERRUPT_MODE_CAST     (PinStatus)
 
+  #if defined(ARDUINO_ARCH_MBED)
   // Arduino mbed OS boards have a really bad tone implementation which will crash after a couple seconds
   #define RADIOLIB_TONE_UNSUPPORTED
   #define RADIOLIB_MBED_TONE_OVERRIDE
+  #endif
 
-#elif defined(ARDUINO_PORTENTA_H7_M7) || defined(ARDUINO_PORTENTA_H7_M4)
+#elif defined(ARDUINO_PORTENTA_H7_M7) || defined(ARDUINO_PORTENTA_H7_M4) || defined(ARDUINO_PORTENTA_H7)
   // Arduino Portenta H7
   #define RADIOLIB_PLATFORM                           "Portenta H7"
   #define RADIOLIB_ARDUINOHAL_PIN_MODE_CAST           (PinMode)
   #define RADIOLIB_ARDUINOHAL_PIN_STATUS_CAST         (PinStatus)
   #define RADIOLIB_ARDUINOHAL_INTERRUPT_MODE_CAST     (PinStatus)
 
+  #if defined(ARDUINO_ARCH_MBED)
   // Arduino mbed OS boards have a really bad tone implementation which will crash after a couple seconds
   #define RADIOLIB_TONE_UNSUPPORTED
   #define RADIOLIB_MBED_TONE_OVERRIDE
+  #endif
 
 #elif defined(__STM32F4__) || defined(__STM32F1__)
   // Arduino STM32 core by Roger Clark (https://github.com/rogerclarkmelbourne/Arduino_STM32)


### PR DESCRIPTION
Since Mbed OS is expected to EoL soon - it looks like Arduino Team is migrating onto Zephyr OS.

Build of a RadioLib demo sketch with latest official [**Arduino Core for Zephyr OS**](https://github.com/arduino/ArduinoCore-zephyr/tree/arduino)

```
$ arduino-cli core list
ID                  Installed Latest Name
arduino:mbed_edge   4.1.5     4.2.1  Arduino Mbed OS Edge Boards
arduino:mbed_nano   4.1.5     4.2.1  Arduino Mbed OS Nano Boards
arduino:mbed_rp2040 4.1.5     4.2.1  Arduino Mbed OS RP2040 Boards
arduino:renesas_uno 1.2.0     1.3.2  Arduino UNO R4 Boards
arduino:zephyr      0.1.0     0.1.0  Arduino Zephyr Boards (llext)
WCH:ch32v           1.0.4     1.0.4  CH32 MCU EVT Boards
WCH:1.0.4           1.0.0     1.0.0  CH32V EVT Boards Support
SiliconLabs:silabs  2.2.0     2.2.0  Silicon Labs

$ export BOARD=arduino:zephyr:nano33ble 
$  arduino-cli compile -v --build-path=/tmp/arduino -b "$BOARD"  /tmp//RadioLib-7.1.2/examples/LR11x0/LR11x0_PingPong/ ;
```

gives a failure:


```
ResolveLibrary(mbed.h)
  -> candidates: []
In file included from /home/codespace/Arduino/libraries/RadioLib/src/RadioLib.h:43,
                 from /tmp/RadioLib-7.1.2/examples/LR11x0/LR11x0_PingPong/LR11x0_PingPong.ino:12:
/home/codespace/Arduino/libraries/RadioLib/src/hal/Arduino/ArduinoHal.h:11:10: fatal error: mbed.h: No such file or directory
   11 | #include "mbed.h"
      |          ^~~~~~~~
compilation terminated.
```

This PR is intended to fix the build issue.
