### PR TITLE
[CI] Measure code coverage after unit test

### DIFF
--- a/extras/test/unit/.gitignore
+++ b/extras/test/unit/.gitignore
@@ -1,1 +1,2 @@
 build/
+lcov*

--- a/extras/test/unit/CMakeLists.txt
+++ b/extras/test/unit/CMakeLists.txt
@@ -18,11 +18,13 @@ add_executable(${PROJECT_NAME} ${TEST_SOURCES})
 target_include_directories(${PROJECT_NAME} PUBLIC include)
 
 # link RadioLib
-target_link_libraries(${PROJECT_NAME} RadioLib fmt)
+target_link_libraries(${PROJECT_NAME} RadioLib fmt gcov)
 
 # set target properties and options
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 20)
-target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra)
+set(BUILD_FLAGS -Wall -Wextra -fprofile-arcs -ftest-coverage -O0)
+target_compile_options(${PROJECT_NAME} PRIVATE ${BUILD_FLAGS})
+target_compile_options(RadioLib PRIVATE ${BUILD_FLAGS})
 
 # set RadioLib debug
 #target_compile_definitions(RadioLib PUBLIC RADIOLIB_DEBUG_BASIC RADIOLIB_DEBUG_SPI RADIOLIB_DEBUG_PROTOCOL)

--- a/extras/test/unit/coverage.sh
+++ b/extras/test/unit/coverage.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+filename="lcov"
+rm -rf $filename.*
+lcov --capture --directory build --output-file "${filename}.info"
+
+# filter out boost and C++ standard library
+lcov --remove "${filename}.info" "/usr/*/boost/*" "/usr/include/c++/*" --output-file "${filename}.info"
+
+# generate HTML
+genhtml "${filename}.info" --output-directory "${filename}.report"
+zip -r "${filename}.report.zip" "${filename}.report"


### PR DESCRIPTION
Added code coverage reporting using lcov. So far only uploaded as artifact for the unit test CI pipeline, but since the report is HTML, maybe we can deploy it to GitHub pages as well.
