### PR TITLE
Increase timeout while waiting for MARC state to be ready to transmit

### DIFF
--- a/src/modules/CC1101/CC1101.cpp
+++ b/src/modules/CC1101/CC1101.cpp
@@ -243,9 +243,10 @@ int16_t CC1101::startTransmit(const uint8_t* data, size_t len, uint8_t addr) {
 
   // Check MARCSTATE and wait until ready to tx
   // 724us is the longest time for calibrate per datasheet
+  // Needs a bit more time for reliability
   RadioLibTime_t start = this->mod->hal->micros();
   while(SPIgetRegValue(RADIOLIB_CC1101_REG_MARCSTATE, 4, 0) != 0x12) {
-    if(this->mod->hal->micros() - start > 724) {
+    if(this->mod->hal->micros() - start > 800) {
       standby();
       return(RADIOLIB_ERR_TX_TIMEOUT);
     }


### PR DESCRIPTION
Hi Jan,

Apologies, but I noticed today in further testing that while waiting for Marc state to be ready to tx the datasheet timeout can sometimes be triggered (it can take longer than the datasheet says). 

I increased the timeout to 800us and haven't gotten another timeout.
