### PR TITLE
[SX128x] add support for GFSK fixed packet length mode

### DIFF
--- a/src/modules/SX128x/SX128x.cpp
+++ b/src/modules/SX128x/SX128x.cpp
@@ -772,8 +772,7 @@ int16_t SX128x::setModem(ModemType_t modem) {
 int16_t SX128x::getModem(ModemType_t* modem) {
   RADIOLIB_ASSERT_PTR(modem);
 
-  uint8_t pType = getPacketType();
-  switch(pType) {
+  switch(getPacketType()) {
     case(RADIOLIB_SX128X_PACKET_TYPE_LORA):
       *modem = ModemType_t::RADIOLIB_MODEM_LORA;
       return(RADIOLIB_ERR_NONE);

--- a/src/modules/SX128x/SX128x.cpp
+++ b/src/modules/SX128x/SX128x.cpp
@@ -772,8 +772,8 @@ int16_t SX128x::setModem(ModemType_t modem) {
 int16_t SX128x::getModem(ModemType_t* modem) {
   RADIOLIB_ASSERT_PTR(modem);
 
-  uint8_t packetType = getPacketType();
-  switch(packetType) {
+  uint8_t pType = getPacketType();
+  switch(pType) {
     case(RADIOLIB_SX128X_PACKET_TYPE_LORA):
       *modem = ModemType_t::RADIOLIB_MODEM_LORA;
       return(RADIOLIB_ERR_NONE);

--- a/src/modules/SX128x/SX128x.h
+++ b/src/modules/SX128x/SX128x.h
@@ -796,6 +796,20 @@ class SX128x: public PhysicalLayer {
     size_t getPacketLength(bool update, uint8_t* offset);
 
     /*!
+      \brief Set modem in fixed packet length mode. Available in GFSK mode only.
+      \param len Packet length.
+      \returns \ref status_codes
+    */
+    int16_t fixedPacketLengthMode(uint8_t len = RADIOLIB_SX128X_MAX_PACKET_LENGTH);
+
+    /*!
+      \brief Set modem in variable packet length mode. Available in GFSK mode only.
+      \param maxLen Maximum packet length.
+      \returns \ref status_codes
+    */
+    int16_t variablePacketLengthMode(uint8_t maxLen = RADIOLIB_SX128X_MAX_PACKET_LENGTH);
+
+    /*!
       \brief Get expected time-on-air for a given size of payload.
       \param len Payload length in bytes.
       \returns Expected time-on-air in microseconds.
@@ -885,7 +899,7 @@ class SX128x: public PhysicalLayer {
     int16_t setTxParams(uint8_t pwr, uint8_t rampTime = RADIOLIB_SX128X_PA_RAMP_10_US);
     int16_t setBufferBaseAddress(uint8_t txBaseAddress = 0x00, uint8_t rxBaseAddress = 0x00);
     int16_t setModulationParams(uint8_t modParam1, uint8_t modParam2, uint8_t modParam3);
-    int16_t setPacketParamsGFSK(uint8_t preambleLen, uint8_t syncLen, uint8_t syncMatch, uint8_t crcLen, uint8_t whiten, uint8_t payLen = 0xFF, uint8_t hdrType = RADIOLIB_SX128X_GFSK_FLRC_PACKET_VARIABLE);
+    int16_t setPacketParamsGFSK(uint8_t preambleLen, uint8_t syncLen, uint8_t syncMatch, uint8_t crcLen, uint8_t whiten, uint8_t hdrType, uint8_t payLen = 0xFF);
     int16_t setPacketParamsBLE(uint8_t connState, uint8_t crcLen, uint8_t bleTest, uint8_t whiten);
     int16_t setPacketParamsLoRa(uint8_t preambleLen, uint8_t hdrType, uint8_t payLen, uint8_t crc, uint8_t invIQ = RADIOLIB_SX128X_LORA_IQ_STANDARD);
     int16_t setDioIrqParams(uint16_t irqMask, uint16_t dio1Mask, uint16_t dio2Mask = RADIOLIB_SX128X_IRQ_NONE, uint16_t dio3Mask = RADIOLIB_SX128X_IRQ_NONE);
@@ -913,6 +927,7 @@ class SX128x: public PhysicalLayer {
     uint16_t bitRateKbps = 0;
     uint8_t bitRate = 0, modIndex = 0, shaping = 0;
     uint8_t preambleLengthGFSK = 0, syncWordLen = 0, syncWordMatch = 0, crcGFSK = 0, whitening = 0;
+    uint8_t packetType = RADIOLIB_SX128X_GFSK_FLRC_PACKET_VARIABLE;
 
     // cached FLRC parameters
     uint8_t codingRateFLRC = 0;
@@ -921,6 +936,7 @@ class SX128x: public PhysicalLayer {
     uint8_t connectionState = 0, crcBLE = 0, bleTestPayload = 0;
 
     int16_t config(uint8_t modem);
+    int16_t setPacketMode(uint8_t mode, uint8_t len);
     int16_t setHeaderType(uint8_t hdrType, size_t len = 0xFF);
 };
 


### PR DESCRIPTION
Unlike SX126X and LR11XX, GFSK fixed packet length mode is currently not supported for SX128X  radios.

![image](https://github.com/user-attachments/assets/a1b802ce-221d-4fd1-8324-c1c7499966d7)

This PR is intended to fix the issue.