### PR TITLE
[SX128x] fix for improper GFSK syncword setting with length other than 5 bytes

### DIFF
--- a/src/modules/SX128x/SX128x.cpp
+++ b/src/modules/SX128x/SX128x.cpp
@@ -996,14 +996,8 @@ int16_t SX128x::setSyncWord(const uint8_t* syncWord, uint8_t len) {
     this->syncWordLen = len;
   }
 
-  uint16_t syncAddr = len == 5 ? RADIOLIB_SX128X_REG_SYNC_WORD_1_BYTE_4 :
-                      len == 4 ? RADIOLIB_SX128X_REG_SYNC_WORD_1_BYTE_3 :
-                      len == 3 ? RADIOLIB_SX128X_REG_SYNC_WORD_1_BYTE_2 :
-                      len == 2 ? RADIOLIB_SX128X_REG_SYNC_WORD_1_BYTE_1 :
-                                 RADIOLIB_SX128X_REG_SYNC_WORD_1_BYTE_0;
-
   // update sync word
-  int16_t state = SX128x::writeRegister(syncAddr, const_cast<uint8_t*>(syncWord), len);
+  int16_t state = SX128x::writeRegister(RADIOLIB_SX128X_REG_SYNC_WORD_1_BYTE_4 + (5 - len), const_cast<uint8_t*>(syncWord), len);
   RADIOLIB_ASSERT(state);
 
   // update packet parameters

--- a/src/modules/SX128x/SX128x.cpp
+++ b/src/modules/SX128x/SX128x.cpp
@@ -996,8 +996,14 @@ int16_t SX128x::setSyncWord(const uint8_t* syncWord, uint8_t len) {
     this->syncWordLen = len;
   }
 
+  uint16_t syncAddr = len == 5 ? RADIOLIB_SX128X_REG_SYNC_WORD_1_BYTE_4 :
+                      len == 4 ? RADIOLIB_SX128X_REG_SYNC_WORD_1_BYTE_3 :
+                      len == 3 ? RADIOLIB_SX128X_REG_SYNC_WORD_1_BYTE_2 :
+                      len == 2 ? RADIOLIB_SX128X_REG_SYNC_WORD_1_BYTE_1 :
+                                 RADIOLIB_SX128X_REG_SYNC_WORD_1_BYTE_0;
+
   // update sync word
-  int16_t state = SX128x::writeRegister(RADIOLIB_SX128X_REG_SYNC_WORD_1_BYTE_4, const_cast<uint8_t*>(syncWord), len);
+  int16_t state = SX128x::writeRegister(syncAddr, const_cast<uint8_t*>(syncWord), len);
   RADIOLIB_ASSERT(state);
 
   // update packet parameters


### PR DESCRIPTION
This is a follow up for https://github.com/jgromes/RadioLib/pull/1444

The PR has been verified with sync word lengths of 2 and 4 bytes.
Expected to work with lengths 1 and 3 bytes as well.

`SX128x::setSyncWord()` method should behave so that LSB of the sync word has to be written into LSB of the `SyncWord1` register.


![image](https://github.com/user-attachments/assets/ae1d5cbf-2a64-4552-90c9-586f6d38cc22)
