### PR TITLE
[RF69] a fix for invalid sync word length setting

### DIFF
--- a/src/modules/RF69/RF69.cpp
+++ b/src/modules/RF69/RF69.cpp
@@ -696,7 +696,7 @@ int16_t RF69::setOutputPower(int8_t pwr, bool highPower) {
 
 int16_t RF69::setSyncWord(const uint8_t* syncWord, size_t len, uint8_t maxErrBits) {
   // check constraints
-  if((maxErrBits > 7) || (len > 8)) {
+  if((maxErrBits > 7) || (len == 0) || (len > 8)) {
     return(RADIOLIB_ERR_INVALID_SYNC_WORD);
   }
 
@@ -712,12 +712,12 @@ int16_t RF69::setSyncWord(const uint8_t* syncWord, size_t len, uint8_t maxErrBit
   RADIOLIB_ASSERT(state);
 
   // set the length
-  state = this->mod->SPIsetRegValue(RADIOLIB_RF69_REG_SYNC_CONFIG, len, 5, 3);
+  state = this->mod->SPIsetRegValue(RADIOLIB_RF69_REG_SYNC_CONFIG, len-1, 5, 3);
 
   // set sync word register
   this->mod->SPIwriteRegisterBurst(RADIOLIB_RF69_REG_SYNC_VALUE_1, syncWord, len);
   if(state == RADIOLIB_ERR_NONE) {
-    this->syncWordLength = len;
+    this->syncWordLength = len-1;
   }
 
   return(state);


### PR DESCRIPTION
A range of `len` argument for the `RF69::setSyncWord()` method is &nbsp;  1 ... 8
while the range of `SyncSize` bitmap &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;  is &nbsp;  0 ... 7

![image](https://github.com/user-attachments/assets/daf686a1-63dd-41bc-a33f-6c0bfa57816b)

