### PR TITLE
[RF69] further fix for sync word length

### DIFF
--- a/src/modules/RF69/RF69.cpp
+++ b/src/modules/RF69/RF69.cpp
@@ -712,7 +712,7 @@ int16_t RF69::setSyncWord(const uint8_t* syncWord, size_t len, uint8_t maxErrBit
   RADIOLIB_ASSERT(state);
 
   // set the length
-  state = this->mod->SPIsetRegValue(RADIOLIB_RF69_REG_SYNC_CONFIG, len-1, 5, 3);
+  state = this->mod->SPIsetRegValue(RADIOLIB_RF69_REG_SYNC_CONFIG, (len-1)<<3, 5, 3);
 
   // set sync word register
   this->mod->SPIwriteRegisterBurst(RADIOLIB_RF69_REG_SYNC_VALUE_1, syncWord, len);


### PR DESCRIPTION
Follow up for PR https://github.com/jgromes/RadioLib/pull/1448

It fixes regression happened after commit https://github.com/jgromes/RadioLib/commit/fc6ff698b9d593d31ee1580f847a15d9ab59bed2


SPI log before the fix
```

RLB_SPI: R      2E      98
RLB_SPI: W      2E      80
RLB_SPI: R      2E      80
RLB_SPI: W      2F      2D      1
```

SPI log after the fix

```
RLB_SPI: R      2E      98
RLB_SPI: W      2E      88
RLB_SPI: R      2E      88
RLB_SPI: W      2F      2D      1
```
