### PR TITLE
[LoRaWAN] Implement Class C (unicast)

### DIFF
--- a/src/modules/LR11x0/LR11x0.cpp
+++ b/src/modules/LR11x0/LR11x0.cpp
@@ -1977,6 +1977,11 @@ int16_t LR11x0::stageMode(RadioModeType_t mode, RadioModeConfig_t* cfg) {
         state = setPacketParamsLoRa(this->preambleLengthLoRa, this->headerType, this->implicitLen, this->crcTypeLoRa, this->invertIQEnabled);
         RADIOLIB_ASSERT(state);
       }
+
+      // if max(uint32_t) is used, revert to RxContinuous
+      if(cfg->receive.timeout == 0xFFFFFFFF) {
+        cfg->receive.timeout = 0xFFFFFF;
+      }
       this->rxTimeout = cfg->receive.timeout;
     } break;
   

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -1554,6 +1554,10 @@ int16_t SX126x::stageMode(RadioModeType_t mode, RadioModeConfig_t* cfg) {
       state = startReceiveCommon(cfg->receive.timeout, cfg->receive.irqFlags, cfg->receive.irqMask);
       RADIOLIB_ASSERT(state);
 
+      // if max(uint32_t) is used, revert to RxContinuous
+      if(cfg->receive.timeout == 0xFFFFFFFF) {
+        cfg->receive.timeout = 0xFFFFFF;
+      }
       this->rxTimeout = cfg->receive.timeout;
     } break;
   

--- a/src/modules/SX127x/SX127x.cpp
+++ b/src/modules/SX127x/SX127x.cpp
@@ -1662,6 +1662,10 @@ int16_t SX127x::stageMode(RadioModeType_t mode, RadioModeConfig_t* cfg) {
 
       int16_t modem = getActiveModem();
       if(modem == RADIOLIB_SX127X_LORA) {
+        // if max(uint32_t) is used, revert to RxContinuous
+        if(cfg->receive.timeout == 0xFFFFFFFF) {
+          cfg->receive.timeout = 0;
+        }
         if(cfg->receive.timeout != 0) {
           // for non-zero timeout value, change mode to Rx single and set the timeout
           this->rxMode = RADIOLIB_SX127X_RXSINGLE;

--- a/src/modules/SX128x/SX128x.cpp
+++ b/src/modules/SX128x/SX128x.cpp
@@ -1426,6 +1426,10 @@ int16_t SX128x::stageMode(RadioModeType_t mode, RadioModeConfig_t* cfg) {
         state = setPacketParamsLoRa(this->preambleLengthLoRa, this->headerType, this->payloadLen, this->crcLoRa, this->invertIQEnabled);
         RADIOLIB_ASSERT(state);
       }
+      // if max(uint32_t) is used, revert to RxContinuous
+      if(cfg->receive.timeout == 0xFFFFFFFF) {
+        cfg->receive.timeout = 0xFFFF;
+      }
       this->rxTimeout = cfg->receive.timeout;
     } break;
   

--- a/src/protocols/LoRaWAN/LoRaWAN.h
+++ b/src/protocols/LoRaWAN/LoRaWAN.h
@@ -11,9 +11,9 @@
 #define RADIOLIB_LORAWAN_MODE_NONE                              (0x0000)
 
 // operation mode
-#define RADIOLIB_LORAWAN_CLASS_A                                (0x0A)
-#define RADIOLIB_LORAWAN_CLASS_B                                (0x0B)
-#define RADIOLIB_LORAWAN_CLASS_C                                (0x0C)
+#define RADIOLIB_LORAWAN_CLASS_A                                (0x00)
+#define RADIOLIB_LORAWAN_CLASS_B                                (0x01)
+#define RADIOLIB_LORAWAN_CLASS_C                                (0x02)
 
 // preamble format
 #define RADIOLIB_LORAWAN_LORA_SYNC_WORD                         (0x34)
@@ -73,9 +73,11 @@
 #define RADIOLIB_LORAWAN_DATA_RATE_UNUSED                       (0xFF << 0) //  7     0     unused data rate
 
 // channels and channel plans
-#define RADIOLIB_LORAWAN_UPLINK                             (0x00 << 0)
-#define RADIOLIB_LORAWAN_DOWNLINK                           (0x01 << 0)
-#define RADIOLIB_LORAWAN_DIR_RX2                                (0x02 << 0)
+#define RADIOLIB_LORAWAN_UPLINK                                 (0x00 << 0)
+#define RADIOLIB_LORAWAN_DOWNLINK                               (0x01 << 0)
+#define RADIOLIB_LORAWAN_RX1                                    (0x01 << 0)
+#define RADIOLIB_LORAWAN_RX2                                    (0x02 << 0)
+#define RADIOLIB_LORAWAN_RXC                                    (0x03 << 0)
 #define RADIOLIB_LORAWAN_BAND_DYNAMIC                           (0)
 #define RADIOLIB_LORAWAN_BAND_FIXED                             (1)
 #define RADIOLIB_LORAWAN_CHANNEL_NUM_DATARATES                  (15)
@@ -177,7 +179,7 @@
 #define RADIOLIB_LORAWAN_MAX_CHANGES_DEFAULT                    (4)
 
 // MAC commands
-#define RADIOLIB_LORAWAN_NUM_MAC_COMMANDS                       (23)
+#define RADIOLIB_LORAWAN_NUM_MAC_COMMANDS                       (24)
 
 #define RADIOLIB_LORAWAN_MAC_RESET                              (0x01)
 #define RADIOLIB_LORAWAN_MAC_LINK_CHECK                         (0x02)
@@ -194,6 +196,7 @@
 #define RADIOLIB_LORAWAN_MAC_DEVICE_TIME                        (0x0D)
 #define RADIOLIB_LORAWAN_MAC_FORCE_REJOIN                       (0x0E)
 #define RADIOLIB_LORAWAN_MAC_REJOIN_PARAM_SETUP                 (0x0F)
+#define RADIOLIB_LORAWAN_MAC_DEVICE_MODE                        (0x20)
 #define RADIOLIB_LORAWAN_MAC_PROPRIETARY                        (0x80)
 
 // the length of internal MAC command queue - hopefully this is enough for most use cases
@@ -251,6 +254,7 @@ constexpr LoRaWANMacCommand_t MacTable[RADIOLIB_LORAWAN_NUM_MAC_COMMANDS] = {
   { RADIOLIB_LORAWAN_MAC_DEVICE_TIME,         5, 0, false, true  },
   { RADIOLIB_LORAWAN_MAC_FORCE_REJOIN,        2, 0, false, false },
   { RADIOLIB_LORAWAN_MAC_REJOIN_PARAM_SETUP,  1, 1, false, false },
+  { RADIOLIB_LORAWAN_MAC_DEVICE_MODE,         1, 1, true,  false },
   { RADIOLIB_LORAWAN_MAC_PROPRIETARY,         5, 0, false, true  },
 };
 
@@ -260,8 +264,7 @@ enum LoRaWANSchemeBase_t {
   RADIOLIB_LORAWAN_NONCES_START       = 0x00,
   RADIOLIB_LORAWAN_NONCES_VERSION     = RADIOLIB_LORAWAN_NONCES_START,                            // 2 bytes
   RADIOLIB_LORAWAN_NONCES_MODE        = RADIOLIB_LORAWAN_NONCES_VERSION + sizeof(uint16_t),       // 2 bytes
-  RADIOLIB_LORAWAN_NONCES_CLASS       = RADIOLIB_LORAWAN_NONCES_MODE + sizeof(uint16_t),          // 1 byte
-  RADIOLIB_LORAWAN_NONCES_PLAN        = RADIOLIB_LORAWAN_NONCES_CLASS + sizeof(uint8_t),          // 1 byte
+  RADIOLIB_LORAWAN_NONCES_PLAN        = RADIOLIB_LORAWAN_NONCES_MODE + sizeof(uint8_t),          // 1 byte
   RADIOLIB_LORAWAN_NONCES_CHECKSUM    = RADIOLIB_LORAWAN_NONCES_PLAN + sizeof(uint8_t),           // 2 bytes
   RADIOLIB_LORAWAN_NONCES_DEV_NONCE   = RADIOLIB_LORAWAN_NONCES_CHECKSUM + sizeof(uint16_t),      // 2 bytes
   RADIOLIB_LORAWAN_NONCES_JOIN_NONCE  = RADIOLIB_LORAWAN_NONCES_DEV_NONCE + sizeof(uint16_t),     // 3 bytes
@@ -288,7 +291,8 @@ enum LoRaWANSchemeSession_t {
   RADIOLIB_LORAWAN_SESSION_RJ_COUNT1          = RADIOLIB_LORAWAN_SESSION_RJ_COUNT0 + sizeof(uint16_t), 	    // 2 bytes
   RADIOLIB_LORAWAN_SESSION_HOMENET_ID         = RADIOLIB_LORAWAN_SESSION_RJ_COUNT1 + sizeof(uint16_t), 	    // 4 bytes
   RADIOLIB_LORAWAN_SESSION_VERSION            = RADIOLIB_LORAWAN_SESSION_HOMENET_ID + sizeof(uint32_t), 	  // 1 byte
-  RADIOLIB_LORAWAN_SESSION_LINK_ADR           = RADIOLIB_LORAWAN_SESSION_VERSION + sizeof(uint8_t),         // 14 bytes
+  RADIOLIB_LORAWAN_SESSION_CLASS              = RADIOLIB_LORAWAN_SESSION_VERSION + 1,             // 1 byte
+  RADIOLIB_LORAWAN_SESSION_LINK_ADR           = RADIOLIB_LORAWAN_SESSION_CLASS + sizeof(uint8_t), // 14 bytes
   RADIOLIB_LORAWAN_SESSION_DUTY_CYCLE         = RADIOLIB_LORAWAN_SESSION_LINK_ADR + 14, 	        // 1 byte
   RADIOLIB_LORAWAN_SESSION_RX_PARAM_SETUP     = RADIOLIB_LORAWAN_SESSION_DUTY_CYCLE + 1, 	        // 4 bytes
   RADIOLIB_LORAWAN_SESSION_RX_TIMING_SETUP    = RADIOLIB_LORAWAN_SESSION_RX_PARAM_SETUP + 4, 	    // 1 byte
@@ -606,6 +610,9 @@ class LoRaWANNode {
     /*! \brief Whether there is an ongoing session active */
     bool isActivated();
 
+    /*! \brief Configure class (A / C) */
+    int16_t setClass(uint8_t cls);
+
     #if defined(RADIOLIB_BUILD_ARDUINO)
     /*!
       \brief Send a message to the server and wait for a downlink during Rx1 and/or Rx2 window.
@@ -679,6 +686,16 @@ class LoRaWANNode {
       \returns Window number > 0 if downlink was received, 0 is no downlink was received, otherwise \ref status_codes
     */
     virtual int16_t sendReceive(const uint8_t* dataUp, size_t lenUp, uint8_t fPort, uint8_t* dataDown, size_t* lenDown, bool isConfirmed = false, LoRaWANEvent_t* eventUp = NULL, LoRaWANEvent_t* eventDown = NULL);
+
+    /*!
+      \brief Check if there is an RxC downlink and parse it if available.
+      \param dataDown Buffer to save received data into.
+      \param lenDown Pointer to variable that will be used to save the number of received bytes.
+      \param eventDown Pointer to a structure to store extra information about the downlink event
+      (fPort, frame counter, etc.). If set to NULL, no extra information will be passed to the user.
+      \returns Window number > 0 if downlink was received, 0 is no downlink was received, otherwise \ref status_codes
+    */
+    int16_t getDownlinkClassC(uint8_t* dataDown, size_t* lenDown, LoRaWANEvent_t* eventDown = NULL);
 
     /*!
       \brief Add a MAC command to the uplink queue.
@@ -946,21 +963,21 @@ class LoRaWANNode {
     // process at the same time. 
     uint8_t backoffMax = RADIOLIB_LORAWAN_BACKOFF_MAX_DEFAULT;
     
-    // number of CADs to estimate a clear CH
+    // number of CADs to estimate a clear channel
     uint8_t difsSlots = RADIOLIB_LORAWAN_DIFS_DEFAULT;
 
     // available channel frequencies from list passed during OTA activation
     LoRaWANChannel_t channelPlan[2][RADIOLIB_LORAWAN_NUM_AVAILABLE_CHANNELS];
 
-    // currently configured channels for TX, RX1, RX2
-    LoRaWANChannel_t channels[3] = { RADIOLIB_LORAWAN_CHANNEL_NONE, RADIOLIB_LORAWAN_CHANNEL_NONE,
-                                     RADIOLIB_LORAWAN_CHANNEL_NONE };
+    // currently configured channels for Tx, Rx1, Rx2, RxC
+    LoRaWANChannel_t channels[4] = { RADIOLIB_LORAWAN_CHANNEL_NONE, RADIOLIB_LORAWAN_CHANNEL_NONE,
+                                     RADIOLIB_LORAWAN_CHANNEL_NONE, RADIOLIB_LORAWAN_CHANNEL_NONE };
 
-    // delays between the uplink and RX1/2 windows
+    // delays between the uplink and Rx1/2 windows
     // the first field is meaningless, but is used for offsetting for Rx windows 1 and 2
     RadioLibTime_t rxDelays[3] = { 0, RADIOLIB_LORAWAN_RECEIVE_DELAY_1_MS, RADIOLIB_LORAWAN_RECEIVE_DELAY_2_MS };
 
-    // offset between TX and RX1 (such that RX1 has equal or lower DR)
+    // offset between Tx and Rx1 (such that Rx1 has equal or lower DR)
     uint8_t rx1DrOffset = 0;
 
     // LoRaWAN revision (1.0 vs 1.1)
@@ -969,11 +986,8 @@ class LoRaWANNode {
     // Time on Air of last uplink
     RadioLibTime_t lastToA = 0;
 
-    // timestamp to measure the RX1/2 delay (from uplink end)
+    // timestamp to measure the Rx1/2 delay (from uplink end)
     RadioLibTime_t rxDelayStart = 0;
-
-    // timestamp when the Rx1/2 windows were closed (timeout or uplink received)
-    RadioLibTime_t rxDelayEnd = 0;
 
     // duration of SPI transaction for phyLayer->launchMode()
     RadioLibTime_t launchDuration = 0;
@@ -1020,13 +1034,17 @@ class LoRaWANNode {
     void micUplink(uint8_t* inOut, uint8_t lenInOut);
 
     // transmit uplink buffer on a specified channel
-    int16_t transmitUplink(const LoRaWANChannel_t* chnl, uint8_t* in, uint8_t len, bool retrans);
+    int16_t transmitUplink(const LoRaWANChannel_t* chnl, uint8_t* in, uint8_t len, bool retrans = false);
+
+    int16_t receiveClassA(uint8_t dir, const LoRaWANChannel_t* dlChannel, uint8_t window, const RadioLibTime_t dlDelay, RadioLibTime_t tReference);
+
+    int16_t receiveClassC(RadioLibTime_t timeout = 0);
 
     // wait for, open and listen during receive windows; only performs listening
-    int16_t receiveCommon(uint8_t dir, const LoRaWANChannel_t* dlChannels, const RadioLibTime_t* dlDelays, uint8_t numWindows, RadioLibTime_t tReference);
+    int16_t receiveDownlink();
 
     // extract downlink payload and process MAC commands
-    int16_t parseDownlink(uint8_t* data, size_t* len, LoRaWANEvent_t* event = NULL);
+    int16_t parseDownlink(uint8_t* data, size_t* len, uint8_t window, LoRaWANEvent_t* event = NULL);
 
     // execute mac command, return the number of processed bytes for sequential processing
     bool execMacCommand(uint8_t cid, uint8_t* optIn, uint8_t lenIn);


### PR DESCRIPTION
As per title. 

Tested on LoRaWAN v1.0.4 (OTAA / EU868) and LoRaWAN v1.1 (OTAA / EU868).  
Implementation as per spec except for one item in the 1.1 specification: 
> The device SHALL switch mode as soon as the first `DeviceModeInd` command is transmitted.

Instead, it switches once `DeviceModeConf` is received. This tackles the note that is included that suggests using some timeout in case there is no response from the network.

No example included yet, but it's pretty simple:
```cpp
void setup() {
  ...
  // join
  ...
  node.setClass(RADIOLIB_LORAWAN_CLASS_C);
  // send a confirmed uplink (assuming it receives a downlink at once) as per TS001 par. 6.2.7
  // this way, the LNS knows that the device has an active session (received the JoinAccept)
  node.sendReceive(payload, payLen, 1, payload, &payLen, true, &eventUp, &eventDown);
  ...
}

void loop() {
  state = node.getDownlinkClassC(payload, &payLen, &eventDown);
  if(state > 0) {
    Serial.println(F("Received a Class C downlink!"));
    // Did we get a downlink with data for us
    if(payLen > 0) {
      Serial.println(F("Downlink data: "));
      arrayDump(payload, payLen);
    }

    // print extra information about the event
    Serial.println(F("[LoRaWAN] Event information:"));
    Serial.print(F("[LoRaWAN] Confirmed:\t"));
    Serial.println(eventDown.confirmed);
    Serial.print(F("[LoRaWAN] Confirming:\t"));
    Serial.println(eventDown.confirming);
    Serial.print(F("[LoRaWAN] Datarate:\t"));
    Serial.println(eventDown.datarate);
    Serial.print(F("[LoRaWAN] Frequency:\t"));
    Serial.print(eventDown.freq, 3);
    Serial.println(F(" MHz"));
    Serial.print(F("[LoRaWAN] Frame count:\t"));
    Serial.println(eventDown.fCnt);
    Serial.print(F("[LoRaWAN] Port:\t\t"));
    Serial.println(eventDown.fPort);
    Serial.print(F("[LoRaWAN] Time-on-air: \t"));
    Serial.print(node.getLastToA());
    Serial.println(F(" ms"));
    Serial.print(F("[LoRaWAN] Rx window: \t"));
    Serial.println(state);
  }
}
```

This 'should' be called continuously in the loop - it doesn't really need to, you can surely delay for seconds, but then a subsequent downlink may already have arrived and overwritten the previous one...

Feedback on higher and lower levels of implementation welcome. Marked as draft to discourage actual use, testing only.