### PR TITLE
Fix(PicoHal): Inline global symbols for tone() to prevent linker errors

### DIFF
--- a/src/hal/RPiPico/PicoHal.h
+++ b/src/hal/RPiPico/PicoHal.h
@@ -12,9 +12,9 @@
 #include "hardware/clocks.h"
 #include "pico/multicore.h"
 
-uint32_t toneLoopPin;
-unsigned int toneLoopFrequency;
-unsigned long toneLoopDuration;
+inline uint32_t toneLoopPin;
+inline unsigned int toneLoopFrequency;
+inline unsigned long toneLoopDuration;
 
 // pre-calculated pulse-widths for 1200 and 2200Hz
 // we do this to save calculation time (see https://github.com/khoih-prog/RP2040_PWM/issues/6)
@@ -25,7 +25,7 @@ unsigned long toneLoopDuration;
 // The tone(...) implementation uses the second core on the RPi Pico. This is to diminish as much 
 // jitter in the output tones as possible.
 
-void toneLoop(){
+inline void toneLoop(){
   gpio_set_dir(toneLoopPin, GPIO_OUT);
 
   uint32_t sleep_dur;


### PR DESCRIPTION
This change addresses "multiple definition" linker errors that occur when `PicoHal.h` is included in multiple C++ translation units within the same project. These errors specifically relate to symbols used by the `tone()` functionality for the Raspberry Pi Pico.

**Problem:**

The global variables `toneLoopPin`, `toneLoopFrequency`, `toneLoopDuration`, and the helper function `toneLoop()` were defined directly in `PicoHal.h` without `static` or `inline` modifiers. When `PicoHal.h` (or a header file that transitively includes it, such as `RadioLib.h`) is included in several `.cpp` files, each compiled object file would contain a definition of these symbols. This leads to "multiple definition" errors at the linking stage (e.g., "multiple definition of `toneLoopPin`"), as the linker encounters the same symbol defined in multiple object files.

**Solution:**

The `inline` keyword has been applied to the definitions of these global symbols within `PicoHal.h`:
- For the variables (`toneLoopPin`, `toneLoopFrequency`, `toneLoopDuration`), this utilizes the C++17 "inline variables" feature. Inline variables can be defined in a header file and ensure that only one definition of the variable exists across the entire program, even if the header is included in multiple translation units. They retain external linkage.
- For the `toneLoop()` function, `inline` suggests to the compiler that calls to the function may be replaced by the function's body, and also allows its definition in a header file included in multiple translation units without causing linker errors.

**Impact:**

- Resolves the "multiple definition" linker errors for `toneLoopPin`, `toneLoopFrequency`, `toneLoopDuration`, and `toneLoop()`.
- Allows `PicoHal.h` to be included more robustly in C++17 (or later) projects with multiple source files that utilize RadioLib on the Raspberry Pi Pico.
- The intended functionality of `PicoHal::tone()`, including the use of the RP2040's second core for tone generation via `multicore_launch_core1(toneLoop)`, is preserved.

**Prerequisites:**

This solution relies on the C++17 standard for the "inline variables" feature. The typical toolchain for Raspberry Pi Pico development (based on GCC ARM Embedded) supports C++17.

**Testing:**
This change has been tested in a project where the multiple definition errors were previously occurring. After applying these `inline` specifiers, the project links successfully, and the `tone()` functionality on the RP2040 operates as expected.
