### PR TITLE
Fix RFM typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ RadioLib was originally created as a driver for [__RadioShield__](https://github
 * __LR11x0__ series LoRa/GFSK modules (LR1110, LR1120, LR1121)
 * __nRF24L01__ 2.4 GHz module
 * __RF69__ FSK/OOK radio module
-* __RFM2x__ series FSK modules (RFM22, RM23)
-* __RFM9x__ series LoRa modules (RFM95, RM96, RFM97, RFM98)
+* __RFM2x__ series FSK modules (RFM22, RFM23)
+* __RFM9x__ series LoRa modules (RFM95, RFM96, RFM97, RFM98)
 * __Si443x__ series FSK modules (Si4430, Si4431, Si4432)
 * __STM32WL__ integrated microcontroller/LoRa module
 * __SX126x__ series LoRa modules (SX1261, SX1262, SX1268)


### PR DESCRIPTION
Fixed a small typo in the README.

- Changing "RM23" to "RFM23"
- Changing "RM96" to "RFM96"