### PR TITLE
Optimize default CAD parameters

### DIFF
--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -1866,20 +1866,12 @@ int16_t SX126x::setRx(uint32_t timeout) {
 }
 
 int16_t SX126x::setCad(uint8_t symbolNum, uint8_t detPeak, uint8_t detMin, uint8_t exitMode, RadioLibTime_t timeout) {
-  // default CAD parameters are shown in Semtech AN1200.48, page 41.
-  const uint8_t detPeakValues[6] = { 22, 22, 24, 25, 26, 30};
-
-  // CAD parameters aren't available for SF-6. Just to be safe.
-  if(this->spreadingFactor < 7) {
-    this->spreadingFactor = 7;
-  } else if(this->spreadingFactor > 12) {
-    this->spreadingFactor = 12;
-  }
+  // default CAD parameters are selected according to recommendations on Semtech DS.SX1261-2.W.APP rev. 1.1, page 92.
 
   // build the packet with default configuration
   uint8_t data[7];
-  data[0] = RADIOLIB_SX126X_CAD_ON_2_SYMB;
-  data[1] = detPeakValues[this->spreadingFactor - 7];
+  data[0] = RADIOLIB_SX126X_CAD_ON_4_SYMB;
+  data[1] = this->spreadingFactor + 13;
   data[2] = RADIOLIB_SX126X_CAD_PARAM_DET_MIN;
   data[3] = RADIOLIB_SX126X_CAD_GOTO_STDBY;
   uint32_t timeout_raw = (float)timeout / 15.625f;


### PR DESCRIPTION
This PR addresses #1526 by optimizing default CAD parameters according to DS.SX1261-2.W.APP rev. 1.1, page 92. This should improve detection rate at lower RSSI values, reduce false positives, and improve detection performance for SF5 and SF6 in particular. In addition, hard-coded values are eliminated for cadDetPeak.