### PR TITLE
[LR11X0] Add support for specifying PA ramp time

### DIFF
--- a/src/modules/LR11x0/LR1110.cpp
+++ b/src/modules/LR11x0/LR1110.cpp
@@ -71,7 +71,7 @@ int16_t LR1110::setOutputPower(int8_t power) {
   return(this->setOutputPower(power, false));
 }
 
-int16_t LR1110::setOutputPower(int8_t power, bool forceHighPower) {
+int16_t LR1110::setOutputPower(int8_t power, bool forceHighPower, uint32_t rampTimeUs) {
   // check if power value is configurable
   int16_t state = this->checkOutputPower(power, NULL, forceHighPower);
   RADIOLIB_ASSERT(state);
@@ -86,7 +86,7 @@ int16_t LR1110::setOutputPower(int8_t power, bool forceHighPower) {
   RADIOLIB_ASSERT(state);
 
   // set output power
-  state = setTxParams(power, RADIOLIB_LR11X0_PA_RAMP_48U);
+  state = setTxParams(power, roundRampTime(rampTimeUs));
   return(state);
 }
 

--- a/src/modules/LR11x0/LR1110.h
+++ b/src/modules/LR11x0/LR1110.h
@@ -103,9 +103,11 @@ class LR1110: public LR11x0 {
       \param power Output power to be set in dBm.
       \param forceHighPower Force using the high-power PA. If set to false, PA will be determined automatically
       based on configured output power, preferring the low-power PA. If set to true, only high-power PA will be used.
+      \param rampTimeUs PA power ramping time in microseconds. Provided value is rounded up to the
+      nearest discrete ramp time supported by the PA. Defaults to 48 us.
       \returns \ref status_codes
     */
-    int16_t setOutputPower(int8_t power, bool forceHighPower);
+    int16_t setOutputPower(int8_t power, bool forceHighPower, uint32_t rampTimeUs = 48);
 
     /*!
       \brief Check if output power is configurable.

--- a/src/modules/LR11x0/LR1120.cpp
+++ b/src/modules/LR11x0/LR1120.cpp
@@ -78,7 +78,7 @@ int16_t LR1120::setOutputPower(int8_t power) {
   return(this->setOutputPower(power, false));
 }
 
-int16_t LR1120::setOutputPower(int8_t power, bool forceHighPower) {
+int16_t LR1120::setOutputPower(int8_t power, bool forceHighPower, uint32_t rampTimeUs) {
   // check if power value is configurable
   int16_t state = this->checkOutputPower(power, NULL, forceHighPower);
   RADIOLIB_ASSERT(state);
@@ -100,7 +100,7 @@ int16_t LR1120::setOutputPower(int8_t power, bool forceHighPower) {
   RADIOLIB_ASSERT(state);
 
   // set output power
-  state = setTxParams(power, RADIOLIB_LR11X0_PA_RAMP_48U);
+  state = setTxParams(power, roundRampTime(rampTimeUs));
   return(state);
 }
 

--- a/src/modules/LR11x0/LR1120.h
+++ b/src/modules/LR11x0/LR1120.h
@@ -112,9 +112,11 @@ class LR1120: public LR11x0 {
       If set to false, PA will be determined automatically based on configured output power and frequency,
       preferring the low-power PA but always using high-frequency PA in 2.4 GHz band.
       Ignored when operating in 2.4 GHz band.
+      \param rampTimeUs PA power ramping time in microseconds. Provided value is rounded up to the
+      nearest discrete ramp time supported by the PA. Defaults to 48 us.
       \returns \ref status_codes
     */
-    int16_t setOutputPower(int8_t power, bool forceHighPower);
+    int16_t setOutputPower(int8_t power, bool forceHighPower, uint32_t rampTimeUs = 48);
 
     /*!
       \brief Check if output power is configurable.

--- a/src/modules/LR11x0/LR11x0.h
+++ b/src/modules/LR11x0/LR11x0.h
@@ -443,7 +443,22 @@
 #define RADIOLIB_LR11X0_GFSK_WHITENING_ENABLED                  (0x01UL << 0)   //  7     0                enabled
 
 // RADIOLIB_LR11X0_CMD_SET_TX_PARAMS
-#define RADIOLIB_LR11X0_PA_RAMP_48U                             (0x02UL << 0)   //  7     0     PA ramp time: 48 us
+#define RADIOLIB_LR11X0_PA_RAMP_16U                             (0x00UL << 0)   //  7     0     PA ramp time: 16 us
+#define RADIOLIB_LR11X0_PA_RAMP_32U                             (0x01UL << 0)   //  7     0                   32 us
+#define RADIOLIB_LR11X0_PA_RAMP_48U                             (0x02UL << 0)   //  7     0                   48 us
+#define RADIOLIB_LR11X0_PA_RAMP_64U                             (0x03UL << 0)   //  7     0                   64 us
+#define RADIOLIB_LR11X0_PA_RAMP_80U                             (0x04UL << 0)   //  7     0                   80 us
+#define RADIOLIB_LR11X0_PA_RAMP_96U                             (0x05UL << 0)   //  7     0                   96 us
+#define RADIOLIB_LR11X0_PA_RAMP_112U                            (0x06UL << 0)   //  7     0                   112 us
+#define RADIOLIB_LR11X0_PA_RAMP_128U                            (0x07UL << 0)   //  7     0                   128 us
+#define RADIOLIB_LR11X0_PA_RAMP_144U                            (0x08UL << 0)   //  7     0                   144 us
+#define RADIOLIB_LR11X0_PA_RAMP_160U                            (0x09UL << 0)   //  7     0                   160 us
+#define RADIOLIB_LR11X0_PA_RAMP_176U                            (0x0AUL << 0)   //  7     0                   176 us
+#define RADIOLIB_LR11X0_PA_RAMP_192U                            (0x0BUL << 0)   //  7     0                   192 us
+#define RADIOLIB_LR11X0_PA_RAMP_208U                            (0x0CUL << 0)   //  7     0                   208 us
+#define RADIOLIB_LR11X0_PA_RAMP_240U                            (0x0DUL << 0)   //  7     0                   240 us
+#define RADIOLIB_LR11X0_PA_RAMP_272U                            (0x0EUL << 0)   //  7     0                   272 us
+#define RADIOLIB_LR11X0_PA_RAMP_304U                            (0x0FUL << 0)   //  7     0                   304 us
 
 // RADIOLIB_LR11X0_CMD_SET_RX_TX_FALLBACK_MODE
 #define RADIOLIB_LR11X0_FALLBACK_MODE_STBY_RC                   (0x01UL << 0)   //  1     0     fallback mode after Rx/Tx: standby with RC
@@ -1609,6 +1624,14 @@ class LR11x0: public PhysicalLayer {
   protected:
 #endif
     Module* getMod() override;
+
+    // LR11x0 command helpers
+    /*!
+      \brief Round up a PA power ramp time to register value
+      \param rampTimeUs Ramp time in microseconds
+      \returns Register value of rounded ramp time
+    */
+    uint8_t roundRampTime(uint32_t rampTimeUs);
 
     // LR11x0 SPI command implementations
     int16_t writeRegMem32(uint32_t addr, const uint32_t* data, size_t len);

--- a/src/modules/LR11x0/LR11x0_commands.cpp
+++ b/src/modules/LR11x0/LR11x0_commands.cpp
@@ -8,6 +8,48 @@
 
 #if !RADIOLIB_EXCLUDE_LR11X0
 
+uint8_t LR11x0::roundRampTime(uint32_t rampTimeUs)
+{
+  uint8_t regVal;
+
+  // Round up the ramp time to nearest discrete register value
+  if(rampTimeUs <= 16) {
+    regVal = RADIOLIB_LR11X0_PA_RAMP_16U;
+  } else if(rampTimeUs <= 32) {
+    regVal = RADIOLIB_LR11X0_PA_RAMP_32U;
+  } else if(rampTimeUs <= 48) {
+    regVal = RADIOLIB_LR11X0_PA_RAMP_48U;
+  } else if(rampTimeUs <= 64) {
+    regVal = RADIOLIB_LR11X0_PA_RAMP_64U;
+  } else if(rampTimeUs <= 80) {
+    regVal = RADIOLIB_LR11X0_PA_RAMP_80U;
+  } else if(rampTimeUs <= 96) {
+    regVal = RADIOLIB_LR11X0_PA_RAMP_96U;
+  } else if(rampTimeUs <= 112) {
+    regVal = RADIOLIB_LR11X0_PA_RAMP_112U;
+  } else if(rampTimeUs <= 128) {
+    regVal = RADIOLIB_LR11X0_PA_RAMP_128U;
+  } else if(rampTimeUs <= 144) {
+    regVal = RADIOLIB_LR11X0_PA_RAMP_144U;
+  } else if(rampTimeUs <= 160) {
+    regVal = RADIOLIB_LR11X0_PA_RAMP_160U;
+  } else if(rampTimeUs <= 176) {
+    regVal = RADIOLIB_LR11X0_PA_RAMP_176U;
+  } else if(rampTimeUs <= 192) {
+    regVal = RADIOLIB_LR11X0_PA_RAMP_192U;
+  } else if(rampTimeUs <= 208) {
+    regVal = RADIOLIB_LR11X0_PA_RAMP_208U;
+  } else if(rampTimeUs <= 240) {
+    regVal = RADIOLIB_LR11X0_PA_RAMP_240U;
+  } else if(rampTimeUs <= 272) {
+    regVal = RADIOLIB_LR11X0_PA_RAMP_272U;
+  } else {  // 304
+    regVal = RADIOLIB_LR11X0_PA_RAMP_304U;
+  }
+
+  return regVal;
+}
+
 int16_t LR11x0::writeRegMem32(uint32_t addr, const uint32_t* data, size_t len) {
   // check maximum size
   if(len > (RADIOLIB_LR11X0_SPI_MAX_READ_WRITE_LEN/sizeof(uint32_t))) {


### PR DESCRIPTION
## Description

This PR adds support for specifying PA power ramp time on the LR11X0 targets by adding an extra `rampTimeUs` parameter to the `setOutputPower()` function.

Note: The LR11x0 targets only support discrete ramp times. A `roundRampTime()` helper function is added to round up a ramp time to the nearest supported ramp time. Conversion is done via `if`/`else if` due to the discrete ramp times not  scale linearly.