### PR TITLE
[CI] ESP-IDF fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -257,6 +257,7 @@ jobs:
           mkdir -p ~/esp
           cd ~/esp
           git clone --recursive https://github.com/espressif/esp-idf.git
+          cd esp-idf
           git checkout v5.4.2
           git submodule update --init --recursive
       

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -257,6 +257,8 @@ jobs:
           mkdir -p ~/esp
           cd ~/esp
           git clone --recursive https://github.com/espressif/esp-idf.git
+          git checkout v5.4.2
+          git submodule update --init --recursive
       
       - name: Install ESP-IDF
         run: |


### PR DESCRIPTION
So far we did not have a fixed version of the ESP-IDF in CI and we always used the master. That's not a great practice which sometimes caused the pipeline to break. This PR fixes the version to the latest currently released ESP-IDF version (5.4.2).

It also masks [some errors with virtual methods overloading](https://github.com/jgromes/RadioLib/actions/runs/15974210120/job/45052310112), but we can return to that after a stable new version of ESP-IDF is released.