### PR TITLE
Update PhysicalLayer.h

### DIFF
--- a/src/protocols/PhysicalLayer/PhysicalLayer.h
+++ b/src/protocols/PhysicalLayer/PhysicalLayer.h
@@ -234,9 +234,6 @@ class PhysicalLayer {
     */
     virtual ~PhysicalLayer() = default;
 
-
-
-
     // basic methods
 
     #if defined(RADIOLIB_BUILD_ARDUINO)

--- a/src/protocols/PhysicalLayer/PhysicalLayer.h
+++ b/src/protocols/PhysicalLayer/PhysicalLayer.h
@@ -229,6 +229,14 @@ class PhysicalLayer {
     */
     PhysicalLayer();
 
+    /*!
+      \brief Default destructor.
+    */
+    virtual ~PhysicalLayer() = default;
+
+
+
+
     // basic methods
 
     #if defined(RADIOLIB_BUILD_ARDUINO)


### PR DESCRIPTION
Add a virtual destructor, so can use new + delete on inherited objects

Solves this error: 
error: deleting object of abstract class type 'PhysicalLayer' which has non-virtual destructor will cause undefined behavior [-Werror=delete-non-virtual-dtor]