### PR TITLE
Remove hard coded interrupt mode from PicoHAL

### DIFF
--- a/src/hal/RPiPico/PicoHal.h
+++ b/src/hal/RPiPico/PicoHal.h
@@ -69,7 +69,7 @@ public:
       return;
     }
 
-    gpio_set_irq_enabled_with_callback(interruptNum, GPIO_IRQ_EDGE_RISE | GPIO_IRQ_EDGE_FALL, true, (gpio_irq_callback_t)interruptCb);
+    gpio_set_irq_enabled_with_callback(interruptNum, mode, true, (gpio_irq_callback_t)interruptCb);
   }
 
   void detachInterrupt(uint32_t interruptNum) override {
@@ -77,7 +77,7 @@ public:
       return;
     }
 
-    gpio_set_irq_enabled_with_callback(interruptNum, GPIO_IRQ_EDGE_RISE | GPIO_IRQ_EDGE_FALL, false, NULL);
+    gpio_set_irq_enabled_with_callback(interruptNum, 0, false, NULL);
   }
 
   void delay(unsigned long ms) override {


### PR DESCRIPTION
Modified the `attachInterrupt` function in PicoHal.h so that the `mode` argument is passed into the events argument of `gpio_set_irq_enabled_with_callback`. Previously this used hard coded values that caused spurious (extra) interrupts.

This was tested using a Raspberry Pi Pico and an RFM96W module using code based on examples/SX127x/SX127x_Receive_Interrupt/SX127x_Receive_Interrupt.ino with a counter added into the receive interrupt callback.

``` c
volatile bool receivedFlag = false;
volatile int rx_count = 0;

void setFlag(void) {
  // we got a packet, set the flag
  receivedFlag = true;
  rx_count++;

}
```

The `receivedFlag` is serviced in the the `main` functions loop as follows:

``` c
        if (receivedFlag)
        {
            // reset flag
            receivedFlag = false;

            int numBytes = radio.getPacketLength();
            int rx_state = radio.readData(rx_buffer, numBytes);

            printf("[RFM96] Received packet %d %d %d %f %f %f\n", rx_count, numBytes, rx_state, radio.getRSSI(), radio.getSNR(), radio.getFrequencyError());
 
     }
```
This image shows the output after 5 packets are sent before the modification to the HAL. The interrupt routine fires twice for each received packet. 
<img width="502" height="172" alt="Pasted image 20250718082405" src="https://github.com/user-attachments/assets/86916bbc-5649-4341-a05f-e30e3745c119" />

This image shows the output after 5 packets are sent after the modification to the HAL. The interrupt routine fires only once for each received packet.
<img width="496" height="95" alt="Pasted image 20250718081804" src="https://github.com/user-attachments/assets/47273b42-7eea-441b-9a0f-c801fbaffbe7" />


