### PR TITLE
Fix overload-virtual errors

### DIFF
--- a/src/modules/CC1101/CC1101.cpp
+++ b/src/modules/CC1101/CC1101.cpp
@@ -662,6 +662,10 @@ int16_t CC1101::checkOutputPower(int8_t power, int8_t* clipped, uint8_t* raw) {
   return(RADIOLIB_ERR_INVALID_OUTPUT_POWER);
 }
 
+int16_t CC1101::setSyncWord(uint8_t* sync, size_t len) {
+  return this->setSyncWord(sync, len, 0, false);
+}
+
 int16_t CC1101::setSyncWord(const uint8_t* syncWord, uint8_t len, uint8_t maxErrBits, bool requireCarrierSense) {
   if((maxErrBits > 1) || (len != 2)) {
     return(RADIOLIB_ERR_INVALID_SYNC_WORD);
@@ -690,6 +694,9 @@ int16_t CC1101::setSyncWord(uint8_t syncH, uint8_t syncL, uint8_t maxErrBits, bo
   return(setSyncWord(syncWord, sizeof(syncWord), maxErrBits, requireCarrierSense));
 }
 
+int16_t CC1101::setPreambleLength(size_t len) {
+  return this->setPreambleLength(len, 7*4);
+}
 int16_t CC1101::setPreambleLength(uint8_t preambleLength, uint8_t qualityThreshold) {
   // check allowed values
   uint8_t value;

--- a/src/modules/CC1101/CC1101.h
+++ b/src/modules/CC1101/CC1101.h
@@ -827,6 +827,14 @@ class CC1101: public PhysicalLayer {
     int16_t checkOutputPower(int8_t power, int8_t* clipped, uint8_t* raw);
 
     /*!
+      \brief Set 1 or 2 bytes of sync word.
+      \param sync Pointer to the sync word.
+      \param len Sync word length in bytes. Maximum length depends on the module used.
+      \returns \ref status_codes
+    */
+    int16_t setSyncWord(uint8_t* sync, size_t len);
+
+    /*!
       \brief Sets 16-bit sync word as a two byte value.
       \param syncH MSB of the sync word.
       \param syncL LSB of the sync word.
@@ -845,6 +853,13 @@ class CC1101: public PhysicalLayer {
       \returns \ref status_codes
     */
     int16_t setSyncWord(const uint8_t* syncWord, uint8_t len, uint8_t maxErrBits = 0, bool requireCarrierSense = false);
+
+    /*!
+      \brief Sets preamble length.
+      \param len Preamble length to be set (in bits), allowed values: 16, 24, 32, 48, 64, 96, 128 and 192.
+      \returns \ref status_codes
+    */
+    int16_t setPreambleLength(size_t len);
 
     /*!
       \brief Sets preamble length.

--- a/src/modules/RF69/RF69.cpp
+++ b/src/modules/RF69/RF69.cpp
@@ -713,7 +713,7 @@ int16_t RF69::setSyncWord(const uint8_t* syncWord, size_t len, uint8_t maxErrBit
   return(state);
 }
 
-int16_t RF69::setPreambleLength(uint8_t preambleLen) {
+int16_t RF69::setPreambleLength(size_t preambleLen) {
   // RF69 configures preamble length in bytes
   if(preambleLen % 8 != 0) {
     return(RADIOLIB_ERR_INVALID_PREAMBLE_LENGTH);

--- a/src/modules/RF69/RF69.h
+++ b/src/modules/RF69/RF69.h
@@ -796,7 +796,7 @@ class RF69: public PhysicalLayer {
       \param preambleLen Preamble length to be set (in bits), allowed values: 16, 24, 32, 48, 64, 96, 128 and 192.
       \returns \ref status_codes
     */
-    int16_t setPreambleLength(uint8_t preambleLen);
+    int16_t setPreambleLength(size_t preambleLen);
 
     /*!
       \brief Sets node address. Calling this method will also enable address filtering for node address only.

--- a/src/modules/SX128x/SX128x.cpp
+++ b/src/modules/SX128x/SX128x.cpp
@@ -793,7 +793,7 @@ int16_t SX128x::getModem(ModemType_t* modem) {
   return(RADIOLIB_ERR_WRONG_MODEM);
 }
 
-int16_t SX128x::setPreambleLength(uint32_t preambleLength) {
+int16_t SX128x::setPreambleLength(size_t preambleLength) {
   uint8_t modem = getPacketType();
   if((modem == RADIOLIB_SX128X_PACKET_TYPE_LORA) || (modem == RADIOLIB_SX128X_PACKET_TYPE_RANGING)) {
     // LoRa or ranging

--- a/src/modules/SX128x/SX128x.h
+++ b/src/modules/SX128x/SX128x.h
@@ -669,7 +669,7 @@ class SX128x: public PhysicalLayer {
       \param preambleLength Preamble length to be set in symbols (LoRa) or bits (FSK/BLE/FLRC).
       \returns \ref status_codes
     */
-    int16_t setPreambleLength(uint32_t preambleLength);
+    int16_t setPreambleLength(size_t preambleLength);
 
     /*!
       \brief Set data rate.

--- a/src/modules/Si443x/Si443x.cpp
+++ b/src/modules/Si443x/Si443x.cpp
@@ -533,7 +533,7 @@ int16_t Si443x::setSyncWord(uint8_t* syncWord, size_t len) {
   return(state);
 }
 
-int16_t Si443x::setPreambleLength(uint8_t preambleLen) {
+int16_t Si443x::setPreambleLength(size_t preambleLen) {
   // Si443x configures preamble length in 4-bit nibbles
   if(preambleLen % 4 != 0) {
     return(RADIOLIB_ERR_INVALID_PREAMBLE_LENGTH);

--- a/src/modules/Si443x/Si443x.h
+++ b/src/modules/Si443x/Si443x.h
@@ -752,7 +752,7 @@ class Si443x: public PhysicalLayer {
       \param preambleLen Preamble length to be set (in bits).
       \returns \ref status_codes
     */
-    int16_t setPreambleLength(uint8_t preambleLen);
+    int16_t setPreambleLength(size_t preambleLen);
 
      /*!
       \brief Query modem for the packet length of received payload.


### PR DESCRIPTION
This fixes the compilation errors on esp-idf v5.5.0: Werror=overloaded-virtual. This fixes #1570 
