### PR TITLE
receive() method - improving and fixing bugs

### DIFF
--- a/src/modules/CC1101/CC1101.cpp
+++ b/src/modules/CC1101/CC1101.cpp
@@ -58,9 +58,9 @@ int16_t CC1101::transmit(const uint8_t* data, size_t len, uint8_t addr) {
   return(finishTransmit());
 }
 
-int16_t CC1101::receive(uint8_t* data, size_t len) {
-  // calculate timeout (500 ms + 400 full max-length packets at current bit rate)
-  RadioLibTime_t timeout = 500 + (1.0f/(this->bitRate))*(RADIOLIB_CC1101_MAX_PACKET_LENGTH*400.0f);
+int16_t CC1101::receive(uint8_t* data, size_t len, RadioLibTime_t exTimeout) {
+  // calculate timeout (500 ms + 400 full max-length packets at current bit rate + user extra timeout)
+  RadioLibTime_t timeout = 500 + (1.0f/(this->bitRate))*(RADIOLIB_CC1101_MAX_PACKET_LENGTH*400.0f) + exTimeout;
 
   // start reception
   int16_t state = startReceive();

--- a/src/modules/CC1101/CC1101.h
+++ b/src/modules/CC1101/CC1101.h
@@ -599,9 +599,11 @@ class CC1101: public PhysicalLayer {
       Overloads for string-based transmissions are implemented in PhysicalLayer.
       \param data Binary data to be sent.
       \param len Number of bytes to send.
+      \param exTimeout User extra timeout (ms). 
+      Used to allow the sender to prepare its reply, if needed.
       \returns \ref status_codes
     */
-    int16_t receive(uint8_t* data, size_t len) override;
+    int16_t receive(uint8_t* data, size_t len, RadioLibTime_t exTimeout) override;
 
     /*!
       \brief Sets the module to standby mode.

--- a/src/modules/LR11x0/LR11x0.cpp
+++ b/src/modules/LR11x0/LR11x0.cpp
@@ -223,7 +223,7 @@ int16_t LR11x0::transmit(const uint8_t* data, size_t len, uint8_t addr) {
   return(finishTransmit());
 }
 
-int16_t LR11x0::receive(uint8_t* data, size_t len) {
+int16_t LR11x0::receive(uint8_t* data, size_t len, RadioLibTime_t exTimeout) {
   // set mode to standby
   int16_t state = standby();
   RADIOLIB_ASSERT(state);
@@ -256,6 +256,9 @@ int16_t LR11x0::receive(uint8_t* data, size_t len) {
     return(RADIOLIB_ERR_UNKNOWN);
   
   }
+
+  // adding user extra timeout
+  timeout += exTimeout;  
 
   RADIOLIB_DEBUG_BASIC_PRINTLN("Timeout in %lu ms", timeout);
 

--- a/src/modules/LR11x0/LR11x0.h
+++ b/src/modules/LR11x0/LR11x0.h
@@ -992,9 +992,11 @@ class LR11x0: public PhysicalLayer {
       Overloads for string-based transmissions are implemented in PhysicalLayer.
       \param data Binary data to be sent.
       \param len Number of bytes to send.
+      \param exTimeout User extra timeout (ms). 
+      Used to allow the sender to prepare its reply, if needed.
       \returns \ref status_codes
     */
-    int16_t receive(uint8_t* data, size_t len) override;
+    int16_t receive(uint8_t* data, size_t len, RadioLibTime_t exTimeout) override;
 
     /*!
       \brief Starts direct mode transmission.

--- a/src/modules/RF69/RF69.cpp
+++ b/src/modules/RF69/RF69.cpp
@@ -122,9 +122,9 @@ int16_t RF69::transmit(const uint8_t* data, size_t len, uint8_t addr) {
   return(finishTransmit());
 }
 
-int16_t RF69::receive(uint8_t* data, size_t len) {
-  // calculate timeout (500 ms + 400 full 64-byte packets at current bit rate)
-  RadioLibTime_t timeout = 500 + (1.0f/(this->bitRate))*(RADIOLIB_RF69_MAX_PACKET_LENGTH*400.0f);
+int16_t RF69::receive(uint8_t* data, size_t len, RadioLibTime_t exTimeout) {
+  // calculate timeout (500 ms + 400 full 64-byte packets at current bit rate + user extra timeout)
+  RadioLibTime_t timeout = 500 + (1.0f/(this->bitRate))*(RADIOLIB_RF69_MAX_PACKET_LENGTH*400.0f) + exTimeout;
 
   // start reception
   int16_t state = startReceive();

--- a/src/modules/RF69/RF69.h
+++ b/src/modules/RF69/RF69.h
@@ -530,9 +530,11 @@ class RF69: public PhysicalLayer {
       Overloads for string-based transmissions are implemented in PhysicalLayer.
       \param data Binary data to be sent.
       \param len Number of bytes to send.
+      \param exTimeout User extra timeout (ms). 
+      Used to allow the sender to prepare its reply, if needed.
       \returns \ref status_codes
     */
-    int16_t receive(uint8_t* data, size_t len) override;
+    int16_t receive(uint8_t* data, size_t len, RadioLibTime_t exTimeout) override;
 
     /*!
       \brief Sets the module to sleep mode.

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -567,9 +567,11 @@ class SX126x: public PhysicalLayer {
       Overloads for string-based transmissions are implemented in PhysicalLayer.
       \param data Binary data to be sent.
       \param len Number of bytes to send.
+      \param exTimeout User extra timeout (ms). 
+      Used to allow the sender to prepare its reply, if needed.
       \returns \ref status_codes
     */
-    int16_t receive(uint8_t* data, size_t len) override;
+    int16_t receive(uint8_t* data, size_t len, RadioLibTime_t exTimeout = 0) override;
 
     /*!
       \brief Starts direct mode transmission.

--- a/src/modules/SX127x/SX127x.cpp
+++ b/src/modules/SX127x/SX127x.cpp
@@ -211,7 +211,7 @@ int16_t SX127x::transmit(const uint8_t* data, size_t len, uint8_t addr) {
   return(finishTransmit());
 }
 
-int16_t SX127x::receive(uint8_t* data, size_t len) {
+int16_t SX127x::receive(uint8_t* data, size_t len, RadioLibTime_t exTimeout) {
   // set mode to standby
   int16_t state = setMode(RADIOLIB_SX127X_STANDBY);
   RADIOLIB_ASSERT(state);

--- a/src/modules/SX127x/SX127x.h
+++ b/src/modules/SX127x/SX127x.h
@@ -641,9 +641,10 @@ class SX127x: public PhysicalLayer {
       For overloads to receive Arduino String, see PhysicalLayer::receive.
       \param data Pointer to array to save the received binary data.
       \param len Number of bytes that will be received. Must be known in advance for binary transmissions.
+      \param exTimeout User extra timeout (ms). [Not yet implemented !]
       \returns \ref status_codes
     */
-    int16_t receive(uint8_t* data, size_t len) override;
+    int16_t receive(uint8_t* data, size_t len, RadioLibTime_t exTimeout) override;
 
     /*!
       \brief Performs scan for valid %LoRa preamble in the current channel.

--- a/src/modules/SX128x/SX128x.h
+++ b/src/modules/SX128x/SX128x.h
@@ -435,9 +435,11 @@ class SX128x: public PhysicalLayer {
       Overloads for string-based transmissions are implemented in PhysicalLayer.
       \param data Binary data to be sent.
       \param len Number of bytes to send.
+      \param exTimeout User extra timeout (ms). 
+      Used to allow the sender to prepare its reply, if needed.
       \returns \ref status_codes
     */
-    int16_t receive(uint8_t* data, size_t len) override;
+    int16_t receive(uint8_t* data, size_t len, RadioLibTime_t exTimeout) override;
 
     /*!
       \brief Starts direct mode transmission.

--- a/src/modules/Si443x/Si443x.cpp
+++ b/src/modules/Si443x/Si443x.cpp
@@ -97,9 +97,9 @@ int16_t Si443x::transmit(const uint8_t* data, size_t len, uint8_t addr) {
   return(finishTransmit());
 }
 
-int16_t Si443x::receive(uint8_t* data, size_t len) {
-  // calculate timeout (500 ms + 400 full 64-byte packets at current bit rate)
-  RadioLibTime_t timeout = 500 + (1.0f/(this->bitRate))*(RADIOLIB_SI443X_MAX_PACKET_LENGTH*400.0f);
+int16_t Si443x::receive(uint8_t* data, size_t len, RadioLibTime_t exTimeout) {
+  // calculate timeout (500 ms + 400 full 64-byte packets at current bit rate + user extra timeout)
+  RadioLibTime_t timeout = 500 + (1.0f/(this->bitRate))*(RADIOLIB_SI443X_MAX_PACKET_LENGTH*400.0f) + exTimeout;
 
   // start reception
   int16_t state = startReceive();

--- a/src/modules/Si443x/Si443x.h
+++ b/src/modules/Si443x/Si443x.h
@@ -598,9 +598,11 @@ class Si443x: public PhysicalLayer {
       For overloads to receive Arduino String, see PhysicalLayer::receive.
       \param data Pointer to array to save the received binary data.
       \param len Number of bytes that will be received. Must be known in advance for binary transmissions.
+      \param exTimeout User extra timeout (ms). 
+      Used to allow the sender to prepare its reply, if needed.
       \returns \ref status_codes
     */
-    int16_t receive(uint8_t* data, size_t len) override;
+    int16_t receive(uint8_t* data, size_t len, RadioLibTime_t exTimeout) override;
 
     /*!
       \brief Sets the module to sleep to save power. %Module will not be able to transmit or receive any data while in sleep mode.

--- a/src/modules/nRF24/nRF24.cpp
+++ b/src/modules/nRF24/nRF24.cpp
@@ -110,7 +110,7 @@ int16_t nRF24::transmit(const uint8_t* data, size_t len, uint8_t addr) {
   return(finishTransmit());
 }
 
-int16_t nRF24::receive(uint8_t* data, size_t len) {
+int16_t nRF24::receive(uint8_t* data, size_t len, RadioLibTime_t exTimeout) {
   // start reception
   int16_t state = startReceive();
   RADIOLIB_ASSERT(state);
@@ -120,8 +120,8 @@ int16_t nRF24::receive(uint8_t* data, size_t len) {
   while(this->mod->hal->digitalRead(this->mod->getIrq())) {
     this->mod->hal->yield();
 
-    // check timeout: 15 retries * 4ms (max Tx time as per datasheet) + 10 ms
-    if(this->mod->hal->millis() - start >= ((15 * 4) + 10)) {
+    // check timeout: 15 retries * 4ms (max Tx time as per datasheet) + 10 ms + user extra timeout
+    if(this->mod->hal->millis() - start >= ((15 * 4) + 10 + (uint32_t)exTimeout)) {
       standby();
       clearIRQ();
       return(RADIOLIB_ERR_RX_TIMEOUT);

--- a/src/modules/nRF24/nRF24.h
+++ b/src/modules/nRF24/nRF24.h
@@ -247,9 +247,11 @@ class nRF24: public PhysicalLayer {
       Overloads for string-based transmissions are implemented in PhysicalLayer.
       \param data Binary data to be sent.
       \param len Number of bytes to send.
+      \param exTimeout User extra timeout (ms). 
+      Used to allow the sender to prepare its reply, if needed.
       \returns \ref status_codes
     */
-    int16_t receive(uint8_t* data, size_t len) override;
+    int16_t receive(uint8_t* data, size_t len, RadioLibTime_t exTimeout) override;
 
     /*!
       \brief Starts direct mode transmission.

--- a/src/protocols/PhysicalLayer/PhysicalLayer.cpp
+++ b/src/protocols/PhysicalLayer/PhysicalLayer.cpp
@@ -62,7 +62,7 @@ int16_t PhysicalLayer::transmit(const uint8_t* data, size_t len, uint8_t addr) {
 }
 
 #if defined(RADIOLIB_BUILD_ARDUINO)
-int16_t PhysicalLayer::receive(String& str, size_t len) {
+int16_t PhysicalLayer::receive(String& str, size_t len, RadioLibTime_t exTimeout) {
   int16_t state = RADIOLIB_ERR_NONE;
 
   // user can override the length of data to read
@@ -82,7 +82,7 @@ int16_t PhysicalLayer::receive(String& str, size_t len) {
   #endif
 
   // attempt packet reception
-  state = receive(data, length);
+  state = receive(data, length, exTimeout);
 
   // any of the following leads to at least some data being available
   // let's leave the decision of whether to keep it or not up to the user
@@ -108,9 +108,10 @@ int16_t PhysicalLayer::receive(String& str, size_t len) {
 }
 #endif
 
-int16_t PhysicalLayer::receive(uint8_t* data, size_t len) {
+int16_t PhysicalLayer::receive(uint8_t* data, size_t len, RadioLibTime_t exTimeout) {
   (void)data;
   (void)len;
+  (void)exTimeout;
   return(RADIOLIB_ERR_UNSUPPORTED);
 }
 

--- a/src/protocols/PhysicalLayer/PhysicalLayer.h
+++ b/src/protocols/PhysicalLayer/PhysicalLayer.h
@@ -322,7 +322,8 @@ class PhysicalLayer {
       \brief Binary receive method. Must be implemented in module class.
       \param data Pointer to array to save the received binary data.
       \param len Packet length, needed for some modules under special circumstances (e.g. LoRa implicit header mode).
-      \param exTimeout User extra timeout, in milliseconds. Used if the sender must do some work before replaying.
+      \param exTimeout User extra timeout (ms). 
+      Used to allow the sender to prepare its reply, if needed.
       \returns \ref status_codes
     */
     virtual int16_t receive(uint8_t* data, size_t len, RadioLibTime_t exTimeout = 0ul);

--- a/src/protocols/PhysicalLayer/PhysicalLayer.h
+++ b/src/protocols/PhysicalLayer/PhysicalLayer.h
@@ -276,9 +276,10 @@ class PhysicalLayer {
       \brief Arduino String receive method.
       \param str Address of Arduino String to save the received data.
       \param len Expected number of characters in the message. Leave as 0 if expecting a unknown size packet
+      \param exTimeout User extra timeout, in milliseconds. Used if the sender must do some work before replaying.
       \returns \ref status_codes
     */
-    int16_t receive(String& str, size_t len = 0);
+    int16_t receive(String& str, size_t len = 0, RadioLibTime_t exTimeout = 0);
     #endif
 
     /*!
@@ -321,9 +322,10 @@ class PhysicalLayer {
       \brief Binary receive method. Must be implemented in module class.
       \param data Pointer to array to save the received binary data.
       \param len Packet length, needed for some modules under special circumstances (e.g. LoRa implicit header mode).
+      \param exTimeout User extra timeout, in milliseconds. Used if the sender must do some work before replaying.
       \returns \ref status_codes
     */
-    virtual int16_t receive(uint8_t* data, size_t len);
+    virtual int16_t receive(uint8_t* data, size_t len, RadioLibTime_t exTimeout = 0ul);
 
     #if defined(RADIOLIB_BUILD_ARDUINO)
     /*!


### PR DESCRIPTION

I was experimenting with SX1262 LoRa modules using RadioLib and I found an issue with the receive() method.

The chip has a hardware timer that can be set in receive mode, and it raises a DIO1 IRQ on timeout if no packet is detected within the specified period. If a packet is detected in time, the timer is stopped and the payload reception continues. The problem is that in the RadioLib receive() method there is also a software safety timer, with the same timeout value (fixed to 100 LoRa symbols). However, this software timer does not stop when the packet is detected, but only after the packet is fully received. In some cases, when the payload is large, this causes the reception to stop too early. See detailed test info in the [receive tests.xlsx](https://github.com/user-attachments/files/21982828/receive.tests.xlsx) attached Excel file. 

The solution is to calculate the software timeout separately using getTimeOnAir, which accounts for the payload length. I implemented this, and although the calculated value matches the Semtech calculator, in practice the actual reception takes about 5–100 ms longer. I believe this comes from delays introduced by the code that prepares the reception (or possibly other factors). To compensate, I added a 160 ms safety margin.
Additionally, the hardware timer needs a minimum limit of 60 ms, because with some settings (e.g. 500 kHz, SF5) the calculated timeout can be very small (5 ms), which also causes failures. With these modifications, the receive() method now passes all of my tests.
Note: For the FSK mode the behavior is unchanged, as I didn't study it and I don't understand how it works. Maybe, in the future, someone will correct that too...

I also added an optional parameter (exTimeout) to the receive() method, allowing the user to extend the calculated timeout if they know that the transmitting module requires extra time to process the request and prepare a reply. This is very important in some use cases.
To add this parameter I had to modify receive() in PhysicalLayer and then implement overrides in all modules that provide this method. I successfully added exTimeout support in all modules except SX127x, because I do not fully understand its logic and did not want to break anything, so I left it unchanged. The code remains backward compatible, as the exTimeout parameter is optional.

While implementing this new parameter, I also found a bug in SX128x: the calculated timeout was in microseconds, but later it was compared with millis() (which returns milliseconds). I fixed this as well.

The modifications summary:
 - SX126x.cpp -> updated for user extra timeout / fixed bug: software timeout doesn't account for the full packet to be received
 - SX128x.cpp -> updated for user extra timeout / fixed bug: microseconds timeout compared with millis() in safety timer
 - LR11x0.cpp -> updated for user extra timeout 
 - Si443x.cpp -> updated for user extra timeout
 - CC1101.cpp -> updated for user extra timeout
 - RF69.cpp   -> updated for user extra timeout
 - nRF24.cpp  -> updated for user extra timeout
 - SX127x.cpp -> extra timeout not used / I don't understand the code logic for this chip