### PR TITLE
Add support for LoRa coding rate 4/4

### DIFF
--- a/src/modules/LLCC68/LLCC68.cpp
+++ b/src/modules/LLCC68/LLCC68.cpp
@@ -151,7 +151,7 @@ int16_t LLCC68::checkDataRate(DataRate_t dr) {
 
   } else if(modem == RADIOLIB_SX126X_PACKET_TYPE_LORA) {
     RADIOLIB_CHECK_RANGE(dr.lora.bandwidth, 100.0f, 510.0f, RADIOLIB_ERR_INVALID_BANDWIDTH);
-    RADIOLIB_CHECK_RANGE(dr.lora.codingRate, 5, 8, RADIOLIB_ERR_INVALID_CODING_RATE);
+    RADIOLIB_CHECK_RANGE(dr.lora.codingRate, 4, 8, RADIOLIB_ERR_INVALID_CODING_RATE);
     uint8_t bw_div2 = dr.lora.bandwidth / 2 + 0.01f;
     switch (bw_div2)  {
       case 62: // 125.0:

--- a/src/modules/LLCC68/LLCC68.h
+++ b/src/modules/LLCC68/LLCC68.h
@@ -29,7 +29,8 @@ class LLCC68: public SX1262 {
       \param freq Carrier frequency in MHz. Defaults to 434.0 MHz.
       \param bw LoRa bandwidth in kHz. Defaults to 125.0 kHz.
       \param sf LoRa spreading factor. Defaults to 9.
-      \param cr LoRa coding rate denominator. Defaults to 7 (coding rate 4/7).
+      \param cr LoRa coding rate denominator. Defaults to 7 (coding rate 4/7). Allowed values range from 4 to 8. Note that a value of 4 means no coding,
+      is undocumented and not recommended without your own FEC.
       \param syncWord 1-byte LoRa sync word. Defaults to RADIOLIB_SX126X_SYNC_WORD_PRIVATE (0x12).
       \param pwr Output power in dBm. Defaults to 10 dBm.
       \param preambleLength LoRa preamble length in symbols. Defaults to 8 symbols.

--- a/src/modules/LR11x0/LR1110.h
+++ b/src/modules/LR11x0/LR1110.h
@@ -27,7 +27,8 @@ class LR1110: public LR11x0 {
       \param freq Carrier frequency in MHz. Defaults to 434.0 MHz.
       \param bw LoRa bandwidth in kHz. Defaults to 125.0 kHz.
       \param sf LoRa spreading factor. Defaults to 9.
-      \param cr LoRa coding rate denominator. Defaults to 7 (coding rate 4/7).
+      \param cr LoRa coding rate denominator. Defaults to 7 (coding rate 4/7). Allowed values range from 4 to 8. Note that a value of 4 means no coding,
+      is undocumented and not recommended without your own FEC.
       \param syncWord 1-byte LoRa sync word. Defaults to RADIOLIB_LR11X0_LORA_SYNC_WORD_PRIVATE (0x12).
       \param power Output power in dBm. Defaults to 10 dBm.
       \param preambleLength LoRa preamble length in symbols. Defaults to 8 symbols.

--- a/src/modules/LR11x0/LR1120.h
+++ b/src/modules/LR11x0/LR1120.h
@@ -27,7 +27,8 @@ class LR1120: public LR11x0 {
       \param freq Carrier frequency in MHz. Defaults to 434.0 MHz.
       \param bw LoRa bandwidth in kHz. Defaults to 125.0 kHz.
       \param sf LoRa spreading factor. Defaults to 9.
-      \param cr LoRa coding rate denominator. Defaults to 7 (coding rate 4/7).
+      \param cr LoRa coding rate denominator. Defaults to 7 (coding rate 4/7). Allowed values range from 4 to 8. Note that a value of 4 means no coding,
+      is undocumented and not recommended without your own FEC.
       \param syncWord 1-byte LoRa sync word. Defaults to RADIOLIB_LR11X0_LORA_SYNC_WORD_PRIVATE (0x12).
       \param power Output power in dBm. Defaults to 10 dBm.
       \param preambleLength LoRa preamble length in symbols. Defaults to 8 symbols.

--- a/src/modules/LR11x0/LR11x0.cpp
+++ b/src/modules/LR11x0/LR11x0.cpp
@@ -628,10 +628,13 @@ int16_t LR11x0::setCodingRate(uint8_t cr, bool longInterleave) {
     return(RADIOLIB_ERR_WRONG_MODEM);
   }
 
-  RADIOLIB_CHECK_RANGE(cr, 5, 8, RADIOLIB_ERR_INVALID_CODING_RATE);
+  RADIOLIB_CHECK_RANGE(cr, 4, 8, RADIOLIB_ERR_INVALID_CODING_RATE);
 
   if(longInterleave) {
     switch(cr) {
+      case 4:
+        this->codingRate = 0;
+        break;
       case 5:
       case 6:
         this->codingRate = cr;
@@ -1003,7 +1006,7 @@ int16_t LR11x0::checkDataRate(DataRate_t dr) {
   } else if(type == RADIOLIB_LR11X0_PACKET_TYPE_LORA) {
     RADIOLIB_CHECK_RANGE(dr.lora.spreadingFactor, 5, 12, RADIOLIB_ERR_INVALID_SPREADING_FACTOR);
     RADIOLIB_CHECK_RANGE(dr.lora.bandwidth, 0.0f, 510.0f, RADIOLIB_ERR_INVALID_BANDWIDTH);
-    RADIOLIB_CHECK_RANGE(dr.lora.codingRate, 5, 8, RADIOLIB_ERR_INVALID_CODING_RATE);
+    RADIOLIB_CHECK_RANGE(dr.lora.codingRate, 4, 8, RADIOLIB_ERR_INVALID_CODING_RATE);
     return(RADIOLIB_ERR_NONE);
   
   }

--- a/src/modules/LR11x0/LR11x0.h
+++ b/src/modules/LR11x0/LR11x0.h
@@ -933,7 +933,8 @@ class LR11x0: public PhysicalLayer {
       \brief Initialization method for LoRa modem.
       \param bw LoRa bandwidth in kHz.
       \param sf LoRa spreading factor.
-      \param cr LoRa coding rate denominator.
+      \param cr LoRa coding rate denominator. Allowed values range from 4 to 8. Note that a value of 4 means no coding,
+      is undocumented and not recommended without your own FEC.
       \param syncWord 1-byte LoRa sync word.
       \param preambleLength LoRa preamble length in symbols
       \param tcxoVoltage TCXO reference voltage to be set.
@@ -1159,7 +1160,8 @@ class LR11x0: public PhysicalLayer {
     int16_t setSpreadingFactor(uint8_t sf, bool legacy = false);
 
     /*!
-      \brief Sets LoRa coding rate denominator. Allowed values range from 5 to 8.
+      \brief Sets LoRa coding rate denominator. Allowed values range from 4 to 8. Note that a value of 4 means no coding, 
+      is undocumented and not recommended without your own FEC.
       \param cr LoRa coding rate denominator to be set.
       \param longInterleave Enable long interleaver when set to true.
       Note that CR 4/7 is not possible with long interleaver enabled!

--- a/src/modules/SX126x/SX1262.h
+++ b/src/modules/SX126x/SX1262.h
@@ -34,7 +34,8 @@ class SX1262: public SX126x {
       \param freq Carrier frequency in MHz. Defaults to 434.0 MHz.
       \param bw LoRa bandwidth in kHz. Defaults to 125.0 kHz.
       \param sf LoRa spreading factor. Defaults to 9.
-      \param cr LoRa coding rate denominator. Defaults to 7 (coding rate 4/7).
+      \param cr LoRa coding rate denominator. Defaults to 7 (coding rate 4/7). Allowed values range from 4 to 8. Note that a value of 4 means no coding,
+      is undocumented and not recommended without your own FEC.
       \param syncWord 1-byte LoRa sync word. Defaults to RADIOLIB_SX126X_SYNC_WORD_PRIVATE (0x12).
       \param power Output power in dBm. Defaults to 10 dBm.
       \param preambleLength LoRa preamble length in symbols. Defaults to 8 symbols.

--- a/src/modules/SX126x/SX1268.h
+++ b/src/modules/SX126x/SX1268.h
@@ -33,7 +33,8 @@ class SX1268: public SX126x {
       \param freq Carrier frequency in MHz. Defaults to 434.0 MHz.
       \param bw LoRa bandwidth in kHz. Defaults to 125.0 kHz.
       \param sf LoRa spreading factor. Defaults to 9.
-      \param cr LoRa coding rate denominator. Defaults to 7 (coding rate 4/7).
+      \param cr LoRa coding rate denominator. Defaults to 7 (coding rate 4/7). Allowed values range from 4 to 8. 
+      Note that a value of 4 means no coding, is undocumented and not recommended without your own FEC.
       \param syncWord 1-byte LoRa sync word. Defaults to RADIOLIB_SX126X_SYNC_WORD_PRIVATE (0x12).
       \param power Output power in dBm. Defaults to 10 dBm.
       \param preambleLength LoRa preamble length in symbols. Defaults to 8 symbols.

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -801,7 +801,7 @@ int16_t SX126x::setCodingRate(uint8_t cr) {
     return(RADIOLIB_ERR_WRONG_MODEM);
   }
 
-  RADIOLIB_CHECK_RANGE(cr, 5, 8, RADIOLIB_ERR_INVALID_CODING_RATE);
+  RADIOLIB_CHECK_RANGE(cr, 4, 8, RADIOLIB_ERR_INVALID_CODING_RATE);
 
   // update modulation parameters
   this->codingRate = cr - 4;
@@ -958,7 +958,7 @@ int16_t SX126x::checkDataRate(DataRate_t dr) {
   } else if(modem == RADIOLIB_SX126X_PACKET_TYPE_LORA) {
     RADIOLIB_CHECK_RANGE(dr.lora.spreadingFactor, 5, 12, RADIOLIB_ERR_INVALID_SPREADING_FACTOR);
     RADIOLIB_CHECK_RANGE(dr.lora.bandwidth, 0.0f, 510.0f, RADIOLIB_ERR_INVALID_BANDWIDTH);
-    RADIOLIB_CHECK_RANGE(dr.lora.codingRate, 5, 8, RADIOLIB_ERR_INVALID_CODING_RATE);
+    RADIOLIB_CHECK_RANGE(dr.lora.codingRate, 4, 8, RADIOLIB_ERR_INVALID_CODING_RATE);
     return(RADIOLIB_ERR_NONE);
   
   }

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -501,7 +501,8 @@ class SX126x: public PhysicalLayer {
 
     /*!
       \brief Initialization method for LoRa modem.
-      \param cr LoRa coding rate denominator. Allowed values range from 5 to 8.
+      \param cr LoRa coding rate denominator. Allowed values range from 4 to 8. Note that a value of 4 means no coding,
+      is undocumented and not recommended without your own FEC.
       \param syncWord 1-byte LoRa sync word.
       \param preambleLength LoRa preamble length in symbols. Allowed values range from 1 to 65535.
       \param tcxoVoltage TCXO reference voltage to be set on DIO3. Defaults to 1.6 V, set to 0 to skip.
@@ -774,7 +775,8 @@ class SX126x: public PhysicalLayer {
     virtual int16_t setSpreadingFactor(uint8_t sf);
 
     /*!
-      \brief Sets LoRa coding rate denominator. Allowed values range from 5 to 8.
+      \brief Sets LoRa coding rate denominator. Allowed values range from 4 to 8. Note that a value of 4 means no coding, 
+      is undocumented and not recommended without your own FEC.
       \param cr LoRa coding rate denominator to be set.
       \returns \ref status_codes
     */

--- a/src/modules/SX127x/SX1272.cpp
+++ b/src/modules/SX127x/SX1272.cpp
@@ -195,6 +195,9 @@ int16_t SX1272::setCodingRate(uint8_t cr) {
 
   // check allowed coding rate values
   switch(cr) {
+    case 4:
+      newCodingRate = RADIOLIB_SX1272_CR_4_4;
+      break;
     case 5:
       newCodingRate = RADIOLIB_SX1272_CR_4_5;
       break;
@@ -267,7 +270,7 @@ int16_t SX1272::checkDataRate(DataRate_t dr) {
   } else if(modem == RADIOLIB_SX127X_LORA) {
     RADIOLIB_CHECK_RANGE(dr.lora.spreadingFactor, 6, 12, RADIOLIB_ERR_INVALID_SPREADING_FACTOR);
     RADIOLIB_CHECK_RANGE(dr.lora.bandwidth, 100.0f, 510.0f, RADIOLIB_ERR_INVALID_BANDWIDTH);
-    RADIOLIB_CHECK_RANGE(dr.lora.codingRate, 5, 8, RADIOLIB_ERR_INVALID_CODING_RATE);
+    RADIOLIB_CHECK_RANGE(dr.lora.codingRate, 4, 8, RADIOLIB_ERR_INVALID_CODING_RATE);
     return(RADIOLIB_ERR_NONE);
   
   }

--- a/src/modules/SX127x/SX1272.h
+++ b/src/modules/SX127x/SX1272.h
@@ -31,7 +31,8 @@
 #define RADIOLIB_SX1272_BW_125_00_KHZ                           0b00000000  //  7     6   bandwidth:  125 kHz
 #define RADIOLIB_SX1272_BW_250_00_KHZ                           0b01000000  //  7     6               250 kHz
 #define RADIOLIB_SX1272_BW_500_00_KHZ                           0b10000000  //  7     6               500 kHz
-#define RADIOLIB_SX1272_CR_4_5                                  0b00001000  //  5     3   error coding rate:  4/5
+#define RADIOLIB_SX1272_CR_4_4                                  0b00000000  //  5     3   error coding rate:  4/4 (undocumented)
+#define RADIOLIB_SX1272_CR_4_5                                  0b00001000  //  5     3                       4/5
 #define RADIOLIB_SX1272_CR_4_6                                  0b00010000  //  5     3                       4/6
 #define RADIOLIB_SX1272_CR_4_7                                  0b00011000  //  5     3                       4/7
 #define RADIOLIB_SX1272_CR_4_8                                  0b00100000  //  5     3                       4/8
@@ -109,7 +110,8 @@ class SX1272: public SX127x {
       \param freq Carrier frequency in MHz. Allowed values range from 860.0 MHz to 1020.0 MHz.
       \param bw %LoRa link bandwidth in kHz. Allowed values are 125, 250 and 500 kHz.
       \param sf %LoRa link spreading factor. Allowed values range from 6 to 12.
-      \param cr %LoRa link coding rate denominator. Allowed values range from 5 to 8.
+      \param cr %LoRa link coding rate denominator. Allowed values range from 4 to 8. Note that a value of 4 means no coding,
+      is undocumented and not recommended without your own FEC.
       \param syncWord %LoRa sync word. Can be used to distinguish different networks. Note that value 0x34 is reserved for LoRaWAN networks.
       \param power Transmission output power in dBm. Allowed values range from 2 to 17 dBm.
       \param preambleLength Length of %LoRa transmission preamble in symbols. The actual preamble length is 4.25 symbols longer than the set number.
@@ -163,7 +165,8 @@ class SX1272: public SX127x {
     virtual int16_t setSpreadingFactor(uint8_t sf);
 
     /*!
-      \brief Sets %LoRa link coding rate denominator. Allowed values range from 5 to 8. Only available in %LoRa mode.
+      \brief Sets %LoRa link coding rate denominator. Allowed values range from 4 to 8. Only available in %LoRa mode.
+      Note that a value of 4 means no coding, is undocumented and not recommended without your own FEC. 
       \param cr %LoRa link coding rate denominator to be set.
       \returns \ref status_codes
     */

--- a/src/modules/SX127x/SX1273.cpp
+++ b/src/modules/SX127x/SX1273.cpp
@@ -107,7 +107,7 @@ int16_t SX1273::checkDataRate(DataRate_t dr) {
   } else if(modem == RADIOLIB_SX127X_LORA) {
     RADIOLIB_CHECK_RANGE(dr.lora.spreadingFactor, 6, 9, RADIOLIB_ERR_INVALID_SPREADING_FACTOR);
     RADIOLIB_CHECK_RANGE(dr.lora.bandwidth, 100.0f, 510.0f, RADIOLIB_ERR_INVALID_BANDWIDTH);
-    RADIOLIB_CHECK_RANGE(dr.lora.codingRate, 5, 8, RADIOLIB_ERR_INVALID_CODING_RATE);
+    RADIOLIB_CHECK_RANGE(dr.lora.codingRate, 4, 8, RADIOLIB_ERR_INVALID_CODING_RATE);
     return(RADIOLIB_ERR_NONE);
   
   }

--- a/src/modules/SX127x/SX1273.h
+++ b/src/modules/SX127x/SX1273.h
@@ -29,7 +29,8 @@ class SX1273: public SX1272 {
       \param freq Carrier frequency in MHz. Allowed values range from 860.0 MHz to 1020.0 MHz.
       \param bw %LoRa link bandwidth in kHz. Allowed values are 125, 250 and 500 kHz.
       \param sf %LoRa link spreading factor. Allowed values range from 6 to 9.
-      \param cr %LoRa link coding rate denominator. Allowed values range from 5 to 8.
+      \param cr %LoRa link coding rate denominator. Allowed values range from 4 to 8. Note that a value of 4 means no coding,
+      is undocumented and not recommended without your own FEC.
       \param syncWord %LoRa sync word. Can be used to distinguish different networks. Note that value 0x34 is reserved for LoRaWAN networks.
       \param power Transmission output power in dBm. Allowed values range from 2 to 17 dBm.
       \param preambleLength Length of %LoRa transmission preamble in symbols. The actual preamble length is 4.25 symbols longer than the set number.

--- a/src/modules/SX127x/SX1276.h
+++ b/src/modules/SX127x/SX1276.h
@@ -29,7 +29,8 @@ class SX1276: public SX1278 {
       \param freq Carrier frequency in MHz. Allowed values range from 137.0 MHz to 1020.0 MHz.
       \param bw %LoRa link bandwidth in kHz. Allowed values are 7.8, 10.4, 15.6, 20.8, 31.25, 41.7, 62.5, 125, 250 and 500 kHz.
       \param sf %LoRa link spreading factor. Allowed values range from 6 to 12.
-      \param cr %LoRa link coding rate denominator. Allowed values range from 5 to 8.
+      \param cr %LoRa link coding rate denominator. Allowed values range from 4 to 8. Note that a value of 4 means no coding,
+      is undocumented and not recommended without your own FEC.
       \param syncWord %LoRa sync word. Can be used to distinguish different networks. Note that value 0x34 is reserved for LoRaWAN networks.
       \param power Transmission output power in dBm. Allowed values range from 2 to 17 dBm.
       \param preambleLength Length of %LoRa transmission preamble in symbols. The actual preamble length is 4.25 symbols longer than the set number.

--- a/src/modules/SX127x/SX1277.cpp
+++ b/src/modules/SX127x/SX1277.cpp
@@ -149,7 +149,7 @@ int16_t SX1277::checkDataRate(DataRate_t dr) {
   } else if(modem == RADIOLIB_SX127X_LORA) {
     RADIOLIB_CHECK_RANGE(dr.lora.spreadingFactor, 6, 9, RADIOLIB_ERR_INVALID_SPREADING_FACTOR);
     RADIOLIB_CHECK_RANGE(dr.lora.bandwidth, 0.0f, 510.0f, RADIOLIB_ERR_INVALID_BANDWIDTH);
-    RADIOLIB_CHECK_RANGE(dr.lora.codingRate, 5, 8, RADIOLIB_ERR_INVALID_CODING_RATE);
+    RADIOLIB_CHECK_RANGE(dr.lora.codingRate, 4, 8, RADIOLIB_ERR_INVALID_CODING_RATE);
     return(RADIOLIB_ERR_NONE);
   
   }

--- a/src/modules/SX127x/SX1277.h
+++ b/src/modules/SX127x/SX1277.h
@@ -29,7 +29,8 @@ class SX1277: public SX1278 {
       \param freq Carrier frequency in MHz. Allowed values range from 137.0 MHz to 1020.0 MHz.
       \param bw %LoRa link bandwidth in kHz. Allowed values are 7.8, 10.4, 15.6, 20.8, 31.25, 41.7, 62.5, 125, 250 and 500 kHz.
       \param sf %LoRa link spreading factor. Allowed values range from 6 to 9.
-      \param cr %LoRa link coding rate denominator. Allowed values range from 5 to 8.
+      \param cr %LoRa link coding rate denominator. Allowed values range from 4 to 8. Note that a value of 4 means no coding,
+      is undocumented and not recommended without your own FEC.
       \param syncWord %LoRa sync word. Can be used to distinguish different networks. Note that value 0x34 is reserved for LoRaWAN networks.
       \param power Transmission output power in dBm. Allowed values range from 2 to 17 dBm.
       \param preambleLength Length of %LoRa transmission preamble in symbols. The actual preamble length is 4.25 symbols longer than the set number.

--- a/src/modules/SX127x/SX1278.cpp
+++ b/src/modules/SX127x/SX1278.cpp
@@ -209,6 +209,9 @@ int16_t SX1278::setCodingRate(uint8_t cr) {
 
   // check allowed coding rate values
   switch(cr) {
+    case 4:
+      newCodingRate = RADIOLIB_SX1278_CR_4_4;
+      break;
     case 5:
       newCodingRate = RADIOLIB_SX1278_CR_4_5;
       break;
@@ -281,7 +284,7 @@ int16_t SX1278::checkDataRate(DataRate_t dr) {
   } else if(modem == RADIOLIB_SX127X_LORA) {
     RADIOLIB_CHECK_RANGE(dr.lora.spreadingFactor, 6, 12, RADIOLIB_ERR_INVALID_SPREADING_FACTOR);
     RADIOLIB_CHECK_RANGE(dr.lora.bandwidth, 0.0f, 510.0f, RADIOLIB_ERR_INVALID_BANDWIDTH);
-    RADIOLIB_CHECK_RANGE(dr.lora.codingRate, 5, 8, RADIOLIB_ERR_INVALID_CODING_RATE);
+    RADIOLIB_CHECK_RANGE(dr.lora.codingRate, 4, 8, RADIOLIB_ERR_INVALID_CODING_RATE);
     return(RADIOLIB_ERR_NONE);
   
   }

--- a/src/modules/SX127x/SX1278.h
+++ b/src/modules/SX127x/SX1278.h
@@ -49,7 +49,8 @@
 #define RADIOLIB_SX1278_BW_125_00_KHZ                           0b01110000  //  7     4               125.00 kHz
 #define RADIOLIB_SX1278_BW_250_00_KHZ                           0b10000000  //  7     4               250.00 kHz
 #define RADIOLIB_SX1278_BW_500_00_KHZ                           0b10010000  //  7     4               500.00 kHz
-#define RADIOLIB_SX1278_CR_4_5                                  0b00000010  //  3     1   error coding rate:  4/5
+#define RADIOLIB_SX1278_CR_4_4                                  0b00000000  //  3     1   error coding rate:  4/4 (undocumented)
+#define RADIOLIB_SX1278_CR_4_5                                  0b00000010  //  3     1                       4/5
 #define RADIOLIB_SX1278_CR_4_6                                  0b00000100  //  3     1                       4/6
 #define RADIOLIB_SX1278_CR_4_7                                  0b00000110  //  3     1                       4/7
 #define RADIOLIB_SX1278_CR_4_8                                  0b00001000  //  3     1                       4/8
@@ -120,7 +121,8 @@ class SX1278: public SX127x {
       \param freq Carrier frequency in MHz. Allowed values range from 137.0 MHz to 525.0 MHz.
       \param bw %LoRa link bandwidth in kHz. Allowed values are 7.8, 10.4, 15.6, 20.8, 31.25, 41.7, 62.5, 125, 250 and 500 kHz.
       \param sf %LoRa link spreading factor. Allowed values range from 6 to 12.
-      \param cr %LoRa link coding rate denominator. Allowed values range from 5 to 8.
+      \param cr %LoRa link coding rate denominator. Allowed values range from 4 to 8. Note that a value of 4 means no coding,
+      is undocumented and not recommended without your own FEC.
       \param syncWord %LoRa sync word. Can be used to distinguish different networks. Note that value 0x34 is reserved for LoRaWAN networks.
       \param power Transmission output power in dBm. Allowed values range from 2 to 17 dBm.
       \param preambleLength Length of %LoRa transmission preamble in symbols. The actual preamble length is 4.25 symbols longer than the set number.
@@ -174,7 +176,8 @@ class SX1278: public SX127x {
     virtual int16_t setSpreadingFactor(uint8_t sf);
 
     /*!
-      \brief Sets %LoRa link coding rate denominator. Allowed values range from 5 to 8. Only available in %LoRa mode.
+      \brief Sets %LoRa link coding rate denominator. Allowed values range from 4 to 8. Only available in %LoRa mode.
+      Note that a value of 4 means no coding, is undocumented and not recommended without your own FEC. 
       \param cr %LoRa link coding rate denominator to be set.
       \returns \ref status_codes
     */

--- a/src/modules/SX127x/SX1279.h
+++ b/src/modules/SX127x/SX1279.h
@@ -29,7 +29,8 @@ class SX1279: public SX1278 {
       \param freq Carrier frequency in MHz. Allowed values range from 137.0 MHz to 960.0 MHz.
       \param bw %LoRa link bandwidth in kHz. Allowed values are 7.8, 10.4, 15.6, 20.8, 31.25, 41.7, 62.5, 125, 250 and 500 kHz.
       \param sf %LoRa link spreading factor. Allowed values range from 6 to 12.
-      \param cr %LoRa link coding rate denominator. Allowed values range from 5 to 8.
+      \param cr %LoRa link coding rate denominator. Allowed values range from 4 to 8. Note that a value of 4 means no coding,
+      is undocumented and not recommended without your own FEC.
       \param syncWord %LoRa sync word. Can be used to distinguish different networks. Note that value 0x34 is reserved for LoRaWAN networks.
       \param power Transmission output power in dBm. Allowed values range from 2 to 17 dBm.
       \param preambleLength Length of %LoRa transmission preamble in symbols. The actual preamble length is 4.25 symbols longer than the set number.

--- a/src/modules/SX128x/SX128x.cpp
+++ b/src/modules/SX128x/SX128x.cpp
@@ -726,11 +726,24 @@ int16_t SX128x::setCodingRate(uint8_t cr, bool longInterleaving) {
 
   // LoRa/ranging
   if((modem == RADIOLIB_SX128X_PACKET_TYPE_LORA) || (modem == RADIOLIB_SX128X_PACKET_TYPE_RANGING)) {
-    RADIOLIB_CHECK_RANGE(cr, 5, 8, RADIOLIB_ERR_INVALID_CODING_RATE);
+    RADIOLIB_CHECK_RANGE(cr, 4, 8, RADIOLIB_ERR_INVALID_CODING_RATE);
 
     // update modulation parameters
     if(longInterleaving && (modem == RADIOLIB_SX128X_PACKET_TYPE_LORA)) {
-      this->codingRateLoRa = cr;
+      switch(cr) {
+        case 4:
+          this->codingRateLoRa = 0;
+          break;
+        case 5:
+        case 6:
+          this->codingRateLoRa = cr;
+          break;
+        case 8: 
+          this->codingRateLoRa = cr - 1;
+          break;
+        default:
+          return(RADIOLIB_ERR_INVALID_CODING_RATE);
+      }
     } else {
       this->codingRateLoRa = cr - 4;
     }

--- a/src/modules/SX128x/SX128x.h
+++ b/src/modules/SX128x/SX128x.h
@@ -370,7 +370,8 @@ class SX128x: public PhysicalLayer {
       \param freq Carrier frequency in MHz. Defaults to 2400.0 MHz.
       \param bw LoRa bandwidth in kHz. Defaults to 812.5 kHz.
       \param sf LoRa spreading factor. Defaults to 9.
-      \param cr LoRa coding rate denominator. Defaults to 7 (coding rate 4/7).
+      \param cr LoRa coding rate denominator. Defaults to 7 (coding rate 4/7). Allowed values range from 4 to 8. Note that a value of 4 means no coding,
+      is undocumented and not recommended without your own FEC.
       \param syncWord 2-byte LoRa sync word. Defaults to RADIOLIB_SX128X_SYNC_WORD_PRIVATE (0x12).
       \param pwr Output power in dBm. Defaults to 10 dBm.
       \param preambleLength LoRa preamble length in symbols. Defaults to 12 symbols.
@@ -626,7 +627,8 @@ class SX128x: public PhysicalLayer {
     int16_t setSpreadingFactor(uint8_t sf);
 
     /*!
-      \brief Sets LoRa coding rate denominator. Allowed values range from 5 to 8.
+      \brief Sets LoRa coding rate denominator. Allowed values range from 4 to 8. Note that a value of 4
+      means no coding, is undocumented and not recommended without your own FEC.
       \param cr LoRa coding rate denominator to be set.
       \param longInterleaving Whether to enable long interleaving mode. Not available for coding rate 4/7,
       defaults to false.


### PR DESCRIPTION
As discussed in #1584, this adds support for coding rate 4/4, meaning no coding. A warning is added that this is not documented and not recommended without applying your own FEC.

Tested to be working on SX1278, SX1262 and LR1110.

