### PR TITLE
Add methods to retrieve received LoRa header info

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -195,6 +195,7 @@ getFHSSChannel	KEYWORD2
 clearFHSSInt	KEYWORD2
 randomByte	KEYWORD2
 getPacketLength	KEYWORD2
+getLoRaRxHeaderInfo	KEYWORD2
 setFifoEmptyAction	KEYWORD2
 clearFifoEmptyAction	KEYWORD2
 setFifoThreshold	KEYWORD2

--- a/src/modules/LR11x0/LR11x0.h
+++ b/src/modules/LR11x0/LR11x0.h
@@ -1355,6 +1355,14 @@ class LR11x0: public PhysicalLayer {
     size_t getPacketLength(bool update, uint8_t* offset);
 
     /*!
+      \brief Get LoRa header information from last received packet. Only valid in explicit header mode.
+      \param cr Pointer to variable to store the coding rate.
+      \param hasCRC Pointer to variable to store the CRC status.
+      \returns \ref status_codes
+    */
+    int16_t getLoRaRxHeaderInfo(uint8_t* cr, bool* hasCRC);
+
+    /*!
       \brief Get expected time-on-air for a given size of payload
       \param len Payload length in bytes.
       \returns Expected time-on-air in microseconds.
@@ -1712,7 +1720,6 @@ class LR11x0: public PhysicalLayer {
     int16_t lrFhssBuildFrame(uint8_t hdrCount, uint8_t cr, uint8_t grid, bool hop, uint8_t bw, uint16_t hopSeq, int8_t devOffset, const uint8_t* payload, size_t len);
     int16_t lrFhssSetSyncWord(uint32_t sync);
     int16_t configBleBeacon(uint8_t chan, const uint8_t* payload, size_t len);
-    int16_t getLoRaRxHeaderInfos(uint8_t* info);
     int16_t bleBeaconSend(uint8_t chan, const uint8_t* payload, size_t len);
 
     int16_t wifiScan(uint8_t type, uint16_t mask, uint8_t acqMode, uint8_t nbMaxRes, uint8_t nbScanPerChan, uint16_t timeout, uint8_t abortOnTimeout);

--- a/src/modules/LR11x0/LR11x0_commands.cpp
+++ b/src/modules/LR11x0/LR11x0_commands.cpp
@@ -770,12 +770,18 @@ int16_t LR11x0::configBleBeacon(uint8_t chan, const uint8_t* payload, size_t len
   return(this->bleBeaconCommon(RADIOLIB_LR11X0_CMD_CONFIG_BLE_BEACON, chan, payload, len));
 }
 
-int16_t LR11x0::getLoRaRxHeaderInfos(uint8_t* info) {
+int16_t LR11x0::getLoRaRxHeaderInfo(uint8_t* cr, bool* hasCRC) {
+  // check if in explicit header mode
+  if(this->headerType == RADIOLIB_LR11X0_LORA_HEADER_IMPLICIT) {
+    return(RADIOLIB_ERR_WRONG_MODEM);
+  }
+
   uint8_t buff[1] = { 0 };
   int16_t state = this->SPIcommand(RADIOLIB_LR11X0_CMD_GET_LORA_RX_HEADER_INFOS, false, buff, sizeof(buff));
 
   // pass the replies
-  if(info) { *info = buff[0]; }
+  if(cr) { *cr = (buff[0] & 0x70) >> 4; }
+  if(hasCRC) { *hasCRC = (buff[0] & RADIOLIB_LR11X0_LAST_HEADER_CRC_ENABLED) != 0; }
 
   return(state);
 }

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -1286,11 +1286,11 @@ float SX126x::getFrequencyError() {
 
   // read the raw frequency error register values
   uint8_t efeRaw[3] = {0};
-  int16_t state = readRegister(RADIOLIB_SX126X_REG_FREQ_ERROR, &efeRaw[0], 1);
+  int16_t state = readRegister(RADIOLIB_SX126X_REG_FREQ_ERROR_RX_CRC, &efeRaw[0], 1);
   RADIOLIB_ASSERT(state);
-  state = readRegister(RADIOLIB_SX126X_REG_FREQ_ERROR + 1, &efeRaw[1], 1);
+  state = readRegister(RADIOLIB_SX126X_REG_FREQ_ERROR_RX_CRC + 1, &efeRaw[1], 1);
   RADIOLIB_ASSERT(state);
-  state = readRegister(RADIOLIB_SX126X_REG_FREQ_ERROR + 2, &efeRaw[2], 1);
+  state = readRegister(RADIOLIB_SX126X_REG_FREQ_ERROR_RX_CRC + 2, &efeRaw[2], 1);
   RADIOLIB_ASSERT(state);
   uint32_t efe = ((uint32_t) efeRaw[0] << 16) | ((uint32_t) efeRaw[1] << 8) | efeRaw[2];
   efe &= 0x0FFFFF;
@@ -1329,6 +1329,20 @@ size_t SX126x::getPacketLength(bool update, uint8_t* offset) {
   if(offset) { *offset = rxBufStatus[1]; }
 
   return((size_t)rxBufStatus[0]);
+}
+
+int16_t SX126x::getLoRaRxHeaderInfo(uint8_t* cr, bool* hasCRC) {
+  int16_t state = RADIOLIB_ERR_NONE;
+
+  // check if in explicit header mode
+  if(this->headerType == RADIOLIB_SX126X_LORA_HEADER_IMPLICIT) {
+    return(RADIOLIB_ERR_WRONG_MODEM);
+  }
+
+  if(cr) { *cr = this->mod->SPIgetRegValue(RADIOLIB_SX126X_REG_LORA_RX_CODING_RATE, 6, 4) >> 4; }
+  if(hasCRC) { *hasCRC = (this->mod->SPIgetRegValue(RADIOLIB_SX126X_REG_FREQ_ERROR_RX_CRC, 4, 4) != 0); }
+
+  return(state);
 }
 
 int16_t SX126x::fixedPacketLengthMode(uint8_t len) {

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -120,7 +120,8 @@
 #define RADIOLIB_SX126X_REG_IQ_CONFIG                           0x0736
 #define RADIOLIB_SX126X_REG_LORA_SYNC_WORD_MSB                  0x0740
 #define RADIOLIB_SX126X_REG_LORA_SYNC_WORD_LSB                  0x0741
-#define RADIOLIB_SX126X_REG_FREQ_ERROR                          0x076B
+#define RADIOLIB_SX126X_REG_LORA_RX_CODING_RATE                 0x0749
+#define RADIOLIB_SX126X_REG_FREQ_ERROR_RX_CRC                   0x076B
 #define RADIOLIB_SX126X_REG_SPECTRAL_SCAN_STATUS                0x07CD
 #define RADIOLIB_SX126X_REG_RX_ADDR_PTR                         0x0803
 #define RADIOLIB_SX126X_REG_RANDOM_NUMBER_0                     0x0819
@@ -974,6 +975,14 @@ class SX126x: public PhysicalLayer {
       \returns Length of last received packet in bytes.
     */
     size_t getPacketLength(bool update, uint8_t* offset);
+
+    /*!
+      \brief Get LoRa header information from last received packet. Only valid in explicit header mode.
+      \param cr Pointer to variable to store the coding rate.
+      \param hasCRC Pointer to variable to store the CRC status.
+      \returns \ref status_codes
+    */
+    int16_t getLoRaRxHeaderInfo(uint8_t* cr, bool* hasCRC);
 
     /*!
       \brief Set modem in fixed packet length mode. Available in FSK mode only.

--- a/src/modules/SX127x/SX127x.cpp
+++ b/src/modules/SX127x/SX127x.cpp
@@ -1109,6 +1109,20 @@ size_t SX127x::getPacketLength(bool update) {
   return(this->packetLength);
 }
 
+int16_t SX127x::getLoRaRxHeaderInfo(uint8_t* cr, bool* hasCRC) {
+  int16_t state = RADIOLIB_ERR_NONE;
+
+  // check if in explicit header mode
+  if(this->implicitHdr) {
+    return(RADIOLIB_ERR_WRONG_MODEM);
+  }
+
+  if(cr) { *cr = this->mod->SPIgetRegValue(RADIOLIB_SX127X_REG_MODEM_STAT, 7, 5) >> 5; }
+  if(hasCRC) { *hasCRC = this->mod->SPIgetRegValue(RADIOLIB_SX127X_REG_HOP_CHANNEL, 6, 6) != 0; }
+
+  return(state);
+}
+
 int16_t SX127x::fixedPacketLengthMode(uint8_t len) {
   return(SX127x::setPacketMode(RADIOLIB_SX127X_PACKET_FIXED, len));
 }

--- a/src/modules/SX127x/SX127x.h
+++ b/src/modules/SX127x/SX127x.h
@@ -1008,6 +1008,14 @@ class SX127x: public PhysicalLayer {
     size_t getPacketLength(bool update = true) override;
 
     /*!
+      \brief Get LoRa header information from last received packet. Only valid in explicit header mode.
+      \param cr Pointer to variable to store the coding rate.
+      \param hasCRC Pointer to variable to store the CRC status.
+      \returns \ref status_codes
+    */
+    int16_t getLoRaRxHeaderInfo(uint8_t* cr, bool* hasCRC);
+
+    /*!
       \brief Set modem in fixed packet length mode. Available in FSK mode only.
       \param len Packet length.
       \returns \ref status_codes

--- a/src/modules/SX128x/SX128x.cpp
+++ b/src/modules/SX128x/SX128x.cpp
@@ -1286,6 +1286,20 @@ size_t SX128x::getPacketLength(bool update, uint8_t* offset) {
   return((size_t)rxBufStatus[0]);
 }
 
+int16_t SX128x::getLoRaRxHeaderInfo(uint8_t* cr, bool* hasCRC) {
+  int16_t state = RADIOLIB_ERR_NONE;
+
+  // check if in explicit header mode
+  if(this->headerType == RADIOLIB_SX128X_LORA_HEADER_IMPLICIT) {
+    return(RADIOLIB_ERR_WRONG_MODEM);
+  }
+
+  if(cr) { *cr = this->mod->SPIgetRegValue(RADIOLIB_SX128X_REG_LORA_RX_CODING_RATE, 6, 4) >> 4; }
+  if(hasCRC) { *hasCRC = (this->mod->SPIgetRegValue(RADIOLIB_SX128X_REG_FEI_MSB, 4, 4) != 0); }
+
+  return(state);
+}
+
 int16_t SX128x::fixedPacketLengthMode(uint8_t len) {
   return(setPacketMode(RADIOLIB_SX128X_GFSK_FLRC_PACKET_FIXED, len));
 }

--- a/src/modules/SX128x/SX128x.h
+++ b/src/modules/SX128x/SX128x.h
@@ -84,6 +84,7 @@
 #define RADIOLIB_SX128X_REG_FREQ_ERROR_CORRECTION               0x093C
 #define RADIOLIB_SX128X_REG_LORA_SYNC_WORD_MSB                  0x0944
 #define RADIOLIB_SX128X_REG_LORA_SYNC_WORD_LSB                  0x0945
+#define RADIOLIB_SX128X_REG_LORA_RX_CODING_RATE                 0x0950
 #define RADIOLIB_SX128X_REG_RANGING_FILTER_RSSI_OFFSET          0x0953
 #define RADIOLIB_SX128X_REG_FEI_MSB                             0x0954
 #define RADIOLIB_SX128X_REG_FEI_MID                             0x0955
@@ -794,6 +795,14 @@ class SX128x: public PhysicalLayer {
       \returns Length of last received packet in bytes.
     */
     size_t getPacketLength(bool update, uint8_t* offset);
+
+    /*!
+      \brief Get LoRa header information from last received packet. Only valid in explicit header mode.
+      \param cr Pointer to variable to store the coding rate.
+      \param hasCRC Pointer to variable to store the CRC status.
+      \returns \ref status_codes
+    */
+    int16_t getLoRaRxHeaderInfo(uint8_t* cr, bool* hasCRC);
 
     /*!
       \brief Set modem in fixed packet length mode. Available in GFSK mode only.


### PR DESCRIPTION
Related to #1584. Since in explicit header mode transmitter and receiver do not necessarily need to use the same coding rate and CRC enable status, it’s useful to know these from a received packet, e.g. for rate control or appropriate airtime calculations (PR to follow).

I used the same function name as existed for the LR11x0, but changed the parameters to explicitly return the CR and CRC.

Tested on SX1276, SX1262 and LR1110.
