### PR TITLE
User-controlled timeout for blocking receive

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -133,6 +133,7 @@ startTransmit	KEYWORD2
 finishTransmit	KEYWORD2
 startReceive	KEYWORD2
 readData	KEYWORD2
+finishReceive	KEYWORD2
 startChannelScan	KEYWORD2
 getChannelScanResult	KEYWORD2
 setBandwidth	KEYWORD2

--- a/src/modules/CC1101/CC1101.cpp
+++ b/src/modules/CC1101/CC1101.cpp
@@ -75,8 +75,7 @@ int16_t CC1101::receive(uint8_t* data, size_t len, RadioLibTime_t timeout) {
     this->mod->hal->yield();
 
     if(this->mod->hal->millis() - start > timeout) {
-      standby();
-      SPIsendCommand(RADIOLIB_CC1101_CMD_FLUSH_RX);
+      (void)finishReceive();
       return(RADIOLIB_ERR_RX_TIMEOUT);
     }
   }
@@ -87,8 +86,7 @@ int16_t CC1101::receive(uint8_t* data, size_t len, RadioLibTime_t timeout) {
     this->mod->hal->yield();
 
     if(this->mod->hal->millis() - start > timeout) {
-      standby();
-      SPIsendCommand(RADIOLIB_CC1101_CMD_FLUSH_RX);
+      (void)finishReceive();
       return(RADIOLIB_ERR_RX_TIMEOUT);
     }
   }
@@ -413,14 +411,15 @@ int16_t CC1101::readData(uint8_t* data, size_t len) {
 
   // Flush then standby according to RXOFF_MODE (default: RADIOLIB_CC1101_RXOFF_IDLE)
   if(SPIgetRegValue(RADIOLIB_CC1101_REG_MCSM1, 3, 2) == RADIOLIB_CC1101_RXOFF_IDLE) {
-
-    // set mode to standby
-    standby();
-
-    // flush Rx FIFO
-    SPIsendCommand(RADIOLIB_CC1101_CMD_FLUSH_RX);
+    finishReceive();
   }
 
+  return(state);
+}
+
+int16_t CC1101::finishReceive() {
+  int16_t state = standby();
+  SPIsendCommand(RADIOLIB_CC1101_CMD_FLUSH_RX);
   return(state);
 }
 

--- a/src/modules/CC1101/CC1101.cpp
+++ b/src/modules/CC1101/CC1101.cpp
@@ -58,9 +58,12 @@ int16_t CC1101::transmit(const uint8_t* data, size_t len, uint8_t addr) {
   return(finishTransmit());
 }
 
-int16_t CC1101::receive(uint8_t* data, size_t len) {
-  // calculate timeout (500 ms + 400 full max-length packets at current bit rate)
-  RadioLibTime_t timeout = 500 + (1.0f/(this->bitRate))*(RADIOLIB_CC1101_MAX_PACKET_LENGTH*400.0f);
+int16_t CC1101::receive(uint8_t* data, size_t len, RadioLibTime_t timeout) {
+  RadioLibTime_t timeoutInternal = timeout;
+  if(!timeoutInternal) {
+    // calculate timeout (500 ms + 400 full max-length packets at current bit rate)
+    timeoutInternal = 500 + (1.0f/(this->bitRate))*(RADIOLIB_CC1101_MAX_PACKET_LENGTH*400.0f);
+  } 
 
   // start reception
   int16_t state = startReceive();

--- a/src/modules/CC1101/CC1101.cpp
+++ b/src/modules/CC1101/CC1101.cpp
@@ -74,7 +74,7 @@ int16_t CC1101::receive(uint8_t* data, size_t len, RadioLibTime_t timeout) {
   while(this->mod->hal->digitalRead(this->mod->getIrq())) {
     this->mod->hal->yield();
 
-    if(this->mod->hal->millis() - start > timeout) {
+    if(this->mod->hal->millis() - start > timeoutInternal) {
       (void)finishReceive();
       return(RADIOLIB_ERR_RX_TIMEOUT);
     }
@@ -85,7 +85,7 @@ int16_t CC1101::receive(uint8_t* data, size_t len, RadioLibTime_t timeout) {
   while(!this->mod->hal->digitalRead(this->mod->getIrq())) {
     this->mod->hal->yield();
 
-    if(this->mod->hal->millis() - start > timeout) {
+    if(this->mod->hal->millis() - start > timeoutInternal) {
       (void)finishReceive();
       return(RADIOLIB_ERR_RX_TIMEOUT);
     }

--- a/src/modules/CC1101/CC1101.h
+++ b/src/modules/CC1101/CC1101.h
@@ -749,6 +749,12 @@ class CC1101: public PhysicalLayer {
     */
     int16_t readData(uint8_t* data, size_t len) override;
 
+    /*!
+      \brief Clean up after reception is done.
+      \returns \ref status_codes
+    */
+    int16_t finishReceive() override;
+
     // configuration methods
 
     /*!

--- a/src/modules/CC1101/CC1101.h
+++ b/src/modules/CC1101/CC1101.h
@@ -597,11 +597,13 @@ class CC1101: public PhysicalLayer {
     /*!
       \brief Blocking binary receive method.
       Overloads for string-based transmissions are implemented in PhysicalLayer.
-      \param data Binary data to be sent.
-      \param len Number of bytes to send.
+      \param data Pointer to array to save the received binary data.
+      \param len Number of bytes that will be received. Must be known in advance for binary transmissions.
+      \param timeout Reception timeout in milliseconds. If set to 0,
+      timeout period will be calculated automatically based on the radio configuration.
       \returns \ref status_codes
     */
-    int16_t receive(uint8_t* data, size_t len) override;
+    int16_t receive(uint8_t* data, size_t len, RadioLibTime_t timeout = 0) override;
 
     /*!
       \brief Sets the module to standby mode.

--- a/src/modules/LR11x0/LR11x0.cpp
+++ b/src/modules/LR11x0/LR11x0.cpp
@@ -287,8 +287,7 @@ int16_t LR11x0::receive(uint8_t* data, size_t len, RadioLibTime_t timeout) {
 
   // check whether this was a timeout or not
   if((getIrqStatus() & RADIOLIB_LR11X0_IRQ_TIMEOUT) || softTimeout) {
-    standby();
-    clearIrqState(RADIOLIB_LR11X0_IRQ_ALL);
+    (void)finishReceive();
     return(RADIOLIB_ERR_RX_TIMEOUT);
   }
 
@@ -480,6 +479,15 @@ int16_t LR11x0::readData(uint8_t* data, size_t len) {
   RADIOLIB_ASSERT(crcState);
 
   return(state);
+}
+
+int16_t LR11x0::finishReceive() {
+  // clear interrupt flags
+  int16_t state = clearIrqState(RADIOLIB_LR11X0_IRQ_ALL);
+  RADIOLIB_ASSERT(state);
+
+  // set mode to standby to disable RF switch
+  return(standby());
 }
 
 int16_t LR11x0::startChannelScan() {

--- a/src/modules/LR11x0/LR11x0.cpp
+++ b/src/modules/LR11x0/LR11x0.cpp
@@ -223,44 +223,46 @@ int16_t LR11x0::transmit(const uint8_t* data, size_t len, uint8_t addr) {
   return(finishTransmit());
 }
 
-int16_t LR11x0::receive(uint8_t* data, size_t len) {
+int16_t LR11x0::receive(uint8_t* data, size_t len, RadioLibTime_t timeout) {
   // set mode to standby
   int16_t state = standby();
   RADIOLIB_ASSERT(state);
 
-  RadioLibTime_t timeout = 0;
+  // calcualte timeout based on the configured modem
+  RadioLibTime_t timeoutInternal = timeout;
+  if(!timeoutInternal) {
+    // get currently active modem
+    uint8_t modem = RADIOLIB_LR11X0_PACKET_TYPE_NONE;
+    state = getPacketType(&modem);
+    RADIOLIB_ASSERT(state);
+    if(modem == RADIOLIB_LR11X0_PACKET_TYPE_LORA) {
+      // calculate timeout (100 LoRa symbols, the default for SX127x series)
+      float symbolLength = (float)(uint32_t(1) << this->spreadingFactor) / (float)this->bandwidthKhz;
+      timeoutInternal = (RadioLibTime_t)(symbolLength * 100.0f);
+    
+    } else if(modem == RADIOLIB_LR11X0_PACKET_TYPE_GFSK) {
+      // calculate timeout (500 % of expected time-one-air)
+      size_t maxLen = len;
+      if(len == 0) { 
+        maxLen = 0xFF;
+      }
+      float brBps = ((float)(RADIOLIB_LR11X0_CRYSTAL_FREQ) * 1000000.0f * 32.0f) / (float)this->bitRate;
+      timeoutInternal = (RadioLibTime_t)(((maxLen * 8.0f) / brBps) * 1000.0f * 5.0f);
+    
+    } else if(modem == RADIOLIB_LR11X0_PACKET_TYPE_LR_FHSS) {
+      // this modem cannot receive
+      return(RADIOLIB_ERR_WRONG_MODEM);
 
-  // get currently active modem
-  uint8_t modem = RADIOLIB_LR11X0_PACKET_TYPE_NONE;
-  state = getPacketType(&modem);
-  RADIOLIB_ASSERT(state);
-  if(modem == RADIOLIB_LR11X0_PACKET_TYPE_LORA) {
-    // calculate timeout (100 LoRa symbols, the default for SX127x series)
-    float symbolLength = (float)(uint32_t(1) << this->spreadingFactor) / (float)this->bandwidthKhz;
-    timeout = (RadioLibTime_t)(symbolLength * 100.0f);
-  
-  } else if(modem == RADIOLIB_LR11X0_PACKET_TYPE_GFSK) {
-    // calculate timeout (500 % of expected time-one-air)
-    size_t maxLen = len;
-    if(len == 0) { 
-      maxLen = 0xFF;
+    } else {
+      return(RADIOLIB_ERR_UNKNOWN);
+    
     }
-    float brBps = ((float)(RADIOLIB_LR11X0_CRYSTAL_FREQ) * 1000000.0f * 32.0f) / (float)this->bitRate;
-    timeout = (RadioLibTime_t)(((maxLen * 8.0f) / brBps) * 1000.0f * 5.0f);
-  
-  } else if(modem == RADIOLIB_LR11X0_PACKET_TYPE_LR_FHSS) {
-    // this modem cannot receive
-    return(RADIOLIB_ERR_WRONG_MODEM);
-
-  } else {
-    return(RADIOLIB_ERR_UNKNOWN);
-  
   }
 
-  RADIOLIB_DEBUG_BASIC_PRINTLN("Timeout in %lu ms", timeout);
+  RADIOLIB_DEBUG_BASIC_PRINTLN("Timeout in %lu ms", timeoutInternal);
 
   // start reception
-  uint32_t timeoutValue = (uint32_t)(((float)timeout * 1000.0f) / 30.52f);
+  uint32_t timeoutValue = (uint32_t)(((float)timeoutInternal * 1000.0f) / 30.52f);
   state = startReceive(timeoutValue);
   RADIOLIB_ASSERT(state);
 
@@ -270,7 +272,7 @@ int16_t LR11x0::receive(uint8_t* data, size_t len) {
   while(!this->mod->hal->digitalRead(this->mod->getIrq())) {
     this->mod->hal->yield();
     // safety check, the timeout should be done by the radio
-    if(this->mod->hal->millis() - start > timeout) {
+    if(this->mod->hal->millis() - start > timeoutInternal) {
       softTimeout = true;
       break;
     }

--- a/src/modules/LR11x0/LR11x0.cpp
+++ b/src/modules/LR11x0/LR11x0.cpp
@@ -474,12 +474,12 @@ int16_t LR11x0::readData(uint8_t* data, size_t len) {
 }
 
 int16_t LR11x0::finishReceive() {
-  // clear interrupt flags
-  int16_t state = clearIrqState(RADIOLIB_LR11X0_IRQ_ALL);
+  // set mode to standby to disable RF switch
+  int16_t state = standby();
   RADIOLIB_ASSERT(state);
 
-  // set mode to standby to disable RF switch
-  return(standby());
+  // clear interrupt flags
+  return(clearIrqState(RADIOLIB_LR11X0_IRQ_ALL));
 }
 
 int16_t LR11x0::startChannelScan() {

--- a/src/modules/LR11x0/LR11x0.h
+++ b/src/modules/LR11x0/LR11x0.h
@@ -1121,6 +1121,12 @@ class LR11x0: public PhysicalLayer {
       \returns \ref status_codes
     */
     int16_t readData(uint8_t* data, size_t len) override;
+
+    /*!
+      \brief Clean up after reception is done.
+      \returns \ref status_codes
+    */
+    int16_t finishReceive() override;
     
     /*!
       \brief Interrupt-driven channel activity detection method. IRQ1 will be activated

--- a/src/modules/LR11x0/LR11x0.h
+++ b/src/modules/LR11x0/LR11x0.h
@@ -991,11 +991,13 @@ class LR11x0: public PhysicalLayer {
     /*!
       \brief Blocking binary receive method.
       Overloads for string-based transmissions are implemented in PhysicalLayer.
-      \param data Binary data to be sent.
-      \param len Number of bytes to send.
+      \param data Pointer to array to save the received binary data.
+      \param len Number of bytes that will be received. Must be known in advance for binary transmissions.
+      \param timeout Reception timeout in milliseconds. If set to 0,
+      timeout period will be calculated automatically based on the radio configuration.
       \returns \ref status_codes
     */
-    int16_t receive(uint8_t* data, size_t len) override;
+    int16_t receive(uint8_t* data, size_t len, RadioLibTime_t timeout = 0) override;
 
     /*!
       \brief Starts direct mode transmission.

--- a/src/modules/RF69/RF69.cpp
+++ b/src/modules/RF69/RF69.cpp
@@ -122,9 +122,12 @@ int16_t RF69::transmit(const uint8_t* data, size_t len, uint8_t addr) {
   return(finishTransmit());
 }
 
-int16_t RF69::receive(uint8_t* data, size_t len) {
-  // calculate timeout (500 ms + 400 full 64-byte packets at current bit rate)
-  RadioLibTime_t timeout = 500 + (1.0f/(this->bitRate))*(RADIOLIB_RF69_MAX_PACKET_LENGTH*400.0f);
+int16_t RF69::receive(uint8_t* data, size_t len, RadioLibTime_t timeout) {
+  RadioLibTime_t timeoutInternal = timeout;
+  if(!timeoutInternal) {
+    // calculate timeout (500 ms + 400 full 64-byte packets at current bit rate)
+    timeoutInternal = 500 + (1.0f/(this->bitRate))*(RADIOLIB_RF69_MAX_PACKET_LENGTH*400.0f);
+  } 
 
   // start reception
   int16_t state = startReceive();
@@ -135,9 +138,7 @@ int16_t RF69::receive(uint8_t* data, size_t len) {
   while(!this->mod->hal->digitalRead(this->mod->getIrq())) {
     this->mod->hal->yield();
 
-    if(this->mod->hal->millis() - start > timeout) {
-      standby();
-      clearIRQFlags();
+    if(this->mod->hal->millis() - start > timeoutInternal) {
       return(RADIOLIB_ERR_RX_TIMEOUT);
     }
   }

--- a/src/modules/RF69/RF69.cpp
+++ b/src/modules/RF69/RF69.cpp
@@ -485,11 +485,12 @@ int16_t RF69::readData(uint8_t* data, size_t len) {
 }
 
 int16_t RF69::finishReceive() {
+  // set mode to standby to disable RF switch
+  int16_t state = standby();
+  
   // clear interrupt flags
   clearIRQFlags();
-
-  // set mode to standby to disable RF switch
-  return(standby());
+  return(state);
 }
 
 int16_t RF69::setOOK(bool enable) {

--- a/src/modules/RF69/RF69.cpp
+++ b/src/modules/RF69/RF69.cpp
@@ -139,6 +139,7 @@ int16_t RF69::receive(uint8_t* data, size_t len, RadioLibTime_t timeout) {
     this->mod->hal->yield();
 
     if(this->mod->hal->millis() - start > timeoutInternal) {
+      (void)finishReceive();
       return(RADIOLIB_ERR_RX_TIMEOUT);
     }
   }
@@ -478,10 +479,17 @@ int16_t RF69::readData(uint8_t* data, size_t len) {
   // clear internal flag so getPacketLength can return the new packet length
   this->packetLengthQueried = false;
 
+  finishReceive();
+
+  return(RADIOLIB_ERR_NONE);
+}
+
+int16_t RF69::finishReceive() {
   // clear interrupt flags
   clearIRQFlags();
 
-  return(RADIOLIB_ERR_NONE);
+  // set mode to standby to disable RF switch
+  return(standby());
 }
 
 int16_t RF69::setOOK(bool enable) {

--- a/src/modules/RF69/RF69.h
+++ b/src/modules/RF69/RF69.h
@@ -528,11 +528,13 @@ class RF69: public PhysicalLayer {
     /*!
       \brief Blocking binary receive method.
       Overloads for string-based transmissions are implemented in PhysicalLayer.
-      \param data Binary data to be sent.
-      \param len Number of bytes to send.
+      \param data Pointer to array to save the received binary data.
+      \param len Number of bytes that will be received. Must be known in advance for binary transmissions.
+      \param timeout Reception timeout in milliseconds. If set to 0,
+      timeout period will be calculated automatically based on the radio configuration.
       \returns \ref status_codes
     */
-    int16_t receive(uint8_t* data, size_t len) override;
+    int16_t receive(uint8_t* data, size_t len, RadioLibTime_t timeout = 0) override;
 
     /*!
       \brief Sets the module to sleep mode.

--- a/src/modules/RF69/RF69.h
+++ b/src/modules/RF69/RF69.h
@@ -729,6 +729,12 @@ class RF69: public PhysicalLayer {
     */
     int16_t readData(uint8_t* data, size_t len) override;
 
+    /*!
+      \brief Clean up after reception is done.
+      \returns \ref status_codes
+    */
+    int16_t finishReceive() override;
+
     // configuration methods
 
     /*!

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -529,6 +529,20 @@ int16_t SX126x::finishTransmit() {
   return(standby());
 }
 
+int16_t SX126x::finishReceive() {
+  // clear interrupt flags
+  int16_t state = clearIrqStatus();
+  RADIOLIB_ASSERT(state);
+
+  // try to fix timeout error in implicit header mode
+  // check for modem type and header mode is done in fixImplicitTimeout()
+  state = fixImplicitTimeout();
+  RADIOLIB_ASSERT(state);
+
+  // set mode to standby to disable RF switch
+  return(standby());
+}
+
 int16_t SX126x::startReceive() {
   return(this->startReceive(RADIOLIB_SX126X_RX_TIMEOUT_INF, RADIOLIB_IRQ_RX_DEFAULT_FLAGS, RADIOLIB_IRQ_RX_DEFAULT_MASK, 0));
 }
@@ -2200,7 +2214,8 @@ int16_t SX126x::fixImplicitTimeout() {
 
   //check if we're in implicit LoRa mode
   if(!((this->headerType == RADIOLIB_SX126X_LORA_HEADER_IMPLICIT) && (getPacketType() == RADIOLIB_SX126X_PACKET_TYPE_LORA))) {
-    return(RADIOLIB_ERR_WRONG_MODEM);
+    // not in the correct mode, nothing to do here
+    return(RADIOLIB_ERR_NONE);
   }
 
   // stop RTC counter

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -256,24 +256,10 @@ int16_t SX126x::receive(uint8_t* data, size_t len, RadioLibTime_t timeout) {
 
   RadioLibTime_t timeoutInternal = timeout;
   if(!timeoutInternal) {
-    // get currently active modem
-    uint8_t modem = getPacketType();
-    if(modem == RADIOLIB_SX126X_PACKET_TYPE_LORA) {
-      // calculate timeout (100 LoRa symbols, the default for SX127x series)
-      float symbolLength = (float)(uint32_t(1) << this->spreadingFactor) / (float)this->bandwidthKhz;
-      timeoutInternal = (RadioLibTime_t)(symbolLength * 100.0f);
-    
-    } else if(modem == RADIOLIB_SX126X_PACKET_TYPE_GFSK) {
-      // calculate timeout (500 % of expected time-one-air)
-      size_t maxLen = len;
-      if(len == 0) { maxLen = 0xFF; }
-      float brBps = (RADIOLIB_SX126X_CRYSTAL_FREQ * 1000000.0f * 32.0f) / (float)this->bitRate;
-      timeoutInternal = (RadioLibTime_t)(((maxLen * 8.0f) / brBps) * 1000.0f * 5.0f);
-
-    } else {
-      return(RADIOLIB_ERR_UNKNOWN);
-    
-    }
+    // calculate timeout (500 % of expected time-one-air)
+    size_t maxLen = len;
+    if(len == 0) { maxLen = RADIOLIB_SX126X_MAX_PACKET_LENGTH; }
+    timeoutInternal = (getTimeOnAir(maxLen) * 5) / 1000;
   }
 
   RADIOLIB_DEBUG_BASIC_PRINTLN("Timeout in %lu ms", timeoutInternal);

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -511,8 +511,8 @@ int16_t SX126x::finishTransmit() {
 }
 
 int16_t SX126x::finishReceive() {
-  // clear interrupt flags
-  int16_t state = clearIrqStatus();
+  // set mode to standby to disable RF switch
+  int16_t state = standby();
   RADIOLIB_ASSERT(state);
 
   // try to fix timeout error in implicit header mode
@@ -520,8 +520,8 @@ int16_t SX126x::finishReceive() {
   state = fixImplicitTimeout();
   RADIOLIB_ASSERT(state);
 
-  // set mode to standby to disable RF switch
-  return(standby());
+  // clear interrupt flags
+  return(clearIrqStatus());
 }
 
 int16_t SX126x::startReceive() {

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -249,38 +249,37 @@ int16_t SX126x::transmit(const uint8_t* data, size_t len, uint8_t addr) {
   return(finishTransmit());
 }
 
-int16_t SX126x::receive(uint8_t* data, size_t len) {
+int16_t SX126x::receive(uint8_t* data, size_t len, RadioLibTime_t timeout) {
   // set mode to standby
   int16_t state = standby();
   RADIOLIB_ASSERT(state);
 
-  RadioLibTime_t timeout = 0;
+  RadioLibTime_t timeoutInternal = timeout;
+  if(!timeoutInternal) {
+    // get currently active modem
+    uint8_t modem = getPacketType();
+    if(modem == RADIOLIB_SX126X_PACKET_TYPE_LORA) {
+      // calculate timeout (100 LoRa symbols, the default for SX127x series)
+      float symbolLength = (float)(uint32_t(1) << this->spreadingFactor) / (float)this->bandwidthKhz;
+      timeoutInternal = (RadioLibTime_t)(symbolLength * 100.0f);
+    
+    } else if(modem == RADIOLIB_SX126X_PACKET_TYPE_GFSK) {
+      // calculate timeout (500 % of expected time-one-air)
+      size_t maxLen = len;
+      if(len == 0) { maxLen = 0xFF; }
+      float brBps = (RADIOLIB_SX126X_CRYSTAL_FREQ * 1000000.0f * 32.0f) / (float)this->bitRate;
+      timeoutInternal = (RadioLibTime_t)(((maxLen * 8.0f) / brBps) * 1000.0f * 5.0f);
 
-  // get currently active modem
-  uint8_t modem = getPacketType();
-  if(modem == RADIOLIB_SX126X_PACKET_TYPE_LORA) {
-    // calculate timeout (100 LoRa symbols, the default for SX127x series)
-    float symbolLength = (float)(uint32_t(1) << this->spreadingFactor) / (float)this->bandwidthKhz;
-    timeout = (RadioLibTime_t)(symbolLength * 100.0f);
-  
-  } else if(modem == RADIOLIB_SX126X_PACKET_TYPE_GFSK) {
-    // calculate timeout (500 % of expected time-one-air)
-    size_t maxLen = len;
-    if(len == 0) {
-      maxLen = 0xFF;
+    } else {
+      return(RADIOLIB_ERR_UNKNOWN);
+    
     }
-    float brBps = (RADIOLIB_SX126X_CRYSTAL_FREQ * 1000000.0f * 32.0f) / (float)this->bitRate;
-    timeout = (RadioLibTime_t)(((maxLen * 8.0f) / brBps) * 1000.0f * 5.0f);
-
-  } else {
-    return(RADIOLIB_ERR_UNKNOWN);
-  
   }
 
-  RADIOLIB_DEBUG_BASIC_PRINTLN("Timeout in %lu ms", timeout);
+  RADIOLIB_DEBUG_BASIC_PRINTLN("Timeout in %lu ms", timeoutInternal);
 
   // start reception
-  uint32_t timeoutValue = (uint32_t)(((float)timeout * 1000.0f) / 15.625f);
+  uint32_t timeoutValue = (uint32_t)(((float)timeoutInternal * 1000.0f) / 15.625f);
   state = startReceive(timeoutValue);
   RADIOLIB_ASSERT(state);
 
@@ -290,7 +289,7 @@ int16_t SX126x::receive(uint8_t* data, size_t len) {
   while(!this->mod->hal->digitalRead(this->mod->getIrq())) {
     this->mod->hal->yield();
     // safety check, the timeout should be done by the radio
-    if(this->mod->hal->millis() - start > timeout) {
+    if(this->mod->hal->millis() - start > timeoutInternal) {
       softTimeout = true;
       break;
     }
@@ -302,18 +301,14 @@ int16_t SX126x::receive(uint8_t* data, size_t len) {
     return(state);
   }
 
-  // check whether this was a timeout or not
-  if((getIrqFlags() & RADIOLIB_SX126X_IRQ_TIMEOUT) || softTimeout) {
-    standby();
-    fixImplicitTimeout();
-    clearIrqStatus();
-    return(RADIOLIB_ERR_RX_TIMEOUT);
-  }
+  // cache the IRQ flags and clean up after reception
+  uint32_t irqFlags = getIrqFlags();
+  state = finishReceive();
+  RADIOLIB_ASSERT(state);
 
-  // fix timeout in implicit LoRa mode
-  if(((this->headerType == RADIOLIB_SX126X_LORA_HEADER_IMPLICIT) && (getPacketType() == RADIOLIB_SX126X_PACKET_TYPE_LORA))) {
-    state = fixImplicitTimeout();
-    RADIOLIB_ASSERT(state);
+  // check whether this was a timeout or not
+  if((irqFlags & RADIOLIB_SX126X_IRQ_TIMEOUT) || softTimeout) {
+    return(RADIOLIB_ERR_RX_TIMEOUT);
   }
 
   // read the received data

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -567,11 +567,13 @@ class SX126x: public PhysicalLayer {
     /*!
       \brief Blocking binary receive method.
       Overloads for string-based transmissions are implemented in PhysicalLayer.
-      \param data Binary data to be sent.
-      \param len Number of bytes to send.
+      \param data Pointer to array to save the received binary data.
+      \param len Number of bytes that will be received. Must be known in advance for binary transmissions.
+      \param timeout Reception timeout in milliseconds. If set to 0,
+      timeout period will be calculated automatically based on the radio configuration.
       \returns \ref status_codes
     */
-    int16_t receive(uint8_t* data, size_t len) override;
+    int16_t receive(uint8_t* data, size_t len, RadioLibTime_t timeout = 0) override;
 
     /*!
       \brief Starts direct mode transmission.

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -689,6 +689,12 @@ class SX126x: public PhysicalLayer {
       \returns \ref status_codes
     */
     int16_t finishTransmit() override;
+
+    /*!
+      \brief Clean up after reception is done.
+      \returns \ref status_codes
+    */
+    int16_t finishReceive() override;
     
     /*!
       \brief Interrupt-driven receive method with default parameters.

--- a/src/modules/SX127x/SX127x.cpp
+++ b/src/modules/SX127x/SX127x.cpp
@@ -211,68 +211,66 @@ int16_t SX127x::transmit(const uint8_t* data, size_t len, uint8_t addr) {
   return(finishTransmit());
 }
 
-int16_t SX127x::receive(uint8_t* data, size_t len) {
+int16_t SX127x::receive(uint8_t* data, size_t len, RadioLibTime_t timeout) {
   // set mode to standby
   int16_t state = setMode(RADIOLIB_SX127X_STANDBY);
   RADIOLIB_ASSERT(state);
 
-  int16_t modem = getActiveModem();
-  if(modem == RADIOLIB_SX127X_LORA) {
-    // set mode to receive
-    state = startReceive(100, RADIOLIB_IRQ_RX_DEFAULT_FLAGS, RADIOLIB_IRQ_RX_DEFAULT_MASK, len);
-    RADIOLIB_ASSERT(state);
+  // calculate timeout based on the configured modem
+  RadioLibTime_t timeoutInternal = timeout;
+  uint32_t timeoutValue = 0;
+  if(!timeoutInternal) {
+    // get currently active modem
+    uint8_t modem = getActiveModem();
+    if(modem == RADIOLIB_SX127X_LORA) {
+      // calculate timeout (100 LoRa symbols, the default for SX127x series)
+      timeoutValue = 100;
+      float symbolLength = (float)(uint32_t(1) << this->spreadingFactor) / (float) this->bandwidth;
+      timeoutInternal = (RadioLibTime_t)(symbolLength * (float)timeoutValue);
+    
+    } else if(modem == RADIOLIB_SX127X_FSK_OOK) {
+      // calculate timeout in ms (500 % of expected time-on-air)
+      size_t maxLen = len;
+      if(len == 0) { maxLen = RADIOLIB_SX127X_MAX_PACKET_LENGTH_FSK; }
+      timeoutInternal = (getTimeOnAir(maxLen) * 5) / 1000;
 
-    // if no DIO1 is provided, use software timeout (100 LoRa symbols, same as hardware timeout)
-    RadioLibTime_t timeout = 0;
-    if(this->mod->getGpio() == RADIOLIB_NC) {
-      float symbolLength = (float) (uint32_t(1) << this->spreadingFactor) / (float) this->bandwidth;
-      timeout = (RadioLibTime_t)(symbolLength * 100.0f);
-    }
+      // FSK modem does not distinguish Rx single and continuous mode
+      timeoutValue = 0;
 
-    // wait for packet reception or timeout
-    RadioLibTime_t start = this->mod->hal->millis();
-    while(!this->mod->hal->digitalRead(this->mod->getIrq())) {
-      this->mod->hal->yield();
-
-      if(this->mod->getGpio() == RADIOLIB_NC) {
-        // no GPIO pin provided, use software timeout
-        if(this->mod->hal->millis() - start > timeout) {
-          clearIrqFlags(RADIOLIB_SX127X_FLAGS_ALL);
-          return(RADIOLIB_ERR_RX_TIMEOUT);
-        }
-      } else {
-        // GPIO provided, use that
-        if(this->mod->hal->digitalRead(this->mod->getGpio())) {
-          clearIrqFlags(RADIOLIB_SX127X_FLAGS_ALL);
-          return(RADIOLIB_ERR_RX_TIMEOUT);
-        }
-      }
-
-    }
-
-  } else if(modem == RADIOLIB_SX127X_FSK_OOK) {
-    // calculate timeout in ms (500 % of expected time-on-air)
-    RadioLibTime_t timeout = (getTimeOnAir(len) * 5) / 1000;
-
-    // set mode to receive
-    state = startReceive(0, RADIOLIB_IRQ_RX_DEFAULT_FLAGS, RADIOLIB_IRQ_RX_DEFAULT_MASK, len);
-    RADIOLIB_ASSERT(state);
-
-    // wait for packet reception or timeout
-    RadioLibTime_t start = this->mod->hal->millis();
-    while(!this->mod->hal->digitalRead(this->mod->getIrq())) {
-      this->mod->hal->yield();
-      if(this->mod->hal->millis() - start > timeout) {
-        clearIrqFlags(RADIOLIB_SX127X_FLAGS_ALL);
-        return(RADIOLIB_ERR_RX_TIMEOUT);
-      }
+    } else {
+      return(RADIOLIB_ERR_UNKNOWN);
+    
     }
   }
 
-  // read the received data
-  state = readData(data, len);
+  RADIOLIB_DEBUG_BASIC_PRINTLN("Timeout in %lu ms", timeoutInternal);
 
-  return(state);
+  // start reception
+  state = startReceive(timeoutValue, RADIOLIB_IRQ_RX_DEFAULT_FLAGS, RADIOLIB_IRQ_RX_DEFAULT_MASK, len);
+  RADIOLIB_ASSERT(state);
+
+  // wait for packet reception or timeout
+  bool softTimeout = false;
+  RadioLibTime_t start = this->mod->hal->millis();
+  while(!this->mod->hal->digitalRead(this->mod->getIrq())) {
+    this->mod->hal->yield();
+    // check the blocking timeout
+    if(this->mod->hal->millis() - start > timeoutInternal) {
+      softTimeout = true;
+      break;
+    }
+  }
+
+  // cache the IRQ flags and clean up after reception
+  uint16_t irqFlags = getIRQFlags();
+
+  // check whether this was a timeout or not
+  if(softTimeout || (irqFlags & this->irqMap[RADIOLIB_IRQ_TIMEOUT])) {
+    return(RADIOLIB_ERR_RX_TIMEOUT);
+  }
+
+  // read the received data
+  return(readData(data, len));
 }
 
 int16_t SX127x::scanChannel() {

--- a/src/modules/SX127x/SX127x.cpp
+++ b/src/modules/SX127x/SX127x.cpp
@@ -571,12 +571,12 @@ int16_t SX127x::readData(uint8_t* data, size_t len) {
 }
 
 int16_t SX127x::finishReceive() {
-  // clear interrupt flags
-  int16_t state = clearIrqFlags(RADIOLIB_SX127X_FLAGS_ALL);
+  // set mode to standby to disable RF switch
+  int16_t state = standby();
   RADIOLIB_ASSERT(state);
 
-  // set mode to standby to disable RF switch
-  return(standby());
+  // clear interrupt flags
+  return(clearIrqFlags(RADIOLIB_SX127X_FLAGS_ALL));
 }
 
 int16_t SX127x::startChannelScan() {

--- a/src/modules/SX127x/SX127x.cpp
+++ b/src/modules/SX127x/SX127x.cpp
@@ -263,6 +263,8 @@ int16_t SX127x::receive(uint8_t* data, size_t len, RadioLibTime_t timeout) {
 
   // cache the IRQ flags and clean up after reception
   uint16_t irqFlags = getIRQFlags();
+  state = finishReceive();
+  RADIOLIB_ASSERT(state);
 
   // check whether this was a timeout or not
   if(softTimeout || (irqFlags & this->irqMap[RADIOLIB_IRQ_TIMEOUT])) {
@@ -579,6 +581,15 @@ int16_t SX127x::readData(uint8_t* data, size_t len) {
   clearIrqFlags(RADIOLIB_SX127X_FLAGS_ALL);
 
   return(state);
+}
+
+int16_t SX127x::finishReceive() {
+  // clear interrupt flags
+  int16_t state = clearIrqFlags(RADIOLIB_SX127X_FLAGS_ALL);
+  RADIOLIB_ASSERT(state);
+
+  // set mode to standby to disable RF switch
+  return(standby());
 }
 
 int16_t SX127x::startChannelScan() {

--- a/src/modules/SX127x/SX127x.h
+++ b/src/modules/SX127x/SX127x.h
@@ -825,6 +825,12 @@ class SX127x: public PhysicalLayer {
     int16_t readData(uint8_t* data, size_t len) override;
 
     /*!
+      \brief Clean up after reception is done.
+      \returns \ref status_codes
+    */
+    int16_t finishReceive() override;
+
+    /*!
       \brief Interrupt-driven channel activity detection method. DIO0 will be activated when LoRa preamble is detected.
       DIO1 will be activated if there's no preamble detected before timeout.
       \returns \ref status_codes

--- a/src/modules/SX127x/SX127x.h
+++ b/src/modules/SX127x/SX127x.h
@@ -641,9 +641,11 @@ class SX127x: public PhysicalLayer {
       For overloads to receive Arduino String, see PhysicalLayer::receive.
       \param data Pointer to array to save the received binary data.
       \param len Number of bytes that will be received. Must be known in advance for binary transmissions.
+      \param timeout Reception timeout in milliseconds. If set to 0,
+      timeout period will be calculated automatically based on the radio configuration.
       \returns \ref status_codes
     */
-    int16_t receive(uint8_t* data, size_t len) override;
+    int16_t receive(uint8_t* data, size_t len, RadioLibTime_t timeout = 0) override;
 
     /*!
       \brief Performs scan for valid %LoRa preamble in the current channel.

--- a/src/modules/SX128x/SX128x.cpp
+++ b/src/modules/SX128x/SX128x.cpp
@@ -569,12 +569,12 @@ int16_t SX128x::readData(uint8_t* data, size_t len) {
 }
 
 int16_t SX128x::finishReceive() {
-  // clear interrupt flags
-  int16_t state = clearIrqStatus();
+  // set mode to standby to disable RF switch
+  int16_t state = standby();
   RADIOLIB_ASSERT(state);
 
-  // set mode to standby to disable RF switch
-  return(standby());
+  // clear interrupt flags
+  return(clearIrqStatus());
 }
 
 uint32_t SX128x::getIrqFlags() {

--- a/src/modules/SX128x/SX128x.cpp
+++ b/src/modules/SX128x/SX128x.cpp
@@ -362,6 +362,8 @@ int16_t SX128x::receive(uint8_t* data, size_t len, RadioLibTime_t timeout) {
   RADIOLIB_ASSERT(state);
 
   // calculate timeout (1000% of expected time-on-air)
+  // for most other modules, it is 500%, however, the overall datarates of SX128x are higher
+  // so we use higher value for the default timeout
   RadioLibTime_t timeoutInternal = timeout;
   if(!timeoutInternal) {
     timeoutInternal = getTimeOnAir(len) * 10;

--- a/src/modules/SX128x/SX128x.cpp
+++ b/src/modules/SX128x/SX128x.cpp
@@ -350,7 +350,7 @@ int16_t SX128x::transmit(const uint8_t* data, size_t len, uint8_t addr) {
   return(finishTransmit());
 }
 
-int16_t SX128x::receive(uint8_t* data, size_t len) {
+int16_t SX128x::receive(uint8_t* data, size_t len, RadioLibTime_t timeout) {
   // check active modem
   uint8_t modem = getPacketType();
   if(modem == RADIOLIB_SX128X_PACKET_TYPE_RANGING) {
@@ -362,11 +362,14 @@ int16_t SX128x::receive(uint8_t* data, size_t len) {
   RADIOLIB_ASSERT(state);
 
   // calculate timeout (1000% of expected time-on-air)
-  RadioLibTime_t timeout = getTimeOnAir(len) * 10;
+  RadioLibTime_t timeoutInternal = timeout;
+  if(!timeoutInternal) {
+    timeoutInternal = getTimeOnAir(len) * 10;
+  }
   RADIOLIB_DEBUG_BASIC_PRINTLN("Timeout in %lu ms", (uint32_t)((timeout + 999) / 1000));
 
   // start reception
-  uint32_t timeoutValue = (uint32_t)((float)timeout / 15.625f);
+  uint32_t timeoutValue = (uint32_t)((float)timeoutInternal / 15.625f);
   state = startReceive(timeoutValue);
   RADIOLIB_ASSERT(state);
 

--- a/src/modules/SX128x/SX128x.cpp
+++ b/src/modules/SX128x/SX128x.cpp
@@ -393,8 +393,7 @@ int16_t SX128x::receive(uint8_t* data, size_t len, RadioLibTime_t timeout) {
 
   // check whether this was a timeout or not
   if((getIrqStatus() & RADIOLIB_SX128X_IRQ_RX_TX_TIMEOUT) || softTimeout) {
-    standby();
-    clearIrqStatus();
+    (void)finishReceive();
     return(RADIOLIB_ERR_RX_TIMEOUT);
   }
 
@@ -567,6 +566,15 @@ int16_t SX128x::readData(uint8_t* data, size_t len) {
   RADIOLIB_ASSERT(crcState);
 
   return(state);
+}
+
+int16_t SX128x::finishReceive() {
+  // clear interrupt flags
+  int16_t state = clearIrqStatus();
+  RADIOLIB_ASSERT(state);
+
+  // set mode to standby to disable RF switch
+  return(standby());
 }
 
 uint32_t SX128x::getIrqFlags() {

--- a/src/modules/SX128x/SX128x.h
+++ b/src/modules/SX128x/SX128x.h
@@ -564,6 +564,12 @@ class SX128x: public PhysicalLayer {
       \returns \ref status_codes
     */
     int16_t readData(uint8_t* data, size_t len) override;
+
+    /*!
+      \brief Clean up after reception is done.
+      \returns \ref status_codes
+    */
+    int16_t finishReceive() override;
     
     /*!
       \brief Read currently active IRQ flags.

--- a/src/modules/SX128x/SX128x.h
+++ b/src/modules/SX128x/SX128x.h
@@ -435,11 +435,13 @@ class SX128x: public PhysicalLayer {
     /*!
       \brief Blocking binary receive method.
       Overloads for string-based transmissions are implemented in PhysicalLayer.
-      \param data Binary data to be sent.
-      \param len Number of bytes to send.
+      \param data Pointer to array to save the received binary data.
+      \param len Number of bytes that will be received. Must be known in advance for binary transmissions.
+      \param timeout Reception timeout in milliseconds. If set to 0,
+      timeout period will be calculated automatically based on the radio configuration.
       \returns \ref status_codes
     */
-    int16_t receive(uint8_t* data, size_t len) override;
+    int16_t receive(uint8_t* data, size_t len, RadioLibTime_t timeout = 0) override;
 
     /*!
       \brief Starts direct mode transmission.

--- a/src/modules/Si443x/Si443x.cpp
+++ b/src/modules/Si443x/Si443x.cpp
@@ -112,6 +112,7 @@ int16_t Si443x::receive(uint8_t* data, size_t len, RadioLibTime_t timeout) {
   RadioLibTime_t start = this->mod->hal->millis();
   while(this->mod->hal->digitalRead(this->mod->getIrq())) {
     if(this->mod->hal->millis() - start > timeoutInternal) {
+      (void)finishReceive();
       return(RADIOLIB_ERR_RX_TIMEOUT);
     }
   }
@@ -346,14 +347,15 @@ int16_t Si443x::readData(uint8_t* data, size_t len) {
   // clear internal flag so getPacketLength can return the new packet length
   this->packetLengthQueried = false;
 
-  // set mode to standby
-  int16_t state = standby();
-  RADIOLIB_ASSERT(state);
+  return(finishReceive());
+}
 
+int16_t Si443x::finishReceive() {
   // clear interrupt flags
   clearIrqStatus();
 
-  return(RADIOLIB_ERR_NONE);
+  // set mode to standby to disable RF switch
+  return(standby());
 }
 
 int16_t Si443x::setBitRate(float br) {

--- a/src/modules/Si443x/Si443x.cpp
+++ b/src/modules/Si443x/Si443x.cpp
@@ -351,11 +351,12 @@ int16_t Si443x::readData(uint8_t* data, size_t len) {
 }
 
 int16_t Si443x::finishReceive() {
+  // set mode to standby to disable RF switch
+  int16_t state = standby();
+  
   // clear interrupt flags
   clearIrqStatus();
-
-  // set mode to standby to disable RF switch
-  return(standby());
+  return(state);
 }
 
 int16_t Si443x::setBitRate(float br) {

--- a/src/modules/Si443x/Si443x.h
+++ b/src/modules/Si443x/Si443x.h
@@ -598,9 +598,11 @@ class Si443x: public PhysicalLayer {
       For overloads to receive Arduino String, see PhysicalLayer::receive.
       \param data Pointer to array to save the received binary data.
       \param len Number of bytes that will be received. Must be known in advance for binary transmissions.
+      \param timeout Reception timeout in milliseconds. If set to 0,
+      timeout period will be calculated automatically based on the radio configuration.
       \returns \ref status_codes
     */
-    int16_t receive(uint8_t* data, size_t len) override;
+    int16_t receive(uint8_t* data, size_t len, RadioLibTime_t timeout = 0) override;
 
     /*!
       \brief Sets the module to sleep to save power. %Module will not be able to transmit or receive any data while in sleep mode.

--- a/src/modules/Si443x/Si443x.h
+++ b/src/modules/Si443x/Si443x.h
@@ -719,6 +719,12 @@ class Si443x: public PhysicalLayer {
     */
     int16_t readData(uint8_t* data, size_t len) override;
 
+    /*!
+      \brief Clean up after reception is done.
+      \returns \ref status_codes
+    */
+    int16_t finishReceive() override;
+
     // configuration methods
 
     /*!

--- a/src/modules/nRF24/nRF24.cpp
+++ b/src/modules/nRF24/nRF24.cpp
@@ -128,6 +128,7 @@ int16_t nRF24::receive(uint8_t* data, size_t len, RadioLibTime_t timeout) {
 
     // check timeout
     if(this->mod->hal->millis() - start >= timeoutInternal) {
+      (void)finishReceive();
       return(RADIOLIB_ERR_RX_TIMEOUT);
     }
   }
@@ -278,10 +279,15 @@ int16_t nRF24::readData(uint8_t* data, size_t len) {
   // read packet data
   SPIreadRxPayload(data, length);
 
-  // clear interrupt
+  return(finishReceive());
+}
+
+int16_t nRF24::finishReceive() {
+  // clear interrupt flags
   clearIRQ();
 
-  return(RADIOLIB_ERR_NONE);
+  // set mode to standby to disable transmitter/RF switch
+  return(standby());
 }
 
 int16_t nRF24::setFrequency(float freq) {

--- a/src/modules/nRF24/nRF24.h
+++ b/src/modules/nRF24/nRF24.h
@@ -243,13 +243,15 @@ class nRF24: public PhysicalLayer {
     int16_t transmit(const uint8_t* data, size_t len, uint8_t addr) override;
 
     /*!
-      \brief Blocking binary receive method.
-      Overloads for string-based transmissions are implemented in PhysicalLayer.
-      \param data Binary data to be sent.
-      \param len Number of bytes to send.
+      \brief Binary receive method. Will attempt to receive arbitrary binary data up to 64 bytes long.
+      For overloads to receive Arduino String, see PhysicalLayer::receive.
+      \param data Pointer to array to save the received binary data.
+      \param len Number of bytes that will be received. Must be known in advance for binary transmissions.
+      \param timeout Reception timeout in milliseconds. If set to 0,
+      timeout period will be calculated automatically based on the radio configuration.
       \returns \ref status_codes
     */
-    int16_t receive(uint8_t* data, size_t len) override;
+    int16_t receive(uint8_t* data, size_t len, RadioLibTime_t timeout = 0) override;
 
     /*!
       \brief Starts direct mode transmission.

--- a/src/modules/nRF24/nRF24.h
+++ b/src/modules/nRF24/nRF24.h
@@ -342,6 +342,12 @@ class nRF24: public PhysicalLayer {
     */
     int16_t readData(uint8_t* data, size_t len) override;
 
+    /*!
+      \brief Clean up after reception is done.
+      \returns \ref status_codes
+    */
+    int16_t finishReceive() override;
+
     // configuration methods
 
     /*!

--- a/src/protocols/PhysicalLayer/PhysicalLayer.cpp
+++ b/src/protocols/PhysicalLayer/PhysicalLayer.cpp
@@ -62,7 +62,7 @@ int16_t PhysicalLayer::transmit(const uint8_t* data, size_t len, uint8_t addr) {
 }
 
 #if defined(RADIOLIB_BUILD_ARDUINO)
-int16_t PhysicalLayer::receive(String& str, size_t len) {
+int16_t PhysicalLayer::receive(String& str, size_t len, RadioLibTime_t timeout) {
   int16_t state = RADIOLIB_ERR_NONE;
 
   // user can override the length of data to read
@@ -82,7 +82,7 @@ int16_t PhysicalLayer::receive(String& str, size_t len) {
   #endif
 
   // attempt packet reception
-  state = receive(data, length);
+  state = receive(data, length, timeout);
 
   // any of the following leads to at least some data being available
   // let's leave the decision of whether to keep it or not up to the user
@@ -108,9 +108,10 @@ int16_t PhysicalLayer::receive(String& str, size_t len) {
 }
 #endif
 
-int16_t PhysicalLayer::receive(uint8_t* data, size_t len) {
+int16_t PhysicalLayer::receive(uint8_t* data, size_t len, RadioLibTime_t timeout) {
   (void)data;
   (void)len;
+  (void)timeout;
   return(RADIOLIB_ERR_UNSUPPORTED);
 }
 

--- a/src/protocols/PhysicalLayer/PhysicalLayer.cpp
+++ b/src/protocols/PhysicalLayer/PhysicalLayer.cpp
@@ -175,6 +175,10 @@ int16_t PhysicalLayer::finishTransmit() {
   return(RADIOLIB_ERR_UNSUPPORTED);
 }
 
+int16_t PhysicalLayer::finishReceive() {
+  return(RADIOLIB_ERR_UNSUPPORTED);
+}
+
 #if defined(RADIOLIB_BUILD_ARDUINO)
 int16_t PhysicalLayer::readData(String& str, size_t len) {
   int16_t state = RADIOLIB_ERR_NONE;

--- a/src/protocols/PhysicalLayer/PhysicalLayer.h
+++ b/src/protocols/PhysicalLayer/PhysicalLayer.h
@@ -364,6 +364,12 @@ class PhysicalLayer {
     */
     virtual int16_t finishTransmit();
 
+    /*!
+      \brief Clean up after reception is done.
+      \returns \ref status_codes
+    */
+    virtual int16_t finishReceive();
+
     #if defined(RADIOLIB_BUILD_ARDUINO)
     /*!
       \brief Reads data that was received after calling startReceive method.

--- a/src/protocols/PhysicalLayer/PhysicalLayer.h
+++ b/src/protocols/PhysicalLayer/PhysicalLayer.h
@@ -275,10 +275,12 @@ class PhysicalLayer {
     /*!
       \brief Arduino String receive method.
       \param str Address of Arduino String to save the received data.
-      \param len Expected number of characters in the message. Leave as 0 if expecting a unknown size packet
+      \param len Expected number of characters in the message. Leave as 0 if expecting a unknown size packet.
+      \param timeout Reception timeout in milliseconds. If set to 0,
+      timeout period will be calculated automatically based on the radio configuration.
       \returns \ref status_codes
     */
-    int16_t receive(String& str, size_t len = 0);
+    int16_t receive(String& str, size_t len = 0, RadioLibTime_t timeout = 0);
     #endif
 
     /*!
@@ -321,9 +323,11 @@ class PhysicalLayer {
       \brief Binary receive method. Must be implemented in module class.
       \param data Pointer to array to save the received binary data.
       \param len Packet length, needed for some modules under special circumstances (e.g. LoRa implicit header mode).
+      \param timeout Reception timeout in milliseconds. If set to 0,
+      timeout period will be calculated automatically based on the radio configuration.
       \returns \ref status_codes
     */
-    virtual int16_t receive(uint8_t* data, size_t len);
+    virtual int16_t receive(uint8_t* data, size_t len, RadioLibTime_t timeout = 0);
 
     #if defined(RADIOLIB_BUILD_ARDUINO)
     /*!


### PR DESCRIPTION
As discussed in #1581, this PR adds simple way for user to directly control the timeout of the blocking `receive` methods by adding a `timeout` argument (in milliseconds). If set to 0 (the default value), the timeout duration is calculated the same way as before.

I also added a `finishReceive` method to clean up after reception.

@StevenCellist I would be very glad for a review, thanks!

cc @MarusGradinaru 