### PR TITLE
[SX126x] Use a default of either 8 or 12 for minSymbols in startReceiveDutyCycleAuto

### DIFF
--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -559,6 +559,13 @@ int16_t SX126x::startReceiveDutyCycleAuto(uint16_t senderPreambleLength, uint16_
   if(senderPreambleLength == 0) {
     senderPreambleLength = this->preambleLengthLoRa;
   }
+  if(minSymbols == 0) {
+    if (this->spreadingFactor <= 6) {
+      minSymbols = 12;
+    } else {
+      minSymbols = 8;
+    }
+  }
 
   // worst case is that the sender starts transmitting when we're just less than minSymbols from going back to sleep.
   // in this case, we don't catch minSymbols before going to sleep,

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -727,10 +727,11 @@ class SX126x: public PhysicalLayer {
       If the sender preamble length is variable or unknown, the maximum expected size should be configured
       on the receiver side by calling setPreambleLength prior to startReceiveDutyCycleAuto.
 
-      \param minSymbols Parameters will be chosen to ensure that the unit will catch at least this many symbols
-      of any preamble of the specified length. Defaults to 8.
-      According to Semtech, receiver requires 8 symbols to reliably latch a preamble.
-      This makes this method redundant when transmitter preamble length is less than 17 (2*minSymbols + 1).
+      \param minSymbols Ensure that the unit will catch at least this many symbols of any preamble of the specified senderPreambleLength.
+      To reliably latch a preamble, the receiver requires 8 symbols for SF7-12 and 12 symbols for SF5-6 (see datasheet section 6.1.1.1, version 1.2).
+      Defaults to 8.
+
+      If senderPreambleLength is less than 2*minSymbols + 1, this method is equivalent to startReceive().
 
       \param irqFlags Sets the IRQ flags, defaults to RX done, RX timeout, CRC error and header error.
       \param irqMask Sets the mask of IRQ flags that will trigger DIO1, defaults to RX done.

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -729,7 +729,7 @@ class SX126x: public PhysicalLayer {
 
       \param minSymbols Ensure that the unit will catch at least this many symbols of any preamble of the specified senderPreambleLength.
       To reliably latch a preamble, the receiver requires 8 symbols for SF7-12 and 12 symbols for SF5-6 (see datasheet section 6.1.1.1, version 1.2).
-      Defaults to 8.
+      If set to zero, the minimum required symbols will be used. Defaults to 0.
 
       If senderPreambleLength is less than 2*minSymbols + 1, this method is equivalent to startReceive().
 
@@ -737,7 +737,7 @@ class SX126x: public PhysicalLayer {
       \param irqMask Sets the mask of IRQ flags that will trigger DIO1, defaults to RX done.
       \returns \ref status_codes
     */
-    int16_t startReceiveDutyCycleAuto(uint16_t senderPreambleLength = 0, uint16_t minSymbols = 8, RadioLibIrqFlags_t irqFlags = RADIOLIB_IRQ_RX_DEFAULT_FLAGS, RadioLibIrqFlags_t irqMask = RADIOLIB_IRQ_RX_DEFAULT_MASK);
+    int16_t startReceiveDutyCycleAuto(uint16_t senderPreambleLength = 0, uint16_t minSymbols = 0, RadioLibIrqFlags_t irqFlags = RADIOLIB_IRQ_RX_DEFAULT_FLAGS, RadioLibIrqFlags_t irqMask = RADIOLIB_IRQ_RX_DEFAULT_MASK);
 
     /*!
       \brief Reads data received after calling startReceive method. When the packet length is not known in advance,


### PR DESCRIPTION
According to the Semtech datasheet (6.1.1.1, version 1.2), the minimum symbols to reliably latch a preamble is 12 for SF5-6. This PR updates the `startReceiveDutyCycleAuto(senderPreambleLength, minSymbols)` method to use a default of 12 for `minSymbols` when SF <= 6.