### PR TITLE
[SX126x] For receiveDutyCycleAuto, check senderPreambleLength is shorter than configured preamble

### DIFF
--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -558,6 +558,9 @@ int16_t SX126x::startReceiveDutyCycle(uint32_t rxPeriod, uint32_t sleepPeriod, R
 int16_t SX126x::startReceiveDutyCycleAuto(uint16_t senderPreambleLength, uint16_t minSymbols, RadioLibIrqFlags_t irqFlags, RadioLibIrqFlags_t irqMask) {
   if(senderPreambleLength == 0) {
     senderPreambleLength = this->preambleLengthLoRa;
+  } else if (senderPreambleLength > this->preambleLengthLoRa) {
+    // the unit must be configured to expect a preamble length at least as long as the sender is using
+    return(RADIOLIB_ERR_INVALID_PREAMBLE_LENGTH);
   }
 
   // worst case is that the sender starts transmitting when we're just less than minSymbols from going back to sleep.

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -724,7 +724,7 @@ class SX126x: public PhysicalLayer {
       \brief Calls \ref startReceiveDutyCycle with rxPeriod and sleepPeriod set so the unit shouldn't miss any messages.
       \param senderPreambleLength Expected preamble length of the messages to receive.
       If set to zero, the currently configured preamble length will be used. Defaults to zero.
-      This value should never exceed the configured preamble length. If the sender preamble length is variable, set the
+      This value cannot exceed the configured preamble length. If the sender preamble length is variable, set the
       maximum expected length by calling setPreambleLength(maximumExpectedLength) prior to this method, and use the
       minimum expected length here.
 

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -724,8 +724,9 @@ class SX126x: public PhysicalLayer {
       \brief Calls \ref startReceiveDutyCycle with rxPeriod and sleepPeriod set so the unit shouldn't miss any messages.
       \param senderPreambleLength Expected preamble length of the messages to receive.
       If set to zero, the currently configured preamble length will be used. Defaults to zero.
-      If the sender preamble length is variable or unknown, the maximum expected size should be configured
-      on the receiver side by calling setPreambleLength prior to startReceiveDutyCycleAuto.
+      This value should never exceed the configured preamble length. If the sender preamble length is variable, set the
+      maximum expected length by calling setPreambleLength(maximumExpectedLength) prior to this method, and use the
+      minimum expected length here.
 
       \param minSymbols Parameters will be chosen to ensure that the unit will catch at least this many symbols
       of any preamble of the specified length. Defaults to 8.


### PR DESCRIPTION
Update documentation of `receiveDutyCycleAuto()` and add a check on the value of `senderPreambleLength`, returning RADIOLIB_ERR_INVALID_PREAMBLE_LENGTH if it exceeds the configured preamble length.

The check cause existing code to return an error instead, although arguably such code may already be causing unnoticed failures. The first commit only changes the documentation if preferred.