### PR TITLE
[SX1262] Use named arguments for SX1262::begin* methods

### DIFF
--- a/examples/SX126x/SX126x_Channel_Activity_Detection_Blocking/SX126x_Channel_Activity_Detection_Blocking.ino
+++ b/examples/SX126x/SX126x_Channel_Activity_Detection_Blocking/SX126x_Channel_Activity_Detection_Blocking.ino
@@ -43,7 +43,7 @@ void setup() {
 
   // initialize SX1262 with default settings
   Serial.print(F("[SX1262] Initializing ... "));
-  int state = radio.begin();
+  int state = radio.begin({});
   if (state == RADIOLIB_ERR_NONE) {
     Serial.println(F("success!"));
   } else {

--- a/examples/SX126x/SX126x_Channel_Activity_Detection_Interrupt/SX126x_Channel_Activity_Detection_Interrupt.ino
+++ b/examples/SX126x/SX126x_Channel_Activity_Detection_Interrupt/SX126x_Channel_Activity_Detection_Interrupt.ino
@@ -53,7 +53,7 @@ void setup() {
 
   // initialize SX1262 with default settings
   Serial.print(F("[SX1262] Initializing ... "));
-  int state = radio.begin();
+  int state = radio.begin({});
   if (state == RADIOLIB_ERR_NONE) {
     Serial.println(F("success!"));
   } else {

--- a/examples/SX126x/SX126x_Channel_Activity_Detection_Receive/SX126x_Channel_Activity_Detection_Receive.ino
+++ b/examples/SX126x/SX126x_Channel_Activity_Detection_Receive/SX126x_Channel_Activity_Detection_Receive.ino
@@ -58,7 +58,7 @@ void setup() {
 
   // initialize SX1262 with default settings
   Serial.print(F("[SX1262] Initializing ... "));
-  int state = radio.begin();
+  int state = radio.begin({});
   if (state == RADIOLIB_ERR_NONE) {
     Serial.println(F("success!"));
   } else {

--- a/examples/SX126x/SX126x_FSK_Modem/SX126x_FSK_Modem.ino
+++ b/examples/SX126x/SX126x_FSK_Modem/SX126x_FSK_Modem.ino
@@ -39,7 +39,7 @@ void setup() {
 
   // initialize SX1262 FSK modem with default settings
   Serial.print(F("[SX1262] Initializing ... "));
-  int state = radio.beginFSK();
+  int state = radio.beginFSK({});
   if (state == RADIOLIB_ERR_NONE) {
     Serial.println(F("success!"));
   } else {
@@ -50,8 +50,8 @@ void setup() {
 
   // if needed, you can switch between LoRa and FSK modes
   //
-  // radio.begin()       start LoRa mode (and disable FSK)
-  // radio.beginFSK()    start FSK mode (and disable LoRa)
+  // radio.begin({})       start LoRa mode (and disable FSK)
+  // radio.beginFSK({})    start FSK mode (and disable LoRa)
 
   // the following settings can also
   // be modified at run-time

--- a/examples/SX126x/SX126x_PingPong/SX126x_PingPong.ino
+++ b/examples/SX126x/SX126x_PingPong/SX126x_PingPong.ino
@@ -59,7 +59,7 @@ void setup() {
 
   // initialize SX1262 with default settings
   Serial.print(F("[SX1262] Initializing ... "));
-  int state = radio.begin();
+  int state = radio.begin({});
   if (state == RADIOLIB_ERR_NONE) {
     Serial.println(F("success!"));
   } else {

--- a/examples/SX126x/SX126x_Receive_Blocking/SX126x_Receive_Blocking.ino
+++ b/examples/SX126x/SX126x_Receive_Blocking/SX126x_Receive_Blocking.ino
@@ -48,7 +48,7 @@ void setup() {
 
   // initialize SX1262 with default settings
   Serial.print(F("[SX1262] Initializing ... "));
-  int state = radio.begin();
+  int state = radio.begin({});
   if (state == RADIOLIB_ERR_NONE) {
     Serial.println(F("success!"));
   } else {

--- a/examples/SX126x/SX126x_Receive_Interrupt/SX126x_Receive_Interrupt.ino
+++ b/examples/SX126x/SX126x_Receive_Interrupt/SX126x_Receive_Interrupt.ino
@@ -59,7 +59,7 @@ void setup() {
 
   // initialize SX1262 with default settings
   Serial.print(F("[SX1262] Initializing ... "));
-  int state = radio.begin();
+  int state = radio.begin({});
   if (state == RADIOLIB_ERR_NONE) {
     Serial.println(F("success!"));
   } else {

--- a/examples/SX126x/SX126x_Spectrum_Scan/SX126x_Spectrum_Scan.ino
+++ b/examples/SX126x/SX126x_Spectrum_Scan/SX126x_Spectrum_Scan.ino
@@ -47,7 +47,7 @@ void setup() {
 
    // initialize SX1262 FSK modem with default settings
   Serial.print(F("[SX1262] Initializing ... "));
-  int state = radio.beginFSK();
+  int state = radio.beginFSK({});
   if(state == RADIOLIB_ERR_NONE) {
     Serial.println(F("success!"));
   } else {

--- a/examples/SX126x/SX126x_Transmit_Blocking/SX126x_Transmit_Blocking.ino
+++ b/examples/SX126x/SX126x_Transmit_Blocking/SX126x_Transmit_Blocking.ino
@@ -43,7 +43,7 @@ void setup() {
 
   // initialize SX1262 with default settings
   Serial.print(F("[SX1262] Initializing ... "));
-  int state = radio.begin();
+  int state = radio.begin({});
   if (state == RADIOLIB_ERR_NONE) {
     Serial.println(F("success!"));
   } else {

--- a/examples/SX126x/SX126x_Transmit_Interrupt/SX126x_Transmit_Interrupt.ino
+++ b/examples/SX126x/SX126x_Transmit_Interrupt/SX126x_Transmit_Interrupt.ino
@@ -58,7 +58,7 @@ void setup() {
 
   // initialize SX1262 with default settings
   Serial.print(F("[SX1262] Initializing ... "));
-  int state = radio.begin();
+  int state = radio.begin({});
   if (state == RADIOLIB_ERR_NONE) {
     Serial.println(F("success!"));
   } else {

--- a/extras/test/SX126x/main.cpp
+++ b/extras/test/SX126x/main.cpp
@@ -13,7 +13,7 @@ SX1261 radio = new Module(hal, 7, 17, 22, RADIOLIB_NC);
 int main(int argc, char** argv) {
   int state = RADIOLIB_ERR_UNKNOWN;
 
-  state = radio.begin();
+  state = radio.begin({});
   printf("[SX1261] Test:begin() = %d\n", state);
   RADIOLIB_TEST_ASSERT(state);
 

--- a/src/modules/SX126x/SX1262.cpp
+++ b/src/modules/SX126x/SX1262.cpp
@@ -7,64 +7,115 @@ SX1262::SX1262(Module* mod) : SX126x(mod) {
   chipType = RADIOLIB_SX1262_CHIP_TYPE;
 }
 
+int16_t SX1262::begin(const Configuration_t& config) {
+  // execute common part
+  int16_t state = SX126x::begin(
+    config.codingRate, config.syncWord, config.preambleLength,
+    config.tcxoVoltage, config.useRegulatorLDO);
+  RADIOLIB_ASSERT(state);
+
+  // configure publicly accessible settings
+  state = setSpreadingFactor(config.spreadingFactor);
+  RADIOLIB_ASSERT(state);
+
+  state = setBandwidth(config.bandwidth);
+  RADIOLIB_ASSERT(state);
+
+  state = setFrequency(config.frequency);
+  RADIOLIB_ASSERT(state);
+
+  state = SX126x::fixPaClamping();
+  RADIOLIB_ASSERT(state);
+
+  state = setOutputPower(config.power);
+  RADIOLIB_ASSERT(state);
+
+  return(state);
+}
+
+// deprecated
 int16_t SX1262::begin(float freq, float bw, uint8_t sf, uint8_t cr, uint8_t syncWord, int8_t power, uint16_t preambleLength, float tcxoVoltage, bool useRegulatorLDO) {
+  // C++11 does not support designated initializers here, so we need to do this the old way
+  Configuration_t config;
+  config.frequency = freq;
+  config.bandwidth = bw;
+  config.spreadingFactor = sf;
+  config.codingRate = cr;
+  config.syncWord = syncWord;
+  config.power = power;
+  config.preambleLength = preambleLength;
+  config.tcxoVoltage = tcxoVoltage;
+  config.useRegulatorLDO = useRegulatorLDO;
+  return(begin(config));
+}
+
+int16_t SX1262::beginFSK(const ConfigurationFSK_t& config) {
   // execute common part
-  int16_t state = SX126x::begin(cr, syncWord, preambleLength, tcxoVoltage, useRegulatorLDO);
+  int16_t state = SX126x::beginFSK(
+    config.bitRate, config.frequencyDeviation, config.receiverBandwidth,
+    config.preambleLength, config.tcxoVoltage, config.useRegulatorLDO);
   RADIOLIB_ASSERT(state);
 
   // configure publicly accessible settings
-  state = setSpreadingFactor(sf);
-  RADIOLIB_ASSERT(state);
-
-  state = setBandwidth(bw);
-  RADIOLIB_ASSERT(state);
-
-  state = setFrequency(freq);
+  state = setFrequency(config.frequency);
   RADIOLIB_ASSERT(state);
 
   state = SX126x::fixPaClamping();
   RADIOLIB_ASSERT(state);
 
-  state = setOutputPower(power);
+  state = setOutputPower(config.power);
   RADIOLIB_ASSERT(state);
 
   return(state);
 }
 
+// deprecated
 int16_t SX1262::beginFSK(float freq, float br, float freqDev, float rxBw, int8_t power, uint16_t preambleLength, float tcxoVoltage, bool useRegulatorLDO) {
+  // C++11 does not support designated initializers here, so we need to do this the old way
+  ConfigurationFSK_t config;
+  config.frequency = freq;
+  config.bitRate = br;
+  config.frequencyDeviation = freqDev;
+  config.receiverBandwidth = rxBw;
+  config.power = power;
+  config.preambleLength = preambleLength;
+  config.tcxoVoltage = tcxoVoltage;
+  config.useRegulatorLDO = useRegulatorLDO;
+  return(beginFSK(config));
+}
+
+int16_t SX1262::beginLRFHSS(const ConfigurationLRFHSS_t& config) {
   // execute common part
-  int16_t state = SX126x::beginFSK(br, freqDev, rxBw, preambleLength, tcxoVoltage, useRegulatorLDO);
+  int16_t state = SX126x::beginLRFHSS(
+    config.bandwidth, config.codingRate, config.narrowGrid,
+    config.tcxoVoltage, config.useRegulatorLDO);
   RADIOLIB_ASSERT(state);
 
   // configure publicly accessible settings
-  state = setFrequency(freq);
+  state = setFrequency(config.frequency);
   RADIOLIB_ASSERT(state);
 
   state = SX126x::fixPaClamping();
   RADIOLIB_ASSERT(state);
 
-  state = setOutputPower(power);
+  state = setOutputPower(config.power);
   RADIOLIB_ASSERT(state);
 
   return(state);
 }
 
+// deprecated
 int16_t SX1262::beginLRFHSS(float freq, uint8_t bw, uint8_t cr, bool narrowGrid, int8_t power, float tcxoVoltage, bool useRegulatorLDO) {
-  // execute common part
-  int16_t state = SX126x::beginLRFHSS(bw, cr, narrowGrid, tcxoVoltage, useRegulatorLDO);
-  RADIOLIB_ASSERT(state);
-
-  // configure publicly accessible settings
-  state = setFrequency(freq);
-  RADIOLIB_ASSERT(state);
-
-  state = SX126x::fixPaClamping();
-  RADIOLIB_ASSERT(state);
-
-  state = setOutputPower(power);
-  RADIOLIB_ASSERT(state);
-
-  return(state);
+  // C++11 does not support designated initializers here, so we need to do this the old way
+  ConfigurationLRFHSS_t config;
+  config.frequency = freq;
+  config.bandwidth = bw;
+  config.codingRate = cr;
+  config.narrowGrid = narrowGrid;
+  config.power = power;
+  config.tcxoVoltage = tcxoVoltage;
+  config.useRegulatorLDO = useRegulatorLDO;
+  return(beginLRFHSS(config));
 }
 
 int16_t SX1262::setFrequency(float freq) {

--- a/src/modules/SX126x/SX1262.h
+++ b/src/modules/SX126x/SX1262.h
@@ -30,6 +30,51 @@ class SX1262: public SX126x {
     // basic methods
 
     /*!
+      \brief Configuration for begin() method.
+    */
+    struct Configuration_t {
+      /*! \brief Carrier frequency in MHz. Defaults to 434.0 MHz. */
+      float frequency = 434.0;
+      /*! \brief LoRa bandwidth in kHz. Defaults to 125.0 kHz. */
+      float bandwidth = 125.0;
+      /*! \brief LoRa spreading factor. Defaults to 9. */
+      uint8_t spreadingFactor = 9;
+      /*! \brief LoRa coding rate. DDefaults to 7 (coding rate 4/7). Allowed values range from 4 to 8. Note that a value of 4 means no coding,
+      is undocumented and not recommended without your own FEC. */
+      uint8_t codingRate = 7;
+      /*! \brief 1-byte LoRa sync word. Defaults to RADIOLIB_SX126X_SYNC_WORD_PRIVATE (0x12). */
+      uint8_t syncWord = RADIOLIB_SX126X_SYNC_WORD_PRIVATE;
+      /*! \brief Output power in dBm. Defaults to 10 dBm. */
+      int8_t power = 10;
+      /*! \brief LoRa preamble length in symbols. Defaults to 8 symbols. */
+      uint16_t preambleLength = 8;
+      /*! \brief TCXO reference voltage to be set on DIO3. Defaults to 1.6 V.
+      If you are seeing -706/-707 error codes, it likely means you are using non-0 value for module with XTAL.
+      To use XTAL, either set this value to 0, or set SX126x::XTAL to true. */
+      float tcxoVoltage = 1.6;
+      /*! \brief Whether to use only LDO regulator (true) or DC-DC regulator (false). Defaults to false. */
+      bool useRegulatorLDO = false;
+    };
+
+    /*!
+      \brief Initialization method for LoRa modem.
+      \details This method initializes the LoRa modem with the specified configuration. Supports designated
+      initializers when using C++14 or above. Example:
+      \code
+      int state = radio.begin({
+        .frequency = 434.0,
+        .bandwidth = 125.0,
+        .spreadingFactor = 9,
+        .codingRate = 7,
+        .preambleLength = 8
+      });
+      \param config Initialization configuration.
+      \returns \ref status_codes
+    */
+    virtual int16_t begin(const Configuration_t& config);
+
+    /*!
+      \deprecated Use \ref begin(const Configuration_t& config) instead.
       \brief Initialization method for LoRa modem.
       \param freq Carrier frequency in MHz. Defaults to 434.0 MHz.
       \param bw LoRa bandwidth in kHz. Defaults to 125.0 kHz.
@@ -48,6 +93,48 @@ class SX1262: public SX126x {
     virtual int16_t begin(float freq = 434.0, float bw = 125.0, uint8_t sf = 9, uint8_t cr = 7, uint8_t syncWord = RADIOLIB_SX126X_SYNC_WORD_PRIVATE, int8_t power = 10, uint16_t preambleLength = 8, float tcxoVoltage = 1.6, bool useRegulatorLDO = false);
 
     /*!
+      \brief Configuration for beginFSK() method.
+    */
+    struct ConfigurationFSK_t {
+      /*! \brief Carrier frequency in MHz. Defaults to 434.0 MHz. */
+      float frequency = 434.0;
+      /*! \brief FSK bit rate in kbps. Defaults to 4.8 kbps. */
+      float bitRate = 4.8;
+      /*! \brief FSK frequency deviation in kHz. Defaults to 5.0 kHz. */
+      float frequencyDeviation = 5.0;
+      /*! \brief FSK receiver bandwidth in kHz. Defaults to 156.2 kHz. */
+      float receiverBandwidth = 156.2;
+      /*! \brief Output power in dBm. Defaults to 10 dBm. */
+      int8_t power = 10;
+      /*! \brief FSK preamble length in bits. Defaults to 16 bits. */
+      uint16_t preambleLength = 16;
+      /*! \brief TCXO reference voltage to be set on DIO3. Defaults to 1.6 V.
+      If you are seeing -706/-707 error codes, it likely means you are using non-0 value for module with XTAL.
+      To use XTAL, either set this value to 0, or set SX126x::XTAL to true. */
+      float tcxoVoltage = 1.6;
+      /*! \brief Whether to use only LDO regulator (true) or DC-DC regulator (false). Defaults to false. */
+      bool useRegulatorLDO = false;
+    };
+
+    /*!
+      \brief Initialization method for FSK modem.
+      \param config Initialization configuration.
+      \details This method initializes the FSK modem with the specified configuration. Supports designated
+      initializers when using C++14 or above. Example:
+      \code
+      int state = radio.beginFSK({
+        .frequency = 434.0,
+        .bitRate = 4.8,
+        .frequencyDeviation = 5.0,
+        .receiverBandwidth = 156.2,
+        .preambleLength = 16
+      });
+      \returns \ref status_codes
+    */
+    virtual int16_t beginFSK(const ConfigurationFSK_t& config);
+
+    /*!
+      \deprecated Use \ref beginFSK(const ConfigurationFSK_t& config) instead.
       \brief Initialization method for FSK modem.
       \param freq Carrier frequency in MHz. Defaults to 434.0 MHz.
       \param br FSK bit rate in kbps. Defaults to 4.8 kbps.
@@ -62,8 +149,44 @@ class SX1262: public SX126x {
       \returns \ref status_codes
     */
     virtual int16_t beginFSK(float freq = 434.0, float br = 4.8, float freqDev = 5.0, float rxBw = 156.2, int8_t power = 10, uint16_t preambleLength = 16, float tcxoVoltage = 1.6, bool useRegulatorLDO = false);
-    
+
+    struct ConfigurationLRFHSS_t {
+      /*! \brief Carrier frequency in MHz. Defaults to 434.0 MHz. */
+      float frequency = 434.0;
+      /*! \brief LR-FHSS bandwidth, one of RADIOLIB_SX126X_LR_FHSS_BW_* values. Defaults to 722.66 kHz. */
+      uint8_t bandwidth = RADIOLIB_SX126X_LR_FHSS_BW_722_66;
+      /*! \brief LR-FHSS coding rate, one of RADIOLIB_SX126X_LR_FHSS_CR_* values. Defaults to 2/3 coding rate. */
+      uint8_t codingRate = RADIOLIB_SX126X_LR_FHSS_CR_2_3;
+      /*! \brief Whether to use narrow (3.9 kHz) or wide (25.39 kHz) grid spacing. Defaults to true (narrow/non-FCC) grid. */
+      bool narrowGrid = true;
+      /*! \brief Output power in dBm. Defaults to 10 dBm. */
+      int8_t power = 10;
+      /*! \brief TCXO reference voltage to be set. Defaults to 1.6 V.
+      If you are seeing -706/-707 error codes, it likely means you are using non-0 value for module with XTAL.
+      To use XTAL, either set this value to 0, or set SX126x::XTAL to true. */
+      float tcxoVoltage = 1.6;
+      /*! \brief Whether to use only LDO regulator (true) or DC-DC regulator (false). Defaults to false. */
+      bool useRegulatorLDO = false;
+    };
+
     /*!
+      \brief Initialization method for LR-FHSS modem.
+      \param config Initialization configuration.
+      \details This method initializes the LR-FHSS modem with the specified configuration. Supports designated
+      initializers when using C++14 or above. Example:
+      \code
+      int state = radio.beginLRFHSS({
+        .frequency = 434.0,
+        .bandwidth = RADIOLIB_SX126X_LR_FHSS_BW_722_66,
+        .codingRate = RADIOLIB_SX126X_LR_FHSS_CR_2_3,
+        .narrowGrid = true
+      });
+      \returns \ref status_codes
+    */
+    virtual int16_t beginLRFHSS(const ConfigurationLRFHSS_t& config);
+
+    /*!
+      \deprecated Use \ref beginLRFHSS(const ConfigurationLRFHSS_t& config) instead.
       \brief Initialization method for LR-FHSS modem. This modem only supports transmission!
       \param freq Carrier frequency in MHz. Defaults to 434.0 MHz.
       \param bw LR-FHSS bandwidth, one of RADIOLIB_SX126X_LR_FHSS_BW_* values. Defaults to 722.66 kHz.


### PR DESCRIPTION
Deprecates SX1262::begin* methods with long argument lists and provides replacements that take a struct of named arguments. Supports invocation using temporary named struct objects (C++14+), e.g.:

```
int state = radio.begin({
    .frequency = 434.0,
    .bandwidth = 125.0,
    .spreadingFactor = 9,
    .codingRate = 7,
    .preambleLength = 8
});
```

If there is support for this approach, I'm happy to extend this PR to apply the pattern in the other modules in RadioLib.