### PR TITLE
Add support for Arduino Uno Q (#1640)

### DIFF
--- a/src/BuildOpt.h
+++ b/src/BuildOpt.h
@@ -388,6 +388,13 @@
   #define RADIOLIB_ARDUINOHAL_PIN_STATUS_CAST         (PinStatus)
   #define RADIOLIB_ARDUINOHAL_INTERRUPT_MODE_CAST     (PinStatus)
 
+#elif defined(ARDUINO_ARCH_ZEPHYR) && defined(ARDUINO_UNO_Q)
+  // Arduino Uno Q (Zephyr OS)
+  #define RADIOLIB_PLATFORM                           "Arduino Uno Q (Zephyr OS)"
+  #define RADIOLIB_ARDUINOHAL_PIN_MODE_CAST           (PinMode)
+  #define RADIOLIB_ARDUINOHAL_PIN_STATUS_CAST         (PinStatus)
+  #define RADIOLIB_ARDUINOHAL_INTERRUPT_MODE_CAST     (PinStatus)
+
 #else
   // other Arduino platforms not covered by the above list - this may or may not work
   #define RADIOLIB_PLATFORM                           "Unknown Arduino"


### PR DESCRIPTION
This PR adds support for the Uno Q (no CI). 
Since we don't know what Qualcomm will bring to Arduino and the use of Zephyr OS, I added both the Zephyr and Uno Q compile flags to be a little conservative. But can change to just Uno Q if that is thought to be enough.

Compiled by selecting the Arduino Uno Q in the Arduino IDE and installing the Zephyr 0.51 core using the prompt from the Arduino IDE about the missing core. 

Closes #1640.