### PR TITLE
Fix `receive` `timeout` parameter docs

### DIFF
--- a/src/modules/SX128x/SX128x.h
+++ b/src/modules/SX128x/SX128x.h
@@ -438,7 +438,7 @@ class SX128x: public PhysicalLayer {
       Overloads for string-based transmissions are implemented in PhysicalLayer.
       \param data Pointer to array to save the received binary data.
       \param len Number of bytes that will be received. Must be known in advance for binary transmissions.
-      \param timeout Reception timeout in milliseconds. If set to 0,
+      \param timeout Reception timeout in microseconds. If set to 0,
       timeout period will be calculated automatically based on the radio configuration.
       \returns \ref status_codes
     */


### PR DESCRIPTION
Hello,

The `timeout` parameter of `recieve` for the SX128x modules actually defines the timeout in **microseconds**, not milliseconds. See the implementation: https://github.com/jgromes/RadioLib/blob/4bba92f382aa7482e23d587b95ba6b4ecdf6e58e/src/modules/SX128x/SX128x.cpp#L298.

This PR fixes that in the function docstring.