### PR TITLE
LR11x0 LoRa BWs per SWSD003 and NiceRF LoRa1121F33-xxx examples

### DIFF
--- a/examples/LR11x0/LoRa1121F33-1G9_PingPong/LoRa1121F33-1G9_PingPong.ino
+++ b/examples/LR11x0/LoRa1121F33-1G9_PingPong/LoRa1121F33-1G9_PingPong.ino
@@ -1,0 +1,192 @@
+/*
+   RadioLib NiceRF LoRa1121F33-1G9 Ping-Pong Example
+
+   For the module description, see the manufacturer page
+   https://www.nicerf.com/lora-module/lora-1121f33-1g9.html
+
+   For default module settings, see the wiki page
+   https://github.com/jgromes/RadioLib/wiki/Default-configuration#lr11x0---lora-modem
+
+   For full API reference, see the GitHub Pages
+   https://jgromes.github.io/RadioLib/
+*/
+
+// include the library
+#include <RadioLib.h>
+
+// uncomment the following only on one
+// of the nodes to initiate the pings
+//#define INITIATING_NODE
+
+// #define RADIO_CE           5UL
+
+// LR1110 has the following connections:
+// NSS pin:   7
+// IRQ pin:   15
+// NRST pin:  4
+// BUSY pin:  44
+// CE pin:    5
+LR1120 radio = new Module(7, 15, 4, 44);
+
+// or detect the pinout automatically using RadioBoards
+// https://github.com/radiolib-org/RadioBoards
+/*
+#define RADIO_BOARD_AUTO
+#include <RadioBoards.h>
+Radio radio = new RadioModule();
+*/
+
+// set RF switch configuration for LoRa1121F33-1G9
+// It uses DIO5, DIO6 and DIO8 for RF switching
+// NOTE: LoRa1121F33-2G4 is different!
+static const uint32_t rfswitch_dio_pins[] = { 
+  RADIOLIB_LR11X0_DIO5, RADIOLIB_LR11X0_DIO6, RADIOLIB_LR11X0_DIO8,
+  RADIOLIB_NC, RADIOLIB_NC
+};
+
+static const Module::RfSwitchMode_t rfswitch_table[] = {
+    // mode                  DIO5  DIO6  DIO8 
+    { LR11x0::MODE_STBY,   { LOW,  LOW,  LOW  } },
+    { LR11x0::MODE_RX,     { LOW,  LOW,  LOW  } },
+    { LR11x0::MODE_TX,     { LOW,  LOW,  LOW  } },
+    { LR11x0::MODE_TX_HP,  { LOW,  LOW,  HIGH } }, //subGHz DIO8
+    { LR11x0::MODE_TX_HF,  { LOW,  HIGH, LOW  } }, //1.9G DIO6
+    { LR11x0::MODE_GNSS,   { LOW,  LOW,  LOW  } },
+    { LR11x0::MODE_WIFI,   { HIGH, LOW,  LOW  } }, //1.9G_RXEN DIO5
+    END_OF_MODE_TABLE,
+};
+
+// save transmission states between loops
+int transmissionState = RADIOLIB_ERR_NONE;
+
+// flag to indicate transmission or reception state
+bool transmitFlag = false;
+
+// flag to indicate that a packet was sent or received
+volatile bool operationDone = false;
+
+// this function is called when a complete packet
+// is transmitted or received by the module
+// IMPORTANT: this function MUST be 'void' type
+//            and MUST NOT have any arguments!
+#if defined(ESP8266) || defined(ESP32)
+  ICACHE_RAM_ATTR
+#endif
+void setFlag(void) {
+  // we sent or received a packet, set the flag
+  operationDone = true;
+}
+
+void setup() {
+  //SPI.begin(RADIO_SCK, RADIO_MISO, RADIO_MOSI, RADIO_NSS);
+
+  // Has internal pullup
+  // pinMode(RADIO_CE, OUTPUT);
+  // digitalWrite(RADIO_CE, HIGH);
+
+  Serial.begin(115200);
+
+  // initialize LR1110 with default settings
+  Serial.print(F("[LR1110] Initializing ... "));
+  radio.XTAL = false;
+  int state = radio.begin(434.0, 125.0, 9, 7, RADIOLIB_LR11X0_LORA_SYNC_WORD_PRIVATE, 1, 8, 3.0);
+  //int state = radio.begin(1919.0, 812.50, 7, 5, RADIOLIB_LR11X0_LORA_SYNC_WORD_PRIVATE, 1, 8, 3.0);
+  //int state = radio.begin(1919.0, 7.8, 7, 5, RADIOLIB_LR11X0_LORA_SYNC_WORD_PRIVATE, 1, 8, 3.0);
+
+  if (state == RADIOLIB_ERR_NONE) {
+    Serial.println(F("success!"));
+  } else {
+    Serial.print(F("failed, code "));
+    Serial.println(state);
+    while (true) { delay(10); }
+  }
+
+  // set RF switch control configuration
+  radio.setRfSwitchTable(rfswitch_dio_pins, rfswitch_table);
+
+  // set the function that will be called
+  // when new packet is received
+  radio.setIrqAction(setFlag);
+
+  radio.setOutputPower(1, true);
+  radio.setRxBoostedGainMode(true);
+
+  #if defined(INITIATING_NODE)
+    // send the first packet on this node
+    Serial.print(F("[LR1110] Sending first packet ... "));
+    transmissionState = radio.startTransmit("Hello World!");
+    transmitFlag = true;
+  #else
+    // start listening for LoRa packets on this node
+    Serial.print(F("[LR1110] Starting to listen ... "));
+    state = radio.startReceive();
+    if (state == RADIOLIB_ERR_NONE) {
+      Serial.println(F("success!"));
+    } else {
+      Serial.print(F("failed, code "));
+      Serial.println(state);
+      while (true) { delay(10); }
+    }
+  #endif
+}
+
+void loop() {
+  // check if the previous operation finished
+  if(operationDone) {
+    // reset flag
+    operationDone = false;
+
+    if(transmitFlag) {
+      // the previous operation was transmission, listen for response
+      // print the result
+      if (transmissionState == RADIOLIB_ERR_NONE) {
+        // packet was successfully sent
+        Serial.println(F("transmission finished!"));
+
+      } else {
+        Serial.print(F("failed, code "));
+        Serial.println(transmissionState);
+
+      }
+
+      // listen for response
+      radio.startReceive();
+      transmitFlag = false;
+
+    } else {
+      // the previous operation was reception
+      // print data and send another packet
+      String str;
+      int state = radio.readData(str);
+
+      if (state == RADIOLIB_ERR_NONE) {
+        // packet was successfully received
+        Serial.println(F("[LR1110] Received packet!"));
+
+        // print data of the packet
+        Serial.print(F("[LR1110] Data:\t\t"));
+        Serial.println(str);
+
+        // print RSSI (Received Signal Strength Indicator)
+        Serial.print(F("[LR1110] RSSI:\t\t"));
+        Serial.print(radio.getRSSI());
+        Serial.println(F(" dBm"));
+
+        // print SNR (Signal-to-Noise Ratio)
+        Serial.print(F("[LR1110] SNR:\t\t"));
+        Serial.print(radio.getSNR());
+        Serial.println(F(" dB"));
+
+      }
+
+      // wait a second before transmitting again
+      delay(1000);
+
+      // send another one
+      Serial.print(F("[LR1110] Sending another packet ... "));
+      transmissionState = radio.startTransmit("Hello World!");
+      transmitFlag = true;
+    }
+  
+  }
+}

--- a/examples/LR11x0/LoRa1121F33-2G4_PingPong/LoRa1121F33-2G4_PingPong.ino
+++ b/examples/LR11x0/LoRa1121F33-2G4_PingPong/LoRa1121F33-2G4_PingPong.ino
@@ -1,0 +1,192 @@
+/*
+   RadioLib NiceRF LoRa1121F33-2G4 Ping-Pong Example
+
+   For the module description, see the manufacturer page
+   https://www.nicerf.com/lora-module/lora-1121f33-2g4.html
+
+   For default module settings, see the wiki page
+   https://github.com/jgromes/RadioLib/wiki/Default-configuration#lr11x0---lora-modem
+
+   For full API reference, see the GitHub Pages
+   https://jgromes.github.io/RadioLib/
+*/
+
+// include the library
+#include <RadioLib.h>
+
+// uncomment the following only on one
+// of the nodes to initiate the pings
+//#define INITIATING_NODE
+
+// #define RADIO_CE           5UL
+
+// LR1110 has the following connections:
+// NSS pin:   7
+// IRQ pin:   15
+// NRST pin:  4
+// BUSY pin:  44
+// CE pin:    5
+LR1120 radio = new Module(7, 15, 4, 44);
+
+// or detect the pinout automatically using RadioBoards
+// https://github.com/radiolib-org/RadioBoards
+/*
+#define RADIO_BOARD_AUTO
+#include <RadioBoards.h>
+Radio radio = new RadioModule();
+*/
+
+// set RF switch configuration for LoRa1121F33-2G4
+// It uses DIO5, DIO6, DIO7 and DIO8 for RF switching
+// NOTE: LoRa1121F33-1G9 is different!
+static const uint32_t rfswitch_dio_pins[] = { 
+    RADIOLIB_LR11X0_DIO5, RADIOLIB_LR11X0_DIO6, RADIOLIB_LR11X0_DIO7, 
+    RADIOLIB_LR11X0_DIO8, RADIOLIB_NC
+};
+
+static const Module::RfSwitchMode_t rfswitch_table[] = {
+    // mode                  DIO5  DIO6  DIO7  DIO8
+    { LR11x0::MODE_STBY,   { LOW,  LOW,  LOW,  LOW  } },
+    { LR11x0::MODE_RX,     { LOW,  LOW,  LOW,  LOW  } },
+    { LR11x0::MODE_TX,     { LOW,  LOW,  LOW,  LOW  } },
+    { LR11x0::MODE_TX_HP,  { LOW,  LOW,  LOW,  HIGH } }, //subghz DIO8
+    { LR11x0::MODE_TX_HF,  { LOW,  HIGH, HIGH, LOW  } }, //2G4 DIO6
+    { LR11x0::MODE_GNSS,   { LOW,  LOW,  LOW,  LOW  } },
+    { LR11x0::MODE_WIFI,   { HIGH, LOW,  LOW,  LOW  } }, //2G4_RXEN DIO5
+    END_OF_MODE_TABLE,
+};
+
+// save transmission states between loops
+int transmissionState = RADIOLIB_ERR_NONE;
+
+// flag to indicate transmission or reception state
+bool transmitFlag = false;
+
+// flag to indicate that a packet was sent or received
+volatile bool operationDone = false;
+
+// this function is called when a complete packet
+// is transmitted or received by the module
+// IMPORTANT: this function MUST be 'void' type
+//            and MUST NOT have any arguments!
+#if defined(ESP8266) || defined(ESP32)
+  ICACHE_RAM_ATTR
+#endif
+void setFlag(void) {
+  // we sent or received a packet, set the flag
+  operationDone = true;
+}
+
+void setup() {
+  //SPI.begin(RADIO_SCK, RADIO_MISO, RADIO_MOSI, RADIO_NSS);
+
+  // Has internal pullup
+  // pinMode(RADIO_CE, OUTPUT);
+  // digitalWrite(RADIO_CE, HIGH);
+
+  Serial.begin(115200);
+
+  // initialize LR1110 with default settings
+  Serial.print(F("[LR1110] Initializing ... "));
+  radio.XTAL = false;
+  int state = radio.begin(434.0, 125.0, 9, 7, RADIOLIB_LR11X0_LORA_SYNC_WORD_PRIVATE, 1, 8, 3.0);
+  //int state = radio.begin(2450.0, 812.50, 7, 5, RADIOLIB_LR11X0_LORA_SYNC_WORD_PRIVATE, 1, 8, 3.0);
+  //int state = radio.begin(2450.0, 7.8, 7, 5, RADIOLIB_LR11X0_LORA_SYNC_WORD_PRIVATE, 1, 8, 3.0);
+  
+  if (state == RADIOLIB_ERR_NONE) {
+    Serial.println(F("success!"));
+  } else {
+    Serial.print(F("failed, code "));
+    Serial.println(state);
+    while (true) { delay(10); }
+  }
+
+  // set RF switch control configuration
+  radio.setRfSwitchTable(rfswitch_dio_pins, rfswitch_table);
+
+  // set the function that will be called
+  // when new packet is received
+  radio.setIrqAction(setFlag);
+
+  radio.setOutputPower(1, true);
+  radio.setRxBoostedGainMode(true);
+
+  #if defined(INITIATING_NODE)
+    // send the first packet on this node
+    Serial.print(F("[LR1110] Sending first packet ... "));
+    transmissionState = radio.startTransmit("Hello World!");
+    transmitFlag = true;
+  #else
+    // start listening for LoRa packets on this node
+    Serial.print(F("[LR1110] Starting to listen ... "));
+    state = radio.startReceive();
+    if (state == RADIOLIB_ERR_NONE) {
+      Serial.println(F("success!"));
+    } else {
+      Serial.print(F("failed, code "));
+      Serial.println(state);
+      while (true) { delay(10); }
+    }
+  #endif
+}
+
+void loop() {
+  // check if the previous operation finished
+  if(operationDone) {
+    // reset flag
+    operationDone = false;
+
+    if(transmitFlag) {
+      // the previous operation was transmission, listen for response
+      // print the result
+      if (transmissionState == RADIOLIB_ERR_NONE) {
+        // packet was successfully sent
+        Serial.println(F("transmission finished!"));
+
+      } else {
+        Serial.print(F("failed, code "));
+        Serial.println(transmissionState);
+
+      }
+
+      // listen for response
+      radio.startReceive();
+      transmitFlag = false;
+
+    } else {
+      // the previous operation was reception
+      // print data and send another packet
+      String str;
+      int state = radio.readData(str);
+
+      if (state == RADIOLIB_ERR_NONE) {
+        // packet was successfully received
+        Serial.println(F("[LR1110] Received packet!"));
+
+        // print data of the packet
+        Serial.print(F("[LR1110] Data:\t\t"));
+        Serial.println(str);
+
+        // print RSSI (Received Signal Strength Indicator)
+        Serial.print(F("[LR1110] RSSI:\t\t"));
+        Serial.print(radio.getRSSI());
+        Serial.println(F(" dBm"));
+
+        // print SNR (Signal-to-Noise Ratio)
+        Serial.print(F("[LR1110] SNR:\t\t"));
+        Serial.print(radio.getSNR());
+        Serial.println(F(" dB"));
+
+      }
+
+      // wait a second before transmitting again
+      delay(1000);
+
+      // send another one
+      Serial.print(F("[LR1110] Sending another packet ... "));
+      transmissionState = radio.startTransmit("Hello World!");
+      transmitFlag = true;
+    }
+  
+  }
+}

--- a/src/modules/LR11x0/LR1120.cpp
+++ b/src/modules/LR11x0/LR1120.cpp
@@ -86,19 +86,23 @@ int16_t LR1120::setOutputPower(int8_t power, bool forceHighPower, uint32_t rampT
   RADIOLIB_ASSERT(state);
 
   // determine whether to use HP or LP PA and check range accordingly
-  uint8_t paSel = 0;
-  uint8_t paSupply = 0;
+  uint8_t paSel = RADIOLIB_LR11X0_PA_SEL_LP;
+  uint8_t paSupply = RADIOLIB_LR11X0_PA_SUPPLY_INTERNAL;
+  uint8_t paDutyCycle = 0x04;
+  uint8_t paHpSel = 0x07;
   if(this->highFreq) {
-    paSel = 2;
-  } else if(forceHighPower || (power > 14)) {
-    paSel = 1;
-    paSupply = 1;
+    paSel = RADIOLIB_LR11X0_PA_SEL_HF;
+    paDutyCycle = 0x00;
+    paHpSel = 0x00;
+  } else if(forceHighPower || (power > 10)) {
+    paSel = RADIOLIB_LR11X0_PA_SEL_HP;
+    paSupply = RADIOLIB_LR11X0_PA_SUPPLY_VBAT;
   }
   
   // TODO how and when to configure OCP?
 
   // update PA config - always use VBAT for high-power PA
-  state = setPaConfig(paSel, paSupply, 0x04, 0x07);
+  state = setPaConfig(paSel, paSupply, paDutyCycle, paHpSel);
   RADIOLIB_ASSERT(state);
 
   // set output power

--- a/src/modules/LR11x0/LR11x0.cpp
+++ b/src/modules/LR11x0/LR11x0.cpp
@@ -572,38 +572,58 @@ int16_t LR11x0::setBandwidth(float bw, bool high) {
 
   // ensure byte conversion doesn't overflow
   if (high) {
-    RADIOLIB_CHECK_RANGE(bw, 203.125f, 815.0f, RADIOLIB_ERR_INVALID_BANDWIDTH);
-
-    if(fabsf(bw - 203.125f) <= 0.001f) {
-      this->bandwidth = RADIOLIB_LR11X0_LORA_BW_203_125;
-    } else if(fabsf(bw - 406.25f) <= 0.001f) {
-      this->bandwidth = RADIOLIB_LR11X0_LORA_BW_406_25;
-    } else if(fabsf(bw - 812.5f) <= 0.001f) {
-      this->bandwidth = RADIOLIB_LR11X0_LORA_BW_812_50;
-    } else {
-      return(RADIOLIB_ERR_INVALID_BANDWIDTH);
-    }
+    RADIOLIB_CHECK_RANGE(bw, 0.0f, 815.0f, RADIOLIB_ERR_INVALID_BANDWIDTH);
   } else {
     RADIOLIB_CHECK_RANGE(bw, 0.0f, 510.0f, RADIOLIB_ERR_INVALID_BANDWIDTH);
-    
-    // check allowed bandwidth values
-    uint8_t bw_div2 = bw / 2 + 0.01f;
-    switch (bw_div2)  {
-      case 31: // 62.5:
-        this->bandwidth = RADIOLIB_LR11X0_LORA_BW_62_5;
-        break;
-      case 62: // 125.0:
-        this->bandwidth = RADIOLIB_LR11X0_LORA_BW_125_0;
-        break;
-      case 125: // 250.0
-        this->bandwidth = RADIOLIB_LR11X0_LORA_BW_250_0;
-        break;
-      case 250: // 500.0
-        this->bandwidth = RADIOLIB_LR11X0_LORA_BW_500_0;
-        break;
-      default:
+  }
+  // check allowed bandwidth values
+  uint8_t bw_div2 = bw / 2 + 0.01f;
+  switch (bw_div2)  {
+    case 3: // 7.8
+      this->bandwidth = RADIOLIB_LR11X0_LORA_BW_7_8;
+      break;
+    case 5: // 10.42
+      this->bandwidth = RADIOLIB_LR11X0_LORA_BW_10_42;
+      break;
+    case 7: // 15.6
+      this->bandwidth = RADIOLIB_LR11X0_LORA_BW_15_6;
+      break;
+    case 10: // 20.83
+      this->bandwidth = RADIOLIB_LR11X0_LORA_BW_20_83;
+      break;
+    case 15: // 31.25
+      this->bandwidth = RADIOLIB_LR11X0_LORA_BW_31_25;
+      break;
+    case 20: // 41.67
+      this->bandwidth = RADIOLIB_LR11X0_LORA_BW_41_67;
+      break;
+    case 31: // 62.5
+      this->bandwidth = RADIOLIB_LR11X0_LORA_BW_62_5;
+      break;
+    case 62: // 125.0
+      this->bandwidth = RADIOLIB_LR11X0_LORA_BW_125_0;
+      break;
+    case 125: // 250.0
+      this->bandwidth = RADIOLIB_LR11X0_LORA_BW_250_0;
+      break;
+    case 250: // 500.0
+      this->bandwidth = RADIOLIB_LR11X0_LORA_BW_500_0;
+      break;
+    default:
+      if (high) {
+        if(fabsf(bw - 203.125f) <= 0.001f) {
+          this->bandwidth = RADIOLIB_LR11X0_LORA_BW_203_125;
+        } else if(fabsf(bw - 406.25f) <= 0.001f) {
+          this->bandwidth = RADIOLIB_LR11X0_LORA_BW_406_25;
+        } else if(fabsf(bw - 812.5f) <= 0.001f) {
+          this->bandwidth = RADIOLIB_LR11X0_LORA_BW_812_50;
+        } else {
+          return(RADIOLIB_ERR_INVALID_BANDWIDTH);
+        }
+      } else {
         return(RADIOLIB_ERR_INVALID_BANDWIDTH);
-    }
+      }
+      break;
   }
 
   // update modulation parameters

--- a/src/modules/LR11x0/LR11x0.h
+++ b/src/modules/LR11x0/LR11x0.h
@@ -290,7 +290,7 @@ class LR11x0: public PhysicalLayer {
     // configuration methods
 
     /*!
-      \brief Sets LoRa bandwidth. Allowed values are 62.5, 125.0, 250.0 and 500.0 kHz. (default, high = false)
+      \brief Sets LoRa bandwidth. Allowed values are 7.8, 10.42, 15.6, 20.83, 31.25, 41.67, 62.5, 125.0, 250.0 and 500.0 kHz. (default, high = false)
       \param bw LoRa bandwidth to be set in kHz.
       \param high if set to true, allowed bandwidth is 203.125, 406.25 and 812.5 kHz, frequency must be above 1GHz
       \returns \ref status_codes

--- a/src/modules/LR11x0/LR11x0_commands.h
+++ b/src/modules/LR11x0/LR11x0_commands.h
@@ -352,10 +352,16 @@
 #define RADIOLIB_LR11X0_PACKET_TYPE_BLE                         (0x06UL << 0)   //  2     0                  BLE beacon
 
 // RADIOLIB_LR11X0_CMD_SET_MODULATION_PARAMS
-#define RADIOLIB_LR11X0_LORA_BW_62_5                            (0x03UL << 0)   //  7     0     LoRa bandwidth: 62.5 kHz
+#define RADIOLIB_LR11X0_LORA_BW_7_8                             (0x00UL << 0)   //  7     0     LoRa bandwidth:  7.8  kHz
+#define RADIOLIB_LR11X0_LORA_BW_15_6                            (0x01UL << 0)   //  7     0                     15.6  kHz
+#define RADIOLIB_LR11X0_LORA_BW_31_25                           (0x02UL << 0)   //  7     0                     31.25 kHz
+#define RADIOLIB_LR11X0_LORA_BW_62_5                            (0x03UL << 0)   //  7     0                      62.5 kHz
 #define RADIOLIB_LR11X0_LORA_BW_125_0                           (0x04UL << 0)   //  7     0                     125.0 kHz
 #define RADIOLIB_LR11X0_LORA_BW_250_0                           (0x05UL << 0)   //  7     0                     250.0 kHz
 #define RADIOLIB_LR11X0_LORA_BW_500_0                           (0x06UL << 0)   //  7     0                     500.0 kHz
+#define RADIOLIB_LR11X0_LORA_BW_10_42                           (0x08UL << 0)   //  7     0                     10.42 kHz
+#define RADIOLIB_LR11X0_LORA_BW_20_83                           (0x09UL << 0)   //  7     0                     20.83 kHz
+#define RADIOLIB_LR11X0_LORA_BW_41_67                           (0x0AUL << 0)   //  7     0                     41.67 kHz
 #define RADIOLIB_LR11X0_LORA_BW_203_125                         (0x0DUL << 0)   //  7     0                     203.0 kHz (2.4GHz only)
 #define RADIOLIB_LR11X0_LORA_BW_406_25                          (0x0EUL << 0)   //  7     0                     406.0 kHz (2.4GHz only)
 #define RADIOLIB_LR11X0_LORA_BW_812_50                          (0x0FUL << 0)   //  7     0                     812.0 kHz (2.4GHz only)


### PR DESCRIPTION
This PR adds all available LR11x0 LoRa BWs per SWSD003 both to sub-GHz and HF bands, add band dependent PA duty cycles and NiceRF LoRa1121F33-1G9/2G4 examples.
