### PR TITLE
[LR2021] fix for no-CRC GFSK and OOK operations when inverted bit is set (default)

### DIFF
--- a/src/modules/LR2021/LR2021_config.cpp
+++ b/src/modules/LR2021/LR2021_config.cpp
@@ -379,7 +379,7 @@ int16_t LR2021::setCRC(uint8_t len, uint32_t initial, uint32_t polynomial, bool 
     }
 
     this->crcTypeGFSK = len;
-    if(inverted) {
+    if((this->crcTypeGFSK != RADIOLIB_LR2021_GFSK_OOK_CRC_OFF) && inverted) {
       this->crcTypeGFSK += 0x08;
     }
 
@@ -394,7 +394,7 @@ int16_t LR2021::setCRC(uint8_t len, uint32_t initial, uint32_t polynomial, bool 
     }
 
     this->crcTypeGFSK = len;
-    if(inverted) {
+    if((this->crcTypeGFSK != RADIOLIB_LR2021_GFSK_OOK_CRC_OFF) && inverted) {
       this->crcTypeGFSK += 0x08;
     }
 


### PR DESCRIPTION
Default value for `inverted` CRC bit is `true`

```
    /*!
      \brief Sets CRC configuration.
      \param len CRC length in bytes, Allowed values are 1 or 2, set to 0 to disable CRC.
      \param initial Initial CRC value. GFSK only. Defaults to 0x1D0F (CCITT CRC).
      \param polynomial Polynomial for CRC calculation. GFSK only. Defaults to 0x1021 (CCITT CRC).
      \param inverted Invert CRC bytes. GFSK only. Defaults to true (CCITT CRC).
      \returns \ref status_codes
    */
    int16_t setCRC(uint8_t len, uint32_t initial = 0x00001D0FUL, uint32_t polynomial = 0x00001021UL, bool inverted = true);
```

when setCRC()) is in use with no-CRC argument (len = 0) - it causes the `setGfskPacketParams` and `setOokPacketParams` commands to set undefined value ( **0x08** ) for (G)FSK packet CRC Parameter.
This action gives negative effect on packets receive function - good packets are invalidated by improper CRC setting applied.

<img width="479" height="174" alt="image" src="https://github.com/user-attachments/assets/04be7fb1-0e52-467f-b98d-00752239910e" />


<img width="1405" height="662" alt="image" src="https://github.com/user-attachments/assets/f86ef64c-10c9-4a0f-9655-985d73da21e5" />
