### PR TITLE
[LR2021] set max limit of GFSK frequency deviation in accordance with datasheet

### DIFF
--- a/src/modules/LR2021/LR2021.h
+++ b/src/modules/LR2021/LR2021.h
@@ -442,7 +442,7 @@ class LR2021: public LRxxxx {
     int16_t setBitRate(float br) override;
 
     /*!
-      \brief Sets GFSK frequency deviation. Allowed values range from 0.0 to 200.0 kHz.
+      \brief Sets GFSK frequency deviation. Allowed values range from 0.6 to 500.0 kHz.
       \param freqDev GFSK frequency deviation to be set in kHz.
       \returns \ref status_codes
     */

--- a/src/modules/LR2021/LR2021_config.cpp
+++ b/src/modules/LR2021/LR2021_config.cpp
@@ -492,11 +492,11 @@ int16_t LR2021::setFrequencyDeviation(float freqDev) {
 
   // set frequency deviation to lowest available setting (required for digimodes)
   float newFreqDev = freqDev;
-  if(freqDev < 0.0f) {
+  if(freqDev < 0.6f) {
     newFreqDev = 0.6f;
   }
 
-  RADIOLIB_CHECK_RANGE(newFreqDev, 0.6f, 200.0f, RADIOLIB_ERR_INVALID_FREQUENCY_DEVIATION);
+  RADIOLIB_CHECK_RANGE(newFreqDev, 0.6f, 500.0f, RADIOLIB_ERR_INVALID_FREQUENCY_DEVIATION);
   this->frequencyDev = newFreqDev * 1000.0f;
   state = setGfskModulationParams(this->bitRate, this->pulseShape, this->rxBandwidth, this->frequencyDev);
   return(state);
@@ -784,7 +784,7 @@ int16_t LR2021::checkDataRate(DataRate_t dr, ModemType_t modem) {
   // select interpretation based on modem
   if(modem == RADIOLIB_MODEM_FSK) {
     RADIOLIB_CHECK_RANGE(dr.fsk.bitRate, 0.6f, 300.0f, RADIOLIB_ERR_INVALID_BIT_RATE);
-    RADIOLIB_CHECK_RANGE(dr.fsk.freqDev, 0.6f, 200.0f, RADIOLIB_ERR_INVALID_FREQUENCY_DEVIATION);
+    RADIOLIB_CHECK_RANGE(dr.fsk.freqDev, 0.6f, 500.0f, RADIOLIB_ERR_INVALID_FREQUENCY_DEVIATION);
     return(RADIOLIB_ERR_NONE);
 
   } else if(modem == RADIOLIB_MODEM_LORA) {


### PR DESCRIPTION
Current value of the limit looks like a copy-paste from LR11x0.cpp

These are the limits specified in the datasheet -

<img width="1652" height="528" alt="image" src="https://github.com/user-attachments/assets/9fd313a3-01bc-47b6-995f-5edb20af359c" />

