### PR TITLE
Missing initialization in for loop of SPI debug

### DIFF
--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -423,7 +423,7 @@ int16_t Module::SPItransferStream(const uint8_t* cmd, uint8_t cmdLen, bool write
       RADIOLIB_DEBUG_SPI_PRINT_NOTAG("R\t");
     }
     size_t n = 0;
-    for(; n < cmdLen; n++) {
+    for(n = 0; n < cmdLen; n++) {
       RADIOLIB_DEBUG_SPI_PRINT_NOTAG("%X\t", cmd[n]);
     }
     RADIOLIB_DEBUG_SPI_PRINTLN_NOTAG("");
@@ -433,7 +433,7 @@ int16_t Module::SPItransferStream(const uint8_t* cmd, uint8_t cmdLen, bool write
     for(n = 0; n < cmdLen; n++) {
       RADIOLIB_DEBUG_SPI_PRINT_NOTAG("\t");
     }
-    for(; n < buffLen; n++) {
+    for(n = 0; n < buffLen; n++) {
       RADIOLIB_DEBUG_SPI_PRINT_NOTAG("%X\t", buffOut[n]);
     }
     RADIOLIB_DEBUG_SPI_PRINTLN_NOTAG("");


### PR DESCRIPTION
There are 2 inits missing in for() loops in the SPI debug part of `Module::SPItransferStream()` .

The second added init might be causing problems. It think it was caused by a copy and paste of the first one (line 426), so let's fix also this to prevent another error in the future. 

Related to #1693