### PR TITLE
[ArduinoHal] ]Add dwt_init() to init() for ARDUINO_ARCH_STM32

### DIFF
--- a/src/hal/Arduino/ArduinoHal.cpp
+++ b/src/hal/Arduino/ArduinoHal.cpp
@@ -10,6 +10,9 @@ void ArduinoHal::init() {
   if(initInterface) {
     spiBegin();
   }
+  #if defined(ARDUINO_ARCH_STM32)
+    dwt_init();
+  #endif
 }
 
 void ArduinoHal::term() {


### PR DESCRIPTION
stm32duino is using DWT for microseconds timing but  [DWT is not enabled by default](https://github.com/stm32duino/Arduino_Core_STM32/blob/8d61785df2ec968b1891515e75ec2626c10a6ab7/libraries/SrcWrapper/src/stm32/hw_config.c#L85) (DWT_BASE is not defined).

This is causing a crash on STM32WL when radio.begin() is called because there's a call to [delayMicroseconds()](https://github.com/jgromes/RadioLib/blob/f1de01d459dcba7ca808fc9442d6d5aa307b7231/src/Module.cpp#L386) in Module::SPItransferStream()

This fixes #1693.