### PR TITLE
[lLoRaWAN] Fix incorrect DR calculation for fixed band in createSession()

### DIFF
--- a/src/protocols/LoRaWAN/LoRaWAN.cpp
+++ b/src/protocols/LoRaWAN/LoRaWAN.cpp
@@ -392,7 +392,7 @@ void LoRaWANNode::createSession() {
     if(this->band->bandType == RADIOLIB_LORAWAN_BAND_DYNAMIC) {
       drUp = (this->band->txFreqs[0].drMin + this->band->txFreqs[0].drMax + 1) / 2;
     } else {                // RADIOLIB_LORAWAN_BAND_FIXED
-      drUp = (this->band->txSpans[0].drMin + this->band->txSpans[0].drMin + 1) / 2;
+      drUp = (this->band->txSpans[0].drMin + this->band->txSpans[0].drMax + 1) / 2;
     }
   }
   uint8_t txSteps = this->txPowerSteps;


### PR DESCRIPTION
**Fix incorrect DR calculation for FIXED band in createSession()**

In LoRaWANNode::createSession(), the data rate calculation for
FIXED band type incorrectly uses drMin twice instead of drMin + drMax.

This causes the initial uplink data rate to be set to approximately
drMin instead of the intended average between drMin and drMax,
which is inconsistent with the DYNAMIC band calculation logic.

```
Changed:
  - (drMin + drMin + 1) / 2
To:
  - (drMin + drMax + 1) / 2
```

This ensures symmetric behavior between DYNAMIC and FIXED band types
and correct initial data rate selection.
