### PR TITLE
[LoRaWAN] Fix for unreliable first transmits (fixed band regions)

### DIFF
--- a/src/protocols/LoRaWAN/LoRaWAN.cpp
+++ b/src/protocols/LoRaWAN/LoRaWAN.cpp
@@ -993,10 +993,10 @@ int16_t LoRaWANNode::activateOTAA(LoRaWANJoinEvent_t *joinEvent) {
   LoRaWANNode::hton<uint16_t>(&this->bufferNonces[RADIOLIB_LORAWAN_NONCES_SIGNATURE], signature);
   LoRaWANNode::hton<uint16_t>(&this->bufferSession[RADIOLIB_LORAWAN_SESSION_NONCES_SIGNATURE], signature);
 
-  (void)this->calculateChannelFlags();
-  
   this->sessionStatus = RADIOLIB_LORAWAN_SESSION_ACTIVE;
 
+  (void)this->calculateChannelFlags();
+  
   return(RADIOLIB_LORAWAN_NEW_SESSION);
 }
 


### PR DESCRIPTION
For regions using `RADIOLIB_LORAWAN_BAND_FIXED` (US915, AU915, CN470), [calculateChannelFlags()](https://github.com/jgromes/RadioLib/blob/5b901a33338887e38960b6972358e19cc938f1b4/src/protocols/LoRaWAN/LoRaWAN.cpp#L3398) gets an[ early return](https://github.com/jgromes/RadioLib/blob/5b901a33338887e38960b6972358e19cc938f1b4/src/protocols/LoRaWAN/LoRaWAN.cpp#L3422) during `activateOTAA()` because `sessionStatus` is set to `RADIOLIB_LORAWAN_SESSION_ACTIVE` after calling `calculateChannelFlags()`.

**activateOTAA()**
```
  (void)this->calculateChannelFlags();
  
  this->sessionStatus = RADIOLIB_LORAWAN_SESSION_ACTIVE;

  return(RADIOLIB_LORAWAN_NEW_SESSION);
```

**calculateChannelFlags()**
```
  } else {                // RADIOLIB_LORAWAN_BAND_FIXED
    // during activation of fixed bands, flag all available channels
    // the datarate will be determined from there
    if(!this->isActivated() && this->band->bandType == RADIOLIB_LORAWAN_BAND_FIXED) {
      memcpy(this->channelFlags, this->channelMasks, sizeof(this->channelMasks));
      return(true);
    }
```

So the rest of `calculateChannelFlags()` is skipped.
```
    // check first frequency span to see if the datarate is allowed and any channel is available
    if(drUp >= this->band->txSpans[0].drMin && drUp <= this->band->txSpans[0].drMax) {
      // if the datarate is OK, all channel in this span can be used
      for(int i = 0; i < this->band->txSpans[0].numChannels / 16; i++) {
        this->channelFlags[i] = this->channelMasks[i];
        if(this->channelMasks[i]) {
          any = true;
        }
      }
    }

    // check second frequency span to see if the datarate is allowed and any channel is available
    if(drUp >= this->band->txSpans[1].drMin && drUp <= this->band->txSpans[1].drMax) {
      this->channelFlags[4] = this->channelMasks[4];
      if(this->channelMasks[4]) {
        any = true;
      }
```
This leads to the first transmits randomly not working (I usually get one of the first 8 transmits not seen by the gateway) until `calculateChannelFlags()` gets called again when all flags are set. This time, the early return is skipped (`isActivated()`  returns true). After that, every transmit works ok.