### PR TITLE
Implement proper AGC reset for SX126x, LR11x0 & SX1276

### DIFF
--- a/src/modules/LR11x0/LR11x0.h
+++ b/src/modules/LR11x0/LR11x0.h
@@ -931,7 +931,6 @@ class LR11x0: public LRxxxx {
 #endif
     uint8_t wifiScanMode = 0;
     bool gnss = false;
-
     int16_t modSetup(float tcxoVoltage, uint8_t modem);
     bool findChip(uint8_t ver);
     int16_t config(uint8_t modem);

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -185,6 +185,22 @@ class SX126x: public PhysicalLayer {
     int16_t scanChannel(const ChannelScanConfig_t &config) override;
 
     /*!
+      \brief Reset the AGC gain state by performing a warm sleep, recalibration, and
+      image rejection calibration cycle. Re-applies DIO2 RF switch and RX boosted gain
+      settings if previously configured. Leaves the radio in standby mode.
+      \returns \ref status_codes
+    */
+    int16_t resetAGC();
+
+    /*!
+      \brief Perform calibration of the specified blocks.
+      \param params Calibration parameters - bitfield of RADIOLIB_SX126X_CALIBRATE_* values.
+      Use RADIOLIB_SX126X_CALIBRATE_ALL to calibrate all blocks.
+      \returns \ref status_codes
+    */
+    int16_t calibrate(uint8_t params);
+
+    /*!
       \brief Sets the module to sleep mode. To wake the device up, call standby().
       Overload with warm start enabled for PhysicalLayer compatibility.
       \returns \ref status_codes
@@ -889,6 +905,8 @@ class SX126x: public PhysicalLayer {
 
     uint32_t tcxoDelay = 0;
     uint8_t pwr = 0;
+    bool dio2RfSwitch = false;
+    bool rxBoostedGainMode = false;
 
     size_t implicitLen = 0;
     uint8_t invertIQEnabled = RADIOLIB_SX126X_LORA_IQ_STANDARD;

--- a/src/modules/SX126x/SX126x_commands.cpp
+++ b/src/modules/SX126x/SX126x_commands.cpp
@@ -8,6 +8,42 @@
 
 #if !RADIOLIB_EXCLUDE_SX126X
 
+int16_t SX126x::resetAGC() {
+  // warm sleep to power down the analog frontend
+  int16_t state = sleep(true);
+  RADIOLIB_ASSERT(state);
+
+  // wake to RC standby
+  state = standby(RADIOLIB_SX126X_STANDBY_RC, true);
+  RADIOLIB_ASSERT(state);
+
+  // recalibrate all blocks
+  state = calibrate(RADIOLIB_SX126X_CALIBRATE_ALL);
+  RADIOLIB_ASSERT(state);
+
+  // re-calibrate image rejection for the operating frequency
+  state = calibrateImage(this->freqMHz);
+  RADIOLIB_ASSERT(state);
+
+  // re-apply DIO2 RF switch if it was configured
+  if(this->dio2RfSwitch) {
+    state = setDio2AsRfSwitch(true);
+    RADIOLIB_ASSERT(state);
+  }
+
+  // re-apply RX boosted gain if it was configured
+  if(this->rxBoostedGainMode) {
+    state = setRxBoostedGainMode(true);
+    RADIOLIB_ASSERT(state);
+  }
+
+  return(RADIOLIB_ERR_NONE);
+}
+
+int16_t SX126x::calibrate(uint8_t params) {
+  return(this->mod->SPIwriteStream(RADIOLIB_SX126X_CMD_CALIBRATE, &params, 1, true, false));
+}
+
 int16_t SX126x::sleep() {
   return(SX126x::sleep(true));
 }

--- a/src/modules/SX126x/SX126x_config.cpp
+++ b/src/modules/SX126x/SX126x_config.cpp
@@ -394,6 +394,8 @@ int16_t SX126x::setRxBandwidth(float rxBw) {
 }
 
 int16_t SX126x::setRxBoostedGainMode(bool rxbgm, bool persist) {
+  this->rxBoostedGainMode = rxbgm;
+
   // update RX gain setting register
   uint8_t rxGain = rxbgm ? RADIOLIB_SX126X_RX_GAIN_BOOSTED : RADIOLIB_SX126X_RX_GAIN_POWER_SAVING;
   int16_t state = writeRegister(RADIOLIB_SX126X_REG_RX_GAIN, &rxGain, 1);
@@ -708,6 +710,7 @@ int16_t SX126x::setTCXO(float voltage, uint32_t delay) {
 }
 
 int16_t SX126x::setDio2AsRfSwitch(bool enable) {
+  this->dio2RfSwitch = enable;
   uint8_t data = enable ? RADIOLIB_SX126X_DIO2_AS_RF_SWITCH : RADIOLIB_SX126X_DIO2_AS_IRQ;
   return(this->mod->SPIwriteStream(RADIOLIB_SX126X_CMD_SET_DIO2_AS_RF_SWITCH_CTRL, &data, 1));
 }


### PR DESCRIPTION
Might be good to have this in RadioLib, based on these PRs:

- https://github.com/meshcore-dev/MeshCore/pull/1743
- https://github.com/meshtastic/firmware/pull/9705

For SX126x & LR11x0: reset analog registers, for SX1276: sleeping should be sufficient. I based this off the SX1262 datasheet & user manuals.

relates to #521