### PR TITLE
Updated CAD detection for LR 2021, resolving the freezing issue

### DIFF
--- a/src/modules/LR2021/LR2021.cpp
+++ b/src/modules/LR2021/LR2021.cpp
@@ -550,7 +550,7 @@ int16_t LR2021::startChannelScan(const ChannelScanConfig_t &config) {
   RADIOLIB_ASSERT(state);
 
   // set mode to CAD
-  return(startCad(config.cad.symNum, config.cad.detPeak, this->pblAny, this->pnrDelta, config.cad.exitMode, config.cad.timeout));
+  return(startCad(config.cad.symNum, config.cad.detPeak, this->fastCad, config.cad.exitMode, config.cad.timeout));
 }
 
 int16_t LR2021::getChannelScanResult() {
@@ -721,7 +721,7 @@ int16_t LR2021::config(uint8_t modem) {
   return(state);
 }
 
-int16_t LR2021::startCad(uint8_t symbolNum, uint8_t detPeak, uint8_t pblAny, uint8_t pnrDelta, uint8_t exitMode, RadioLibTime_t timeout) {
+int16_t LR2021::startCad(uint8_t symbolNum, uint8_t detPeak, bool fast, uint8_t exitMode, RadioLibTime_t timeout) {
   // check active modem
   uint8_t type = RADIOLIB_LR2021_PACKET_TYPE_NONE;
   int16_t state = getPacketType(&type);
@@ -731,23 +731,21 @@ int16_t LR2021::startCad(uint8_t symbolNum, uint8_t detPeak, uint8_t pblAny, uin
   }
 
   // select CAD parameters
-  //! \TODO: [LR2021] the magic numbers for CAD are based on Semtech examples, this is probably suboptimal
   uint8_t num = symbolNum;
   if(num == RADIOLIB_LR2021_CAD_PARAM_DEFAULT) {
     num = 2;
   }
   
-  // reference values ​​from the datasheet, for num = 2.
+  // reference values ​​from the datasheet for 2 symbols
+  //! \TODO: [LR2021] allow CAD peak detection autoconfiguration
   const uint8_t detPeakValues[8] = { 56, 56, 56, 58, 58, 60, 64, 68 };
   uint8_t peak = detPeak;
   if(peak == RADIOLIB_LR2021_CAD_PARAM_DEFAULT) {
     peak = detPeakValues[this->spreadingFactor - 5];
   }
 
-  bool pbl = (pblAny >= 1 );
-
-  // default don't use acceleration.
-  uint8_t delta = pnrDelta; 
+  // in Fast CAD mode enable acceleration
+  uint8_t pnrDelta = fast ? RADIOLIB_LR2021_LORA_CAD_PNR_DELTA_FAST : RADIOLIB_LR2021_LORA_CAD_PNR_DELTA_STANDARD;
 
   uint8_t mode = exitMode; 
   if(mode == RADIOLIB_LR2021_CAD_PARAM_DEFAULT) {
@@ -756,8 +754,9 @@ int16_t LR2021::startCad(uint8_t symbolNum, uint8_t detPeak, uint8_t pblAny, uin
 
   uint32_t timeout_raw = (float)timeout / 30.52f;
 
-  // set Lora CAD parameters
-  state = setLoRaCadParams(num, pbl, delta, mode, timeout_raw, peak);
+  // set LoRa CAD parameters
+  // preamble only mode is intentionally disabled, as it is unreliable according to the datasheet
+  state = setLoRaCadParams(num, false, pnrDelta, mode, timeout_raw, peak);
   RADIOLIB_ASSERT(state);
 
   // start LoraCAD

--- a/src/modules/LR2021/LR2021.h
+++ b/src/modules/LR2021/LR2021.h
@@ -42,11 +42,12 @@ class LR2021: public LRxxxx {
     */
     uint32_t irqDioNum = 5;
 
-    /*! \brief Determines the type of symbols that trigger CAD detection. */
-    uint8_t pblAny = 0;
-  
-    /*! \brief Controls the possible acceleration of CAD detection */
-    uint8_t pnrDelta = 0;
+    /*! 
+      \brief Determines the type of Lora CAD to perform, either "standard" CAD
+      (same as is implem,ented LR11x0, SX126x and others), or a "fast" CAD if set to true.
+      If there is no signal to be detected, fast CAD should return faster than standard CAD.
+    */
+    bool fastCad = false;
 
     /*!
       \brief Custom operation modes for LR2021.
@@ -724,7 +725,7 @@ class LR2021: public LRxxxx {
     bool findChip(void);
     int16_t config(uint8_t modem);
     int16_t setPacketMode(uint8_t mode, uint8_t len);
-    int16_t startCad(uint8_t symbolNum, uint8_t detPeak,  uint8_t pblAny, uint8_t pnrDelta, uint8_t exitMode, RadioLibTime_t timeout);
+    int16_t startCad(uint8_t symbolNum, uint8_t detPeak, bool fast, uint8_t exitMode, RadioLibTime_t timeout);
 
     // chip control commands
     int16_t readRadioRxFifo(uint8_t* data, size_t len);

--- a/src/modules/LR2021/LR2021_commands.h
+++ b/src/modules/LR2021/LR2021_commands.h
@@ -404,6 +404,10 @@
 #define RADIOLIB_LR2021_LORA_SYNC_WORD_PRIVATE                  (0x12UL << 0)   //  7     0     LoRa sync word: 0x12 (private networks)
 #define RADIOLIB_LR2021_LORA_SYNC_WORD_LORAWAN                  (0x34UL << 0)   //  7     0                     0x34 (LoRaWAN reserved)
 
+// RADIOLIB_LR2021_CMD_SET_LORA_CAD_PARAMS
+#define RADIOLIB_LR2021_LORA_CAD_PNR_DELTA_STANDARD             (0x00UL << 0)   //  7     0     LoRa CAD speed: normal
+#define RADIOLIB_LR2021_LORA_CAD_PNR_DELTA_FAST                 (0x08UL << 0)   //  7     0                     fast CAD
+
 // RADIOLIB_LR2021_CMD_SET_LORA_HOPPING
 #define RADIOLIB_LR2021_LORA_HOPPING_DISABLED                   (0x00UL << 6)   //  7     6     LoRa intra-packet hopping: disabled
 #define RADIOLIB_LR2021_LORA_HOPPING_ENABLED                    (0x01UL << 6)   //  7     6                                enabled


### PR DESCRIPTION

While using the `scanChannel()` function in lr2021, it was observed that the program would enter an infinite loop (suspected to be caused by the use of `setCad` without a configured timeout, resulting in the `CadDone` interrupt failing to trigger).

The original implementation of `scanChannel` in lr2021 relied on the `setCadParams` and `setCad` commands; 
however, the datasheet indicates that these are intended for "non-LoRa mode." 
In LoRa mode, the `SetLoraCadParams` and `SetLoraCAD` commands should be used instead.

This Pull Request modifies the specific implementation of `scanChannel` and adds support for default parameter configuration.
The code has been tested and verified to successfully complete the CAD process without freezing.
