### PR TITLE
[LR2021] Add getLoRaRxHeaderInfo function

### DIFF
--- a/src/modules/LR2021/LR2021.cpp
+++ b/src/modules/LR2021/LR2021.cpp
@@ -1048,4 +1048,10 @@ uint8_t LR2021::randomByte() {
   return((uint8_t)num);
 }
 
+int16_t LR2021::getLoRaRxHeaderInfo(uint8_t* cr, bool* hasCRC){
+  int16_t state;
+  state = this->getLoRaPacketStatus(cr, hasCRC, NULL, NULL, NULL, NULL);
+  return (state);
+}
+
 #endif

--- a/src/modules/LR2021/LR2021.h
+++ b/src/modules/LR2021/LR2021.h
@@ -691,7 +691,15 @@ class LR2021: public LRxxxx {
       \returns \ref status_codes
     */
     int16_t getLoRaPacketStatus(uint8_t* cr, bool* crc, uint8_t* packetLen = NULL, float* snrPacket = NULL, float* rssiPacket = NULL, float* rssiSignalPacket = NULL);
-    
+
+    /*!
+      \brief Get LoRa header information from last received packet. Implementation based on getLoRaPacketStatus.
+      \param cr Pointer to variable to store the coding rate.
+      \param hasCRC Pointer to variable to store the CRC status.
+      \returns \ref status_codes
+    */
+    int16_t getLoRaRxHeaderInfo(uint8_t* cr, bool* hasCRC);
+
 #if !RADIOLIB_GODMODE && !RADIOLIB_LOW_LEVEL
   protected:
 #endif


### PR DESCRIPTION
### Add getLoRaRxHeaderInfo function

Since Mashtastic utilizes template classes to initialize or invoke APIs, and rl2021 lacks a direct getLoRaRxHeaderInfo command, a compilation error would occur. 

While it is technically possible to handle the rl2021 class separately via conditional logic, doing so would be overly cumbersome; adding an additional interface would be a much more convenient solution.