### PR TITLE
[HAL] Check if board is using DWT before calling dwt_init() on STM32

### DIFF
--- a/src/hal/Arduino/ArduinoHal.cpp
+++ b/src/hal/Arduino/ArduinoHal.cpp
@@ -10,7 +10,7 @@ void ArduinoHal::init() {
   if(initInterface) {
     spiBegin();
   }
-  #if defined(ARDUINO_ARCH_STM32)
+  #if defined(ARDUINO_ARCH_STM32) && defined(DWT_BASE)
     dwt_init();
   #endif
 }


### PR DESCRIPTION
On STM32 boards using Cortex-M0, `micros()` is not based on DWT, so calling [dwt_init()](https://github.com/jgromes/RadioLib/blob/631e0910a220b6e69021b0a51bcc83e490b3237d/src/hal/Arduino/ArduinoHal.cpp#L13-L15) in `ArduinoHal::init()` creates a compile error.

Every STM32 board using DWT defines DWT_BASE, so adding a preprocessor check prevents the compile error.

Please note that dwt_init() is usually called by default on STM32duino in [premain()](https://github.com/stm32duino/Arduino_Core_STM32/blob/93d2c963d8cb2dd2953d838a75edc3ad34a665a4/cores/arduino/main.cpp#L25), but it seems it's not called if using your own main() function (linker issue?).

The path is premain() -> init() -> hw_config_init() -> dwt_init()

This PR fixes first part of #1730.

References:
- DWT_BASE is defined in [framework-cmsis](https://github.com/ARM-software/CMSIS_6)
- For Cortex-M3 : [core_cm3.h](https://github.com/ARM-software/CMSIS_6/blob/fdbbc52f24a14ba7ba06a8db9421721a7f604e48/CMSIS/Core/Include/core_cm3.h#L1376)
- For Cortex-M4 : [core_cm4.h](https://github.com/ARM-software/CMSIS_6/blob/fdbbc52f24a14ba7ba06a8db9421721a7f604e48/CMSIS/Core/Include/core_cm4.h#L1552 )
