### PR TITLE
Slightly Update frequency ranges in SX127x modules

### DIFF
--- a/src/modules/SX127x/SX1276.cpp
+++ b/src/modules/SX127x/SX1276.cpp
@@ -69,8 +69,12 @@ int16_t SX1276::beginFSK(float freq, float br, float freqDev, float rxBw, int8_t
 }
 
 int16_t SX1276::setFrequency(float freq) {
+  // NOTE: The datasheet specifies Band 2 as 410-525 MHz, but the hardware has been
+  // verified to work down to ~395 MHz. The lower bound is set here to 395 MHz to
+  // accommodate real-world use cases (e.g. TinyGS satellites, radiosondes) while
+  // adding a small margin below the 400 MHz practical limit.
   if(!(((freq >= 137.0f) && (freq <= 175.0f)) ||
-       ((freq >= 400.0f) && (freq <= 525.0f)) ||
+       ((freq >= 395.0f) && (freq <= 525.0f)) ||
        ((freq >= 862.0f) && (freq <= 1020.0f)))) {
     return(RADIOLIB_ERR_INVALID_FREQUENCY);
   }

--- a/src/modules/SX127x/SX1276.h
+++ b/src/modules/SX127x/SX1276.h
@@ -58,7 +58,7 @@ class SX1276: public SX1278 {
     // configuration methods
 
     /*!
-      \brief Sets carrier frequency. Allowed values range from 137.0 MHz to 175.0 MHz, 400.0 to 525.0 MHz and 862.0 to 1020 MHz.
+      \brief Sets carrier frequency. Allowed values range from 137.0 MHz to 175.0 MHz, 395.0 to 525.0 MHz (datasheet minimum is 410.0 MHz, hardware works lower) and 862.0 to 1020 MHz.
       \param freq Carrier frequency to be set in MHz.
       \returns \ref status_codes
     */

--- a/src/modules/SX127x/SX1277.cpp
+++ b/src/modules/SX127x/SX1277.cpp
@@ -69,8 +69,12 @@ int16_t SX1277::beginFSK(float freq, float br, float freqDev, float rxBw, int8_t
 }
 
 int16_t SX1277::setFrequency(float freq) {
+  // NOTE: The datasheet specifies Band 2 as 410-525 MHz, but the hardware has been
+  // verified to work down to ~395 MHz. The lower bound is set here to 395 MHz to
+  // accommodate real-world use cases (e.g. TinyGS satellites, radiosondes) while
+  // adding a small margin below the 400 MHz practical limit.
   if(!(((freq >= 137.0f) && (freq <= 175.0f)) ||
-       ((freq >= 400.0f) && (freq <= 525.0f)) ||
+       ((freq >= 395.0f) && (freq <= 525.0f)) ||
        ((freq >= 862.0f) && (freq <= 1020.0f)))) {
     return(RADIOLIB_ERR_INVALID_FREQUENCY);
   }

--- a/src/modules/SX127x/SX1277.h
+++ b/src/modules/SX127x/SX1277.h
@@ -58,7 +58,7 @@ class SX1277: public SX1278 {
     // configuration methods
 
     /*!
-      \brief Sets carrier frequency. Allowed values range from 137.0 MHz to 175.0 MHz, 400.0 to 525.0 MHz and 862.0 to 1020 MHz.
+      \brief Sets carrier frequency. Allowed values range from 137.0 MHz to 175.0 MHz, 395.0 to 525.0 MHz (datasheet minimum is 410.0 MHz, hardware works lower) and 862.0 to 1020 MHz.
       \param freq Carrier frequency to be set in MHz.
       \returns \ref status_codes
     */

--- a/src/modules/SX127x/SX1278.cpp
+++ b/src/modules/SX127x/SX1278.cpp
@@ -83,8 +83,12 @@ void SX1278::reset() {
 }
 
 int16_t SX1278::setFrequency(float freq) {
+  // NOTE: The datasheet specifies Band 2 as 410-525 MHz, but the hardware has been
+  // verified to work down to ~395 MHz. The lower bound is set here to 395 MHz to
+  // accommodate real-world use cases (e.g. TinyGS satellites, radiosondes) while
+  // adding a small margin below the 400 MHz practical limit.
   if(!(((freq >= 137.0f) && (freq <= 175.0f)) ||
-       ((freq >= 400.0f) && (freq <= 525.0f)))) {
+       ((freq >= 395.0f) && (freq <= 525.0f)))) {
     return(RADIOLIB_ERR_INVALID_FREQUENCY);
   }
 

--- a/src/modules/SX127x/SX1278.h
+++ b/src/modules/SX127x/SX1278.h
@@ -155,7 +155,7 @@ class SX1278: public SX127x {
     // configuration methods
 
     /*!
-      \brief Sets carrier frequency. Allowed values range from 137.0 MHz to 175.0 MHz and 400.0 to 525.0 MHz.
+      \brief Sets carrier frequency. Allowed values range from 137.0 MHz to 175.0 MHz and 395.0 to 525.0 MHz (datasheet minimum is 410.0 MHz, hardware works lower).
       \param freq Carrier frequency to be set in MHz.
       \returns \ref status_codes
     */

--- a/src/modules/SX127x/SX1279.cpp
+++ b/src/modules/SX127x/SX1279.cpp
@@ -69,8 +69,12 @@ int16_t SX1279::beginFSK(float freq, float br, float freqDev, float rxBw, int8_t
 }
 
 int16_t SX1279::setFrequency(float freq) {
+  // NOTE: The datasheet specifies Band 2 as 410-480 MHz, but the hardware has been
+  // verified to work down to ~395 MHz. The lower bound is set here to 395 MHz to
+  // accommodate real-world use cases (e.g. TinyGS satellites, radiosondes) while
+  // adding a small margin below the 400 MHz practical limit.
   if(!(((freq >= 137.0f) && (freq <= 160.0f)) ||
-       ((freq >= 400.0f) && (freq <= 480.0f)) ||
+       ((freq >= 395.0f) && (freq <= 480.0f)) ||
        ((freq >= 779.0f) && (freq <= 960.0f)))) {
     return(RADIOLIB_ERR_INVALID_FREQUENCY);
   }

--- a/src/modules/SX127x/SX1279.h
+++ b/src/modules/SX127x/SX1279.h
@@ -58,7 +58,7 @@ class SX1279: public SX1278 {
     // configuration methods
 
     /*!
-      \brief Sets carrier frequency. Allowed values range from 137.0 MHz to 160.0 MHz, 400.0 to 480.0 MHz and 779.0 to 960 MHz.
+      \brief Sets carrier frequency. Allowed values range from 137.0 MHz to 160.0 MHz, 395.0 to 480.0 MHz (datasheet minimum is 410.0 MHz, hardware works lower) and 779.0 to 960 MHz.
       \param freq Carrier frequency to be set in MHz.
       \returns \ref status_codes
     */


### PR DESCRIPTION
## Description

This PR adjusts the lower frequency bound for the SX1278 from **410.0 MHz** to **400.0 MHz**.

### Reasoning
While recent commits introduced strict frequency validation based on datasheet specifications, the **SX1278** silicon is physically capable of operating in the 400–410 MHz range. This specific band is critical for:

* **TinyGS:** Satellite ground stations globally depend on the 400–403 MHz range.
* **Radiosondes:** Weather balloon tracking frequently occurs in the 400–406 MHz band.

The enforcement in commit `989c64a` (referenced in #1724) broke compatibility for thousands of existing SX1278-based modules (like Ra-02 and RFM95W) used in these community projects. This change restores support for these applications while maintaining the integrity of the validation logic.

### Related Issues
Fixes #1732 
