### PR TITLE
Fix Module copy assignment

### DIFF
--- a/extras/test/unit/tests/TestModule.cpp
+++ b/extras/test/unit/tests/TestModule.cpp
@@ -6,6 +6,63 @@
 
 BOOST_FIXTURE_TEST_SUITE(suite_Module, ModuleFixture)
 
+  BOOST_FIXTURE_TEST_CASE(Module_copy_assignment_copies_spi_config_without_mutating_source, ModuleFixture)
+  {
+    BOOST_TEST_MESSAGE("--- Test Module copy assignment copies SPI config correctly ---");
+
+    Module other(hal, EMULATED_RADIO_NSS_PIN, EMULATED_RADIO_IRQ_PIN, EMULATED_RADIO_RST_PIN, EMULATED_RADIO_GPIO_PIN);
+
+    mod->spiConfig.stream = true;
+    mod->spiConfig.err = 123;
+    mod->spiConfig.cmds[RADIOLIB_MODULE_SPI_COMMAND_READ] = 0x42;
+    mod->spiConfig.cmds[RADIOLIB_MODULE_SPI_COMMAND_WRITE] = 0x99;
+    mod->spiConfig.widths[RADIOLIB_MODULE_SPI_WIDTH_ADDR] = Module::BITS_16;
+    mod->spiConfig.widths[RADIOLIB_MODULE_SPI_WIDTH_CMD] = Module::BITS_8;
+    mod->spiConfig.statusPos = 7;
+    mod->spiConfig.timeout = 4321;
+    mod->rfSwitchPins[0] = 1001;
+    mod->rfSwitchPins[1] = 1002;
+    mod->rfSwitchTable = reinterpret_cast<const Module::RfSwitchMode_t*>(0x1234);
+
+    other.spiConfig.stream = false;
+    other.spiConfig.err = -77;
+    other.spiConfig.cmds[RADIOLIB_MODULE_SPI_COMMAND_READ] = 0x11;
+    other.spiConfig.cmds[RADIOLIB_MODULE_SPI_COMMAND_WRITE] = 0x22;
+    other.spiConfig.widths[RADIOLIB_MODULE_SPI_WIDTH_ADDR] = Module::BITS_24;
+    other.spiConfig.widths[RADIOLIB_MODULE_SPI_WIDTH_CMD] = Module::BITS_16;
+    other.spiConfig.statusPos = 3;
+    other.spiConfig.timeout = 555;
+    other.rfSwitchPins[0] = 2001;
+    other.rfSwitchPins[1] = 2002;
+    other.rfSwitchTable = reinterpret_cast<const Module::RfSwitchMode_t*>(0x5678);
+
+    other = *mod;
+
+    BOOST_TEST(other.spiConfig.stream == mod->spiConfig.stream);
+    BOOST_TEST(other.spiConfig.err == mod->spiConfig.err);
+    BOOST_TEST(other.spiConfig.cmds[RADIOLIB_MODULE_SPI_COMMAND_READ] == mod->spiConfig.cmds[RADIOLIB_MODULE_SPI_COMMAND_READ]);
+    BOOST_TEST(other.spiConfig.cmds[RADIOLIB_MODULE_SPI_COMMAND_WRITE] == mod->spiConfig.cmds[RADIOLIB_MODULE_SPI_COMMAND_WRITE]);
+    BOOST_TEST(other.spiConfig.widths[RADIOLIB_MODULE_SPI_WIDTH_ADDR] == mod->spiConfig.widths[RADIOLIB_MODULE_SPI_WIDTH_ADDR]);
+    BOOST_TEST(other.spiConfig.widths[RADIOLIB_MODULE_SPI_WIDTH_CMD] == mod->spiConfig.widths[RADIOLIB_MODULE_SPI_WIDTH_CMD]);
+    BOOST_TEST(other.spiConfig.statusPos == mod->spiConfig.statusPos);
+    BOOST_TEST(other.spiConfig.timeout == mod->spiConfig.timeout);
+    BOOST_TEST(other.rfSwitchPins[0] == mod->rfSwitchPins[0]);
+    BOOST_TEST(other.rfSwitchPins[1] == mod->rfSwitchPins[1]);
+    BOOST_TEST(other.rfSwitchTable == mod->rfSwitchTable);
+
+    BOOST_TEST(mod->spiConfig.stream == true);
+    BOOST_TEST(mod->spiConfig.err == 123);
+    BOOST_TEST(mod->spiConfig.cmds[RADIOLIB_MODULE_SPI_COMMAND_READ] == 0x42);
+    BOOST_TEST(mod->spiConfig.cmds[RADIOLIB_MODULE_SPI_COMMAND_WRITE] == 0x99);
+    BOOST_TEST(mod->spiConfig.widths[RADIOLIB_MODULE_SPI_WIDTH_ADDR] == Module::BITS_16);
+    BOOST_TEST(mod->spiConfig.widths[RADIOLIB_MODULE_SPI_WIDTH_CMD] == Module::BITS_8);
+    BOOST_TEST(mod->spiConfig.statusPos == 7);
+    BOOST_TEST(mod->spiConfig.timeout == 4321);
+    BOOST_TEST(mod->rfSwitchPins[0] == 1001);
+    BOOST_TEST(mod->rfSwitchPins[1] == 1002);
+    BOOST_TEST(mod->rfSwitchTable == reinterpret_cast<const Module::RfSwitchMode_t*>(0x1234));
+  }
+
   BOOST_FIXTURE_TEST_CASE(Module_SPIgetRegValue_reg, ModuleFixture)
   {
     BOOST_TEST_MESSAGE("--- Test Module::SPIgetRegValue register access ---");

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -25,11 +25,20 @@ Module::Module(const Module& mod) {
 }
 
 Module& Module::operator=(const Module& mod) {
-  memcpy(reinterpret_cast<void*>(&(const_cast<Module&>(mod)).spiConfig), &this->spiConfig, sizeof(SPIConfig_t));
+  this->hal = mod.hal;
+  memcpy(&this->spiConfig, &mod.spiConfig, sizeof(SPIConfig_t));
   this->csPin = mod.csPin;
   this->irqPin = mod.irqPin;
   this->rstPin = mod.rstPin;
   this->gpioPin = mod.gpioPin;
+  memcpy(this->rfSwitchPins, mod.rfSwitchPins, sizeof(this->rfSwitchPins));
+  this->rfSwitchTable = mod.rfSwitchTable;
+
+  #if RADIOLIB_INTERRUPT_TIMING
+  this->TimerSetupCb = mod.TimerSetupCb;
+  this->TimerFlag = mod.TimerFlag;
+  this->prevTimingLen = mod.prevTimingLen;
+  #endif
   return(*this);
 }
 


### PR DESCRIPTION
## Summary
- fix `Module::operator=` so it copies from the source object into the destination
- stop assignment from mutating the source object's `spiConfig`
- copy RF switch state and interrupt timing state as part of assignment
- add a regression test covering `Module` copy assignment behavior

## Why this is a bug
The original `Module::operator=` copied `this->spiConfig` into `mod.spiConfig` instead of copying from `mod` into `this`.

That had two bad effects:
- the destination object did not receive the source SPI configuration
- the source object was silently mutated by assignment

The original operator also did not copy the RF switch state, so assignment produced an incomplete `Module` copy even aside from the reversed `spiConfig` copy.

## History
`Module` copy constructor and assignment were introduced in commit `b8de06288` ("Added copy ctor and assignment operator", July 5, 2020). The bad copy direction in `operator=` dates back to that introduction.

I did not find a later mitigation elsewhere in-tree. In-tree usage of `Module` assignment appears to be rare, which likely kept this bug latent, but the operator is public API and its current behavior is incorrect.

## Validation
I ran the full existing unit suite in `extras/test/unit` with Homebrew GCC/Boost/fmt paths configured.

### Against original code
I copied only the new regression test into a clean worktree at the original `HEAD` and reran the full suite. The new test failed, showing that:
- the assigned object did not receive RF switch state
- the source object's `spiConfig` was overwritten by assignment

### Against this fix
I ran the full unit suite after the fix.

Result:
- `*** No errors detected`

## Test coverage
Adds `Module_copy_assignment_copies_spi_config_without_mutating_source` in:
- `extras/test/unit/tests/TestModule.cpp`

The test verifies:
- destination receives `spiConfig`
- destination receives RF switch state
- source object is not mutated by assignment
