### PR TITLE
Fail closed on SX126x receive metadata errors

### DIFF
--- a/extras/test/unit/CMakeLists.txt
+++ b/extras/test/unit/CMakeLists.txt
@@ -13,6 +13,7 @@ file(GLOB_RECURSE TEST_SOURCES
   "tests/ModuleFixture.cpp"
   "tests/TestModule.cpp"
   "tests/TestCalculateTimeOnAir.cpp"
+  "tests/TestSX126x.cpp"
   "tests/TestPhyComplete.cpp"
   "tests/TestCrypto.cpp"
 )

--- a/extras/test/unit/tests/TestSX126x.cpp
+++ b/extras/test/unit/tests/TestSX126x.cpp
@@ -1,0 +1,131 @@
+#include <boost/test/unit_test.hpp>
+
+#include "ModuleFixture.hpp"
+
+#include "modules/SX126x/SX126x.h"
+
+class EmulatedSX126x : public EmulatedRadio {
+  public:
+    bool failRxBufferStatus = false;
+    bool failPacketType = false;
+    uint8_t packetType = RADIOLIB_SX126X_PACKET_TYPE_GFSK;
+    uint8_t rxBufferStatus[2] = {0x11, 0x22};
+
+    void HandleGPIO() override {
+      if(this->cs && this->cs->event && (this->cs->value == 0)) {
+        this->txnPos = 0;
+        this->currentCmd = 0x00;
+      }
+    }
+
+    uint8_t HandleSPI(uint8_t b) override {
+      if(this->txnPos == 0) {
+        this->currentCmd = b;
+        this->txnPos++;
+        return(0x00);
+      }
+
+      uint8_t out = 0x32;
+      if(this->txnPos == 1) {
+        if((this->currentCmd == RADIOLIB_SX126X_CMD_GET_RX_BUFFER_STATUS) && this->failRxBufferStatus) {
+          out = RADIOLIB_SX126X_STATUS_CMD_TIMEOUT;
+        } else if((this->currentCmd == RADIOLIB_SX126X_CMD_GET_PACKET_TYPE) && this->failPacketType) {
+          out = RADIOLIB_SX126X_STATUS_CMD_TIMEOUT;
+        }
+      } else {
+        switch(this->currentCmd) {
+          case RADIOLIB_SX126X_CMD_GET_PACKET_TYPE:
+            out = this->packetType;
+            break;
+          case RADIOLIB_SX126X_CMD_GET_RX_BUFFER_STATUS:
+            out = this->rxBufferStatus[this->txnPos - 2];
+            break;
+          case RADIOLIB_SX126X_CMD_GET_IRQ_STATUS:
+            out = 0x00;
+            break;
+          default:
+            out = EMULATED_RADIO_SPI_RETURN;
+            break;
+        }
+      }
+
+      this->txnPos++;
+      return(out);
+    }
+
+  private:
+    uint8_t currentCmd = 0x00;
+    size_t txnPos = 0;
+};
+
+class SX126xFixture {
+  public:
+    TestHal* hal = nullptr;
+    Module* mod = nullptr;
+    EmulatedSX126x hw;
+    SX126x* radio = nullptr;
+
+    SX126xFixture() {
+      hal = new TestHal();
+      hal->connectRadio(&hw);
+      mod = new Module(hal, EMULATED_RADIO_NSS_PIN, EMULATED_RADIO_IRQ_PIN, EMULATED_RADIO_RST_PIN, EMULATED_RADIO_GPIO_PIN);
+      mod->init();
+
+      radio = new SX126x(mod);
+      mod->hal->pinMode(mod->getIrq(), mod->hal->GpioModeInput);
+      mod->hal->pinMode(mod->getGpio(), mod->hal->GpioModeInput);
+      mod->spiConfig.widths[RADIOLIB_MODULE_SPI_WIDTH_ADDR] = Module::BITS_16;
+      mod->spiConfig.widths[RADIOLIB_MODULE_SPI_WIDTH_CMD] = Module::BITS_8;
+      mod->spiConfig.statusPos = 1;
+      mod->spiConfig.cmds[RADIOLIB_MODULE_SPI_COMMAND_READ] = RADIOLIB_SX126X_CMD_READ_REGISTER;
+      mod->spiConfig.cmds[RADIOLIB_MODULE_SPI_COMMAND_WRITE] = RADIOLIB_SX126X_CMD_WRITE_REGISTER;
+      mod->spiConfig.cmds[RADIOLIB_MODULE_SPI_COMMAND_NOP] = RADIOLIB_SX126X_CMD_NOP;
+      mod->spiConfig.cmds[RADIOLIB_MODULE_SPI_COMMAND_STATUS] = RADIOLIB_SX126X_CMD_GET_STATUS;
+      mod->spiConfig.stream = true;
+      mod->spiConfig.parseStatusCb = SX126x::SPIparseStatus;
+      mod->spiConfig.timeout = 5;
+    }
+
+    ~SX126xFixture() {
+      delete radio;
+      mod->term();
+      delete mod;
+      delete hal;
+    }
+};
+
+BOOST_FIXTURE_TEST_SUITE(suite_SX126x, SX126xFixture)
+
+  BOOST_AUTO_TEST_CASE(SX126x_tryGetPacketLength_reports_command_timeout) {
+    hw.packetType = RADIOLIB_SX126X_PACKET_TYPE_GFSK;
+    hw.failRxBufferStatus = true;
+
+    size_t length = 99;
+    uint8_t offset = 77;
+    int16_t state = radio->tryGetPacketLength(&length, true, &offset);
+
+    BOOST_TEST(state == RADIOLIB_ERR_SPI_CMD_TIMEOUT);
+    BOOST_TEST(length == (size_t)99);
+    BOOST_TEST(offset == 77);
+  }
+
+  BOOST_AUTO_TEST_CASE(SX126x_getPacketLength_compatibility_wrapper_does_not_return_zero_on_command_timeout) {
+    hw.packetType = RADIOLIB_SX126X_PACKET_TYPE_GFSK;
+    hw.failRxBufferStatus = true;
+
+    size_t length = radio->getPacketLength();
+
+    BOOST_TEST(length == (size_t)RADIOLIB_SX126X_MAX_PACKET_LENGTH);
+  }
+
+  BOOST_AUTO_TEST_CASE(SX126x_readData_fails_closed_when_rx_buffer_status_read_fails) {
+    hw.packetType = RADIOLIB_SX126X_PACKET_TYPE_GFSK;
+    hw.failRxBufferStatus = true;
+
+    uint8_t data[8] = {0};
+    int16_t state = radio->readData(data, sizeof(data));
+
+    BOOST_TEST(state == RADIOLIB_ERR_SPI_CMD_TIMEOUT);
+  }
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -604,7 +604,9 @@ int16_t SX126x::readData(uint8_t* data, size_t len) {
   
   // get packet length and Rx buffer offset
   uint8_t offset = 0;
-  size_t length = getPacketLength(true, &offset);
+  size_t length = 0;
+  state = tryGetPacketLength(&length, true, &offset);
+  RADIOLIB_ASSERT(state);
   if((len != 0) && (len < length)) {
     // user requested less data than we got, only return what was requested
     length = len;
@@ -690,7 +692,9 @@ float SX126x::getRSSI() {
 float SX126x::getRSSI(bool packet) {
   if(packet) { 
     // get last packet RSSI from packet status
-    uint32_t packetStatus = getPacketStatus();
+    uint32_t packetStatus = 0;
+    int16_t state = tryGetPacketStatus(&packetStatus);
+    RADIOLIB_ASSERT(state);
     uint8_t rssiPkt = packetStatus & 0xFF;
     return(-1.0 * rssiPkt/2.0);
   } else {
@@ -703,12 +707,17 @@ float SX126x::getRSSI(bool packet) {
 
 float SX126x::getSNR() {
   // check active modem
-  if(getPacketType() != RADIOLIB_SX126X_PACKET_TYPE_LORA) {
+  uint8_t packetType = 0;
+  int16_t state = tryGetPacketType(&packetType);
+  RADIOLIB_ASSERT(state);
+  if(packetType != RADIOLIB_SX126X_PACKET_TYPE_LORA) {
     return(RADIOLIB_ERR_WRONG_MODEM);
   }
 
   // get last packet SNR from packet status
-  uint32_t packetStatus = getPacketStatus();
+  uint32_t packetStatus = 0;
+  state = tryGetPacketStatus(&packetStatus);
+  RADIOLIB_ASSERT(state);
   uint8_t snrPkt = (packetStatus >> 8) & 0xFF;
   if(snrPkt < 128) {
     return(snrPkt/4.0);
@@ -755,20 +764,40 @@ size_t SX126x::getPacketLength(bool update) {
 }
 
 size_t SX126x::getPacketLength(bool update, uint8_t* offset) {
+  size_t length = this->maxPacketLength;
+  if(this->tryGetPacketLength(&length, update, offset) == RADIOLIB_ERR_NONE) {
+    return(length);
+  }
+
+  // PhysicalLayer::getPacketLength() has no error channel. Returning a
+  // bounded non-zero sentinel prevents callers from silently treating
+  // a failed metadata read as "no packet".
+  return(this->maxPacketLength);
+}
+
+int16_t SX126x::tryGetPacketLength(size_t* length, bool update, uint8_t* offset) {
   (void)update;
 
+  uint8_t packetType = 0;
+  int16_t state = tryGetPacketType(&packetType);
+  RADIOLIB_ASSERT(state);
+
   // in implicit mode, return the cached value if the offset was not requested
-  if((getPacketType() == RADIOLIB_SX126X_PACKET_TYPE_LORA) && (this->headerType == RADIOLIB_SX126X_LORA_HEADER_IMPLICIT) && (!offset)) {
-    return(this->implicitLen);
+  if((packetType == RADIOLIB_SX126X_PACKET_TYPE_LORA) && (this->headerType == RADIOLIB_SX126X_LORA_HEADER_IMPLICIT) && (!offset)) {
+    if(length) {
+      *length = this->implicitLen;
+    }
+    return(RADIOLIB_ERR_NONE);
   }
 
   // if offset was requested, or in explicit mode, we always have to perform the SPI transaction
   uint8_t rxBufStatus[2] = {0, 0};
-  this->mod->SPIreadStream(RADIOLIB_SX126X_CMD_GET_RX_BUFFER_STATUS, rxBufStatus, 2);
+  state = this->mod->SPIreadStream(RADIOLIB_SX126X_CMD_GET_RX_BUFFER_STATUS, rxBufStatus, 2);
+  RADIOLIB_ASSERT(state);
 
   if(offset) { *offset = rxBufStatus[1]; }
-
-  return((size_t)rxBufStatus[0]);
+  if(length) { *length = (size_t)rxBufStatus[0]; }
+  return(RADIOLIB_ERR_NONE);
 }
 
 int16_t SX126x::getLoRaRxHeaderInfo(uint8_t* cr, bool* hasCRC) {

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -857,6 +857,7 @@ class SX126x: public PhysicalLayer {
     virtual int16_t clearIrqStatus(uint16_t clearIrqParams = RADIOLIB_SX126X_IRQ_ALL);
     int16_t setRfFrequency(uint32_t frf);
     int16_t calibrateImage(const uint8_t* data);
+    int16_t tryGetPacketType(uint8_t* type);
     uint8_t getPacketType();
     int16_t setTxParams(uint8_t power, uint8_t rampTime);
     int16_t setModulationParams(uint8_t sf, uint8_t bw, uint8_t cr, uint8_t ldro);
@@ -868,7 +869,9 @@ class SX126x: public PhysicalLayer {
     int16_t setBufferBaseAddress(uint8_t txBaseAddress = 0x00, uint8_t rxBaseAddress = 0x00);
     int16_t setRegulatorMode(uint8_t mode);
     uint8_t getStatus();
+    int16_t tryGetPacketStatus(uint32_t* status);
     uint32_t getPacketStatus();
+    int16_t tryGetPacketLength(size_t* length, bool update = true, uint8_t* offset = NULL);
     uint16_t getDeviceErrors();
     int16_t clearDeviceErrors();
 

--- a/src/modules/SX126x/SX126x_commands.cpp
+++ b/src/modules/SX126x/SX126x_commands.cpp
@@ -202,10 +202,20 @@ int16_t SX126x::calibrateImage(const uint8_t* data) {
   return(state);
 }
 
-uint8_t SX126x::getPacketType() {
+int16_t SX126x::tryGetPacketType(uint8_t* type) {
   uint8_t data = 0xFF;
-  this->mod->SPIreadStream(RADIOLIB_SX126X_CMD_GET_PACKET_TYPE, &data, 1);
-  return(data);
+  int16_t state = this->mod->SPIreadStream(RADIOLIB_SX126X_CMD_GET_PACKET_TYPE, &data, 1);
+  RADIOLIB_ASSERT(state);
+  if(type) {
+    *type = data;
+  }
+  return(RADIOLIB_ERR_NONE);
+}
+
+uint8_t SX126x::getPacketType() {
+  uint8_t type = 0xFF;
+  (void)this->tryGetPacketType(&type);
+  return(type);
 }
 
 int16_t SX126x::setTxParams(uint8_t pwr, uint8_t rampTime) {
@@ -290,10 +300,20 @@ uint8_t SX126x::getStatus() {
   return(data);
 }
 
-uint32_t SX126x::getPacketStatus() {
+int16_t SX126x::tryGetPacketStatus(uint32_t* status) {
   uint8_t data[3] = {0, 0, 0};
-  this->mod->SPIreadStream(RADIOLIB_SX126X_CMD_GET_PACKET_STATUS, data, 3);
-  return((((uint32_t)data[0]) << 16) | (((uint32_t)data[1]) << 8) | (uint32_t)data[2]);
+  int16_t state = this->mod->SPIreadStream(RADIOLIB_SX126X_CMD_GET_PACKET_STATUS, data, 3);
+  RADIOLIB_ASSERT(state);
+  if(status) {
+    *status = (((uint32_t)data[0]) << 16) | (((uint32_t)data[1]) << 8) | (uint32_t)data[2];
+  }
+  return(RADIOLIB_ERR_NONE);
+}
+
+uint32_t SX126x::getPacketStatus() {
+  uint32_t status = 0;
+  (void)this->tryGetPacketStatus(&status);
+  return(status);
 }
 
 uint16_t SX126x::getDeviceErrors() {


### PR DESCRIPTION
## Summary
- add internal error-aware SX126x helpers for packet type, packet status, and packet length metadata
- make `SX126x::readData()` fail closed when receive metadata retrieval fails
- stop packet RSSI/SNR helpers from fabricating values from failed metadata reads
- add regression tests covering SX126x receive-metadata command failures

## Problem
On SX126x, several receive-metadata helpers ignored `SPIreadStream(...)` return codes and treated zeroed or seeded buffers as valid chip data.

The highest-impact case is `SX126x::getPacketLength()`:
- it issued `GET_RX_BUFFER_STATUS`
- ignored the returned status
- and returned whatever remained in `rxBufStatus`

That meant a command/SPI failure could be interpreted as a valid packet length, including `0`.

This is a live issue for MeshCore's RadioLib integration. MeshCore's receive path asks RadioLib for packet length first and only calls `readData()` if the reported length is non-zero:
- `src/helpers/radiolib/RadioLibWrappers.cpp`

So on SX126x-family boards, a failed metadata read could be silently treated as “no packet”, or as a bogus packet length, instead of surfacing a receive error.

## Fix approach
I kept the public API stable and added internal error-aware helpers:
- `tryGetPacketType(...)`
- `tryGetPacketStatus(...)`
- `tryGetPacketLength(...)`

Those helpers return a real status code and only write outputs on success.

Then I switched the internal hot paths that need correctness to use them:
- `SX126x::readData()`
- packet RSSI and SNR helpers

For the legacy public `size_t getPacketLength()` API, there is no error channel because it comes from `PhysicalLayer`. To avoid silently collapsing a failed metadata read into “no packet”, the compatibility wrapper now returns a bounded non-zero sentinel (`maxPacketLength`) on failure instead of returning stale or zero metadata.

## Why this design
A more comprehensive long-term solution would be to add a public error-aware metadata API at the `PhysicalLayer` layer, for example a `tryGetPacketLength(...)`-style method that downstream users can adopt directly.

I did not do that in this PR because it would be a larger cross-library API change affecting many radios and downstream consumers.

This PR is intentionally narrower:
- fix the real live SX126x bug
- keep the existing public API intact
- create internal error-aware helpers that can support a broader future refactor

## Validation
### New regression tests
Added `extras/test/unit/tests/TestSX126x.cpp` covering:
- `tryGetPacketLength()` propagates SX126x command timeout
- compatibility `getPacketLength()` no longer looks like “no packet” on metadata failure
- `readData()` fails closed when RX buffer status retrieval fails

### Proof against original code
I ran the new SX126x tests against an unmodified latest-master worktree.
The original code fails those tests because:
- `getPacketLength()` surfaces bogus packet-length data from a failed metadata read
- `readData()` returns success instead of propagating the metadata failure

### Fixed branch validation
Ran the full existing unit suite and the focused SX126x suite:
- `extras/test/unit/test.sh "-I/opt/homebrew/include -L/opt/homebrew/lib"`
- `./build/radiolib-unittest --run_test=suite_SX126x/* --log_level=test_suite`

Result:
- full suite passed
- SX126x regression suite passed
