### PR TITLE
[Debug] Add warning if USB CDC used for debug output

### DIFF
--- a/src/RadioLib.h
+++ b/src/RadioLib.h
@@ -63,6 +63,10 @@
   #pragma message(RADIOLIB_INFO)
 #endif
 
+#if CFG_TUD_CDC == 1 || ARDUINO_USB_CDC_ON_BOOT == 1 || defined(USBD_USE_CDC)
+  #warning "Use of USB CDC for debug output is not recommended (might stop on first sleep). Use hardware UART instead."
+#endif
+
 // check unknown/unsupported platform
 #if defined(RADIOLIB_UNKNOWN_PLATFORM)
   #warning "RadioLib might not be compatible with this Arduino board - check supported platforms at https://github.com/jgromes/RadioLib!"


### PR DESCRIPTION
When USB CDC is used, the debug output will usually stop at first sleep, giving the impression that the execution of the code crashed. This is what happened in #1746.

This PR prints a warning if USB CDC is used. 

- [CFG_TUD_CDC](https://github.com/hathach/tinyusb/blob/751f465a39299ba0638c1700d1aa2d53e8d1b877/examples/device/cdc_msc/src/tusb_config.h#L94) : boards using TinyUSB (Adafruit nRF52, ESP32 and [other CPUs](https://github.com/hathach/tinyusb/tree/master?tab=readme-ov-file#supported-cpus)). TUD stands for TinyUSB Device.

- [ARDUINO_USB_CDC_ON_BOOT](https://community.platformio.org/t/esp32-serial-library-suddenly-stopped-to-work/42361) : ESP32-S2 / S3 / C3

- [USBD_USE_CDC](https://github.com/limbongofficial/STM32_Core-Arduino/blob/5e2e32ab4f79ffbf9401eb2fc68ed403e974f145/cores/arduino/stm32/usb/usbd_desc.c#L51) : STM32

I don't think we should do a workaround and make CDC serial work, as restarting the serial connection will mess up the precise timing some protocols needs (especially LoRaWAN).