### PR TITLE
[SX126x] Fix packet length in FSK fixed mode always returns 0xFF

### DIFF
--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -762,6 +762,11 @@ size_t SX126x::getPacketLength(bool update, uint8_t* offset) {
     return(this->implicitLen);
   }
 
+  // in fixed-length FSK mode, Rx buffer status seems to be always returning 0xFF
+  if((getPacketType() == RADIOLIB_SX126X_PACKET_TYPE_GFSK) && (this->packetType == RADIOLIB_SX126X_GFSK_PACKET_FIXED)) {
+    return(this->implicitLen);
+  }
+
   // if offset was requested, or in explicit mode, we always have to perform the SPI transaction
   uint8_t rxBufStatus[2] = {0, 0};
   this->mod->SPIreadStream(RADIOLIB_SX126X_CMD_GET_RX_BUFFER_STATUS, rxBufStatus, 2);

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -574,6 +574,8 @@ class SX126x: public PhysicalLayer {
 
     /*!
       \brief Query modem for the packet length of received payload.
+      In LoRa implicit header mode or FSK fixed length mode,
+      this method always returns the user-configured packet length.
       \param update Not used for SX126x modules.
       \returns Length of last received packet in bytes.
     */
@@ -581,6 +583,8 @@ class SX126x: public PhysicalLayer {
 
     /*!
       \brief Query modem for the packet length of received payload and Rx buffer offset.
+      In LoRa implicit header mode or FSK fixed length mode,
+      this method always returns the user-configured packet length.
       \param update Not used for SX126x modules.
       \param offset Pointer to variable to store the Rx buffer offset.
       \returns Length of last received packet in bytes.

--- a/src/modules/SX126x/SX126x_config.cpp
+++ b/src/modules/SX126x/SX126x_config.cpp
@@ -749,6 +749,7 @@ int16_t SX126x::setPacketMode(uint8_t mode, uint8_t len) {
 
   // update cached value
   this->packetType = mode;
+  this->implicitLen = len;
   return(state);
 }
 


### PR DESCRIPTION
As reported in #1749. Simple enough fix, but pushed to branch to resolve the currently failing CI on master separately
