### PR TITLE
[LoRaWAN] Add TS003 Application Layer Clock Synchronization package

### DIFF
--- a/examples/LoRaWAN/LoRaWAN_Package_Manager/LoRaWAN_Package_Manager.ino
+++ b/examples/LoRaWAN/LoRaWAN_Package_Manager/LoRaWAN_Package_Manager.ino
@@ -46,6 +46,8 @@ void setup() {
 
   // Warning: radio.begin() must be called before enabling packages!
 
+  // Enable TS003 (Application Time) on default FPort
+  pacMan.enableTS003(RADIOLIB_LORAWAN_FPORT_TS003, setSeconds);
   // Enable TS009 (Certification Protocol) with delay, interval, and reboot callbacks
   pacMan.enableTS009(&radio, delaySeconds, setUplinkInterval, performReboot);
 

--- a/examples/LoRaWAN/LoRaWAN_Package_Manager/example.h
+++ b/examples/LoRaWAN/LoRaWAN_Package_Manager/example.h
@@ -6,6 +6,9 @@
   
   This file provides example implementations of the callbacks that the 
   Package Manager uses to interact with the device and/or application.
+
+  Note: the functions used MUST be configured for your device to function
+  correctly with the enabled packages.
 */
 
 #include <Arduino.h>
@@ -13,10 +16,23 @@
 #include "config.h"
 
 // Most packages need a true time reference in seconds (not time since boot).
-// However, TS009 is an exception that does not require a real time reference,
-// so we can just return millis()/1000.
+// This is the current time in seconds (GPS time since epoch - not Unix!).
+// Commented below is a reference implementation for the ESP32.
 RadioLibTime_t getSeconds() {
-  return((RadioLibTime_t)millis() / 1000);
+  return(0);
+
+  // return((RadioLibTime_t)time(NULL));
+}
+
+// Configure the current true time in seconds (GPS time since epoch - not Unix!).
+// Commented below is a reference implementation for the ESP32.
+inline void setSeconds(RadioLibTime_t seconds) {
+  (void)seconds;
+
+  // struct timeval tv;
+  // tv.tv_sec = seconds;
+  // tv.tv_usec = 0;
+  // settimeofday(&tv, NULL);
 }
 
 // This function is called by a package when it receives a reset command.

--- a/src/protocols/LoRaWAN/LoRaWANPacMan.cpp
+++ b/src/protocols/LoRaWAN/LoRaWANPacMan.cpp
@@ -67,7 +67,7 @@ int16_t LoRaWANPackageManager::enableTS003(uint8_t fPort, SetSecondsCb_t setSeco
   }
 
   // verify callback is provided
-  if(setSecondsFunc == NULL) {
+  if(this->getSecondsCb == NULL || setSecondsFunc == NULL) {
     return(RADIOLIB_ERR_NULL_POINTER);
   }
 

--- a/src/protocols/LoRaWAN/LoRaWANPacMan.cpp
+++ b/src/protocols/LoRaWAN/LoRaWANPacMan.cpp
@@ -16,6 +16,7 @@ size_t LoRaWANPackage::processData(const uint8_t* data, size_t len, LoRaWANEvent
   // Default implementation: assume the provided buffer is entirely consumed.
   // Derived classes should override and return actual bytes consumed.
   (void)data;
+  (void)event;
   return(len);
 }
 

--- a/src/protocols/LoRaWAN/LoRaWANPacMan.cpp
+++ b/src/protocols/LoRaWAN/LoRaWANPacMan.cpp
@@ -1,6 +1,7 @@
 #if !RADIOLIB_EXCLUDE_LORAWAN
 
 #include "LoRaWANPacMan.h"
+#include "LoRaWANPackageTS003.h"
 #include "LoRaWANPackageTS009.h"
 #include <string.h>
 
@@ -59,6 +60,34 @@ LoRaWANPackageManager::LoRaWANPackageManager(LoRaWANNode* node, GetSecondsCb_t s
   this->getSecondsCb = secondsCb;
 }
 
+int16_t LoRaWANPackageManager::enableTS003(uint8_t fPort, SetSecondsCb_t setSecondsFunc) {
+  // check if node is not activated
+  if(this->lorawanNode == NULL || this->lorawanNode->isActivated()) {
+    return(RADIOLIB_ERR_NETWORK_NOT_JOINED);
+  }
+
+  // verify callback is provided
+  if(setSecondsFunc == NULL) {
+    return(RADIOLIB_ERR_NULL_POINTER);
+  }
+
+  // create package if not already created
+  if(this->packages[RADIOLIB_LORAWAN_PACKAGE_TS003] == NULL) {
+    this->packages[RADIOLIB_LORAWAN_PACKAGE_TS003] = new LoRaWANPackageTS003(this, this->lorawanNode, this->getSecondsCb);
+    this->packagePorts[RADIOLIB_LORAWAN_PACKAGE_TS003] = fPort;
+  }
+
+  // set time handler callback on TS003 package
+  LoRaWANPackageTS003* ts003 = static_cast<LoRaWANPackageTS003*>(this->packages[RADIOLIB_LORAWAN_PACKAGE_TS003]);
+  ts003->setSecondsCb(setSecondsFunc);
+
+  // enable the package
+  this->enabledPackages[RADIOLIB_LORAWAN_PACKAGE_TS003] = true;
+
+  return(RADIOLIB_ERR_NONE);
+}
+
+
 int16_t LoRaWANPackageManager::enableTS009(PhysicalLayer* radio, DelaySecondsCb_t delayCb, UplinkIntervalCb_t intervalCb, RebootCb_t rebootCb) {
   // check if node is not activated
   if(this->lorawanNode == NULL || this->lorawanNode->isActivated()) {
@@ -91,6 +120,14 @@ int16_t LoRaWANPackageManager::enableTS009(PhysicalLayer* radio, DelaySecondsCb_
   return(RADIOLIB_ERR_NONE);
 }
 
+void LoRaWANPackageManager::requestAppTime() {
+  // if TS003 is enabled, trigger an immediate uplink with the AppTimeReq CID
+  LoRaWANPackageTS003* ts003 = static_cast<LoRaWANPackageTS003*>(this->packages[RADIOLIB_LORAWAN_PACKAGE_TS003]);
+  if(ts003 == NULL) {
+    return;
+  }
+  ts003->requestAppTime();
+}
 
 bool LoRaWANPackageManager::getConfirmed() {
   LoRaWANPackageTS009* ts009 = static_cast<LoRaWANPackageTS009*>(this->packages[RADIOLIB_LORAWAN_PACKAGE_TS009]);

--- a/src/protocols/LoRaWAN/LoRaWANPacMan.h
+++ b/src/protocols/LoRaWAN/LoRaWANPacMan.h
@@ -130,6 +130,7 @@ class LoRaWANPackageManager {
   public:
 
     typedef RadioLibTime_t (*GetSecondsCb_t)();
+    typedef void (*SetSecondsCb_t)(RadioLibTime_t seconds);
     typedef void (*DelaySecondsCb_t)(RadioLibTime_t seconds);
     typedef void (*UplinkIntervalCb_t)(RadioLibTime_t intervalSeconds);
     typedef void (*RebootCb_t)();
@@ -138,9 +139,17 @@ class LoRaWANPackageManager {
       \brief Create a package manager
       \param node Pointer to the LoRaWAN node
       \param getSeconds Pointer to getSeconds() function for time handling
-    */
+    */    
     
-    LoRaWANPackageManager(LoRaWANNode* node, GetSecondsCb_t secondsCb);
+
+    // Package enable methods
+    /*!
+      \brief Enable TS003 Application Time Synchronization package
+      \param fPort The FPort to which this package will listen
+      \param setSecondsFunc Pointer to setSeconds() function
+      \returns \ref status_codes
+    */
+    int16_t enableTS003(uint8_t fPort, SetSecondsCb_t setSecondsFunc);
 
     // Package enablement methods
     /*!
@@ -153,6 +162,13 @@ class LoRaWANPackageManager {
     */
     int16_t enableTS009(PhysicalLayer* radio, DelaySecondsCb_t delayCb, UplinkIntervalCb_t intervalCb, RebootCb_t rebootCb);
 
+    // TS003
+    /*!
+      \brief Send an application time request
+      \returns \ref status_codes
+    */
+    void requestAppTime();
+    
     // TS009
     /*!
       \brief Check whether subsequent uplinks should be confirmed

--- a/src/protocols/LoRaWAN/LoRaWANPacMan.h
+++ b/src/protocols/LoRaWAN/LoRaWANPacMan.h
@@ -140,7 +140,7 @@ class LoRaWANPackageManager {
       \param node Pointer to the LoRaWAN node
       \param getSeconds Pointer to getSeconds() function for time handling
     */    
-    
+    LoRaWANPackageManager(LoRaWANNode* node, GetSecondsCb_t secondsCb);
 
     // Package enable methods
     /*!

--- a/src/protocols/LoRaWAN/LoRaWANPackageTS003.cpp
+++ b/src/protocols/LoRaWAN/LoRaWANPackageTS003.cpp
@@ -65,6 +65,8 @@ void LoRaWANPackageTS003::doAction() {
 }
 
 size_t LoRaWANPackageTS003::processData(const uint8_t* dataDown, size_t lenDown, LoRaWANEvent_t* event) {
+  (void)event;
+
   size_t procLen = 0;
   this->lenUp = 0;
 
@@ -110,7 +112,7 @@ size_t LoRaWANPackageTS003::processData(const uint8_t* dataDown, size_t lenDown,
         this->transmissions = 0;
 
         // if correction is min/max value, trigger another AppTimeReq
-        if(correction == 0x7FFFFFFF || correction == 0x80000000) {
+        if(uCorrection == (uint32_t)0x7FFFFFFF || uCorrection == (uint32_t)0x80000000) {
           this->nextAppReqTime = this->getSeconds();
 
         // otherwise, schedule next AppTimeReq based on periodicity (if set)

--- a/src/protocols/LoRaWAN/LoRaWANPackageTS003.cpp
+++ b/src/protocols/LoRaWAN/LoRaWANPackageTS003.cpp
@@ -1,0 +1,173 @@
+#if !RADIOLIB_EXCLUDE_LORAWAN
+
+#include "LoRaWANPackageTS003.h"
+
+LoRaWANPackageTS003::LoRaWANPackageTS003(LoRaWANPackageManager* pacMan, LoRaWANNode* node, GetSecondsCb_t secondsCb)
+  : LoRaWANPackage(RADIOLIB_LORAWAN_PACKAGE_TS003, pacMan, node, secondsCb),
+    setSeconds(NULL), tokenReq(0), periodicity(0), nextAppReqTime(0) {
+  this->packageVersion = 2;
+}
+
+void LoRaWANPackageTS003::setSecondsCb(SetSecondsCb_t cb) {
+  this->setSeconds = cb;
+}
+
+LoRaWANTaskInfo LoRaWANPackageTS003::hasTask() {
+  LoRaWANTaskInfo task;
+  task.type = RADIOLIB_LORAWAN_TASK_NONE;
+  task.time = 0;
+
+  RadioLibTime_t nowSec = this->getSeconds();
+
+  // check for any pending uplinks
+  if(this->lenUp > 0) {
+    task.type = RADIOLIB_LORAWAN_TASK_UPLINK;
+    task.time = nowSec;
+    return(task);
+  }
+
+  // check if we are doing AppTimeReq at all
+  if(this->nextAppReqTime == 0) {
+    return(task);
+  }
+
+  task.type = RADIOLIB_LORAWAN_TASK_UPLINK;
+  task.time = this->nextAppReqTime;
+
+  // if next time is in the future, schedule for that time
+  if(this->nextAppReqTime > nowSec) {
+    return(task);
+  }
+
+  // if next time is now or in the past, trigger AppTimeReq and schedule next one
+  this->requestAppTime();
+
+  // if there are forced retransmissions, ignore periodicity
+  if(this->transmissions > 0) {
+    this->transmissions -= 1;
+    this->nextAppReqTime = nowSec + random(60);
+
+  // otherwise schedule based on periodicity
+  } else if(this->periodicity > 0) {
+    this->nextAppReqTime += this->periodicity - 30 + random(60);
+  }
+
+  // if there are no forced retransmissions and no periodicity, do not schedule
+  else {
+    this->nextAppReqTime = 0;
+  }
+  
+  return(task);
+}
+
+void LoRaWANPackageTS003::doAction() {
+  return;
+}
+
+size_t LoRaWANPackageTS003::processData(const uint8_t* dataDown, size_t lenDown, LoRaWANEvent_t* event) {
+  size_t procLen = 0;
+  this->lenUp = 0;
+
+  while (procLen < lenDown) {
+    RADIOLIB_DEBUG_PROTOCOL_PRINTLN("CID = %02x, len = %d", dataDown[procLen], lenDown - procLen - 1);
+  
+    switch(dataDown[procLen]) {
+      case(RADIOLIB_LORAWAN_TS003_PACKAGE_VERSION): {
+        // no downlink payload
+        procLen += 1;
+
+        this->dataUp[this->lenUp + 0] = RADIOLIB_LORAWAN_TS003_PACKAGE_VERSION;
+        this->dataUp[this->lenUp + 1] = this->packageIdentifier;
+        this->dataUp[this->lenUp + 2] = this->packageVersion;
+        this->lenUp += 3;
+        
+        RADIOLIB_DEBUG_PROTOCOL_PRINTLN("PackageIdentifier: %d, PackageVersion: %d", 
+                                        this->dataUp[1], this->dataUp[2]);
+  
+      } break;
+      case(RADIOLIB_LORAWAN_TS003_APP_TIME): {
+        uint8_t tokenAns = dataDown[procLen + 5] & 0x0F;
+        if(tokenAns != this->tokenReq) {
+          procLen += 6;         // skip payload
+          break;
+        }
+        this->tokenReq += 1;
+        this->tokenReq %= 16;
+        uint32_t uCorrection = 0;
+        uCorrection |= (uint32_t)dataDown[procLen + 1];
+        uCorrection |= (uint32_t)dataDown[procLen + 2] <<  8;
+        uCorrection |= (uint32_t)dataDown[procLen + 3] << 16;
+        uCorrection |= (uint32_t)dataDown[procLen + 4] << 24;
+        procLen += 6;
+        int32_t correction = (int32_t)uCorrection;
+
+        RADIOLIB_DEBUG_PROTOCOL_PRINTLN("TimeCorrection: %d, TokenAns: %d", correction, tokenAns);
+
+        // apply time correction via callback
+        this->setSeconds(this->getSeconds() + correction);
+
+        // clear pending AppTimeReq uplink transmissions
+        this->transmissions = 0;
+
+        // if correction is min/max value, trigger another AppTimeReq
+        if(correction == 0x7FFFFFFF || correction == 0x80000000) {
+          this->nextAppReqTime = this->getSeconds();
+
+        // otherwise, schedule next AppTimeReq based on periodicity (if set)
+        } else if(this->periodicity) {
+          this->nextAppReqTime = this->getSeconds() + this->periodicity - 30 + random(60);
+        } else {
+          this->nextAppReqTime = 0;
+        }
+  
+      } break;
+      case(RADIOLIB_LORAWAN_TS003_APP_TIME_PERIODICITY): {
+        uint32_t period = dataDown[procLen + 1];
+        procLen += 2;
+
+        this->dataUp[this->lenUp + 0] = RADIOLIB_LORAWAN_TS003_APP_TIME_PERIODICITY;
+        this->dataUp[this->lenUp + 1] = 0;
+        RadioLibTime_t now = this->getSeconds();
+        this->dataUp[this->lenUp + 2] = (uint8_t)((now >> 0)  & 0xFF);
+        this->dataUp[this->lenUp + 3] = (uint8_t)((now >> 8)  & 0xFF);
+        this->dataUp[this->lenUp + 4] = (uint8_t)((now >> 16) & 0xFF);
+        this->dataUp[this->lenUp + 5] = (uint8_t)((now >> 24) & 0xFF);
+        this->lenUp += 6;
+
+        RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Period: %lu, Time: %lu", period, now);
+        this->periodicity = 128 << period;
+        this->nextAppReqTime = this->getSeconds() + this->periodicity - 30 + random(60);
+        
+      } break;
+      case(RADIOLIB_LORAWAN_TS003_FORCE_DEVICE_RESYNC): {
+        uint8_t trans = dataDown[procLen + 1] & 0x0F;
+        procLen += 2;
+
+        RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Forced transmissions: %d", trans);
+        if(trans > 0) {
+          this->nextAppReqTime = this->getSeconds();
+          trans--;
+        }
+        this->transmissions = trans;
+
+      } break;
+    }
+  }
+
+  return(procLen);
+}
+
+int16_t LoRaWANPackageTS003::requestAppTime(bool force) {
+  this->dataUp[0] = RADIOLIB_LORAWAN_TS003_APP_TIME;
+  
+  RadioLibTime_t now = this->getSeconds();
+  this->dataUp[1] = (uint8_t)((now >> 0)  & 0xFF);
+  this->dataUp[2] = (uint8_t)((now >> 8)  & 0xFF);
+  this->dataUp[3] = (uint8_t)((now >> 16) & 0xFF);
+  this->dataUp[4] = (uint8_t)((now >> 24) & 0xFF);
+  this->dataUp[5] = (uint8_t)force << 4 | (this->tokenReq & 0x0F);
+  this->lenUp = 6;
+  return(RADIOLIB_ERR_NONE);
+}
+
+#endif

--- a/src/protocols/LoRaWAN/LoRaWANPackageTS003.cpp
+++ b/src/protocols/LoRaWAN/LoRaWANPackageTS003.cpp
@@ -4,7 +4,7 @@
 
 LoRaWANPackageTS003::LoRaWANPackageTS003(LoRaWANPackageManager* pacMan, LoRaWANNode* node, GetSecondsCb_t secondsCb)
   : LoRaWANPackage(RADIOLIB_LORAWAN_PACKAGE_TS003, pacMan, node, secondsCb),
-    setSeconds(NULL), tokenReq(0), periodicity(0), nextAppReqTime(0) {
+    setSeconds(NULL), tokenReq(0), transmissions(0), periodicity(0), nextAppReqTime(0) {
   this->packageVersion = 2;
 }
 

--- a/src/protocols/LoRaWAN/LoRaWANPackageTS003.cpp
+++ b/src/protocols/LoRaWAN/LoRaWANPackageTS003.cpp
@@ -45,11 +45,11 @@ LoRaWANTaskInfo LoRaWANPackageTS003::hasTask() {
   // if there are forced retransmissions, ignore periodicity
   if(this->transmissions > 0) {
     this->transmissions -= 1;
-    this->nextAppReqTime = nowSec + random(60);
+    this->nextAppReqTime = nowSec + (rand() % 60);
 
   // otherwise schedule based on periodicity
   } else if(this->periodicity > 0) {
-    this->nextAppReqTime += this->periodicity - 30 + random(60);
+    this->nextAppReqTime += this->periodicity - 30 + (rand() % 60);
   }
 
   // if there are no forced retransmissions and no periodicity, do not schedule
@@ -117,7 +117,7 @@ size_t LoRaWANPackageTS003::processData(const uint8_t* dataDown, size_t lenDown,
 
         // otherwise, schedule next AppTimeReq based on periodicity (if set)
         } else if(this->periodicity) {
-          this->nextAppReqTime = this->getSeconds() + this->periodicity - 30 + random(60);
+          this->nextAppReqTime = this->getSeconds() + this->periodicity - 30 + (rand() % 60);
         } else {
           this->nextAppReqTime = 0;
         }
@@ -138,7 +138,7 @@ size_t LoRaWANPackageTS003::processData(const uint8_t* dataDown, size_t lenDown,
 
         RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Period: %lu, Time: %lu", period, now);
         this->periodicity = 128 << period;
-        this->nextAppReqTime = this->getSeconds() + this->periodicity - 30 + random(60);
+        this->nextAppReqTime = this->getSeconds() + this->periodicity - 30 + (rand() % 60);
         
       } break;
       case(RADIOLIB_LORAWAN_TS003_FORCE_DEVICE_RESYNC): {

--- a/src/protocols/LoRaWAN/LoRaWANPackageTS003.h
+++ b/src/protocols/LoRaWAN/LoRaWANPackageTS003.h
@@ -1,0 +1,85 @@
+#if !defined(_RADIOLIB_LORAWAN_PACKAGE_TS003_H) && !RADIOLIB_EXCLUDE_LORAWAN
+#define _RADIOLIB_LORAWAN_PACKAGE_TS003_H
+
+#include "LoRaWANPacMan.h"
+
+// The major benefit of using this package compared to using the DeviceTimeReq MAC
+// command is that, most of the time, the Application Server is not required to answer the
+// AppTimeReq command from the end-device. A downlink is only required when the end
+// device clock is outside the accuracy requirement that is targeted by the application. In
+// contrast, every DeviceTimeReq MAC command sent by the end-device requires an answer
+// from the Network Server.
+
+#define RADIOLIB_LORAWAN_TS003_PACKAGE_VERSION        (0x00)
+#define RADIOLIB_LORAWAN_TS003_APP_TIME               (0x01)
+#define RADIOLIB_LORAWAN_TS003_APP_TIME_PERIODICITY   (0x02)
+#define RADIOLIB_LORAWAN_TS003_FORCE_DEVICE_RESYNC    (0x03)
+
+/*!
+  \class LoRaWANPackageTS003
+  \brief LoRaWAN Application package for TS003 Application Time.
+*/
+class LoRaWANPackageTS003 : public LoRaWANPackage {
+  public:
+
+    // copy constructor is removed to prevent users from creating copies of this class
+    LoRaWANPackageTS003(const LoRaWANPackageTS003& obj) = delete;
+
+    /*!
+      \brief Process downlink data for the TS003 application time package
+      \param dataDown Pointer to received downlink data
+      \param lenDown Length of downlink data
+    */
+    size_t processData(const uint8_t* dataDown, size_t lenDown, LoRaWANEvent_t* event) override;
+
+    /*!
+      \brief Send an application time request
+      \returns \ref status_codes
+    */
+    int16_t requestAppTime(bool force = false);
+
+    /*!
+      \brief Set the setSeconds callback function
+      \param setSeconds Callback function to set device time
+    */
+    typedef void (*SetSecondsCb_t)(RadioLibTime_t);
+    void setSecondsCb(SetSecondsCb_t setSecondsCb);
+
+    /*!
+      \brief Find out what the next task is and when it occurs
+      \returns `LoRaWANTaskInfo` containing task type and time
+    */
+    LoRaWANTaskInfo hasTask() override;
+
+    /*!
+      \brief Perform an ACTION task (if any).
+    */
+    void doAction() override;
+
+#if !RADIOLIB_GODMODE
+  protected:
+#endif
+
+    SetSecondsCb_t setSeconds;      // callback to configure current GPS time in seconds since epoch
+    uint8_t tokenReq;               // validation of AppTimeReq response
+    uint8_t transmissions;          // maximum number of AppTimeReq (re)transmissions
+    uint32_t periodicity;           // requested interval between AppTimeReq transmissions (s)
+    RadioLibTime_t nextAppReqTime;  // next scheduled AppTimeReq transmission
+
+#if !RADIOLIB_GODMODE
+  private:
+#endif
+    // private constructor, to not allow the user to create additional instances of this package
+    /*!
+      \brief Constructor
+      \param pacMan Pointer to the package manager
+      \param node Pointer to the LoRaWAN node
+      \param secondsCb Pointer to getSeconds() function
+    */
+    LoRaWANPackageTS003(LoRaWANPackageManager* pacMan, LoRaWANNode* node, GetSecondsCb_t secondsCb);
+
+    // allow LoRaWANPackageManager to access the private constructor
+    friend LoRaWANPackageManager;
+};
+
+#endif


### PR DESCRIPTION
This pull request adds the LoRaWAN TS003 Application Layer Clock Synchronization package to the Package Manager. Specification as per [doc](https://resources.lora-alliance.org/technical-specifications/ts003-2-0-0-application-layer-clock-synchronization). Feel free to read through it but it's verified using LCTT so personally not concerned about functionality. Code review is useful though.