### PR TITLE
feat(SX128x): add per-step debug diagnostics to begin()

### DIFF
--- a/src/modules/SX128x/SX128x.cpp
+++ b/src/modules/SX128x/SX128x.cpp
@@ -33,28 +33,52 @@ int16_t SX128x::begin(float freq, float bw, uint8_t sf, uint8_t cr, uint8_t sync
 
   // set module properties and perform initial setup
   int16_t state = this->modSetup(RADIOLIB_SX128X_PACKET_TYPE_LORA);
+  if(state != RADIOLIB_ERR_NONE) {
+    RADIOLIB_DEBUG_BASIC_PRINTLN("SX128x LoRa begin() failed at modSetup [%d]", state);
+  }
   RADIOLIB_ASSERT(state);
 
   // configure publicly accessible settings
   state = setFrequency(freq);
+  if(state != RADIOLIB_ERR_NONE) {
+    RADIOLIB_DEBUG_BASIC_PRINTLN("SX128x LoRa begin() failed at setFrequency(%.3f MHz) [%d]", freq, state);
+  }
   RADIOLIB_ASSERT(state);
 
   state = setBandwidth(bw);
+  if(state != RADIOLIB_ERR_NONE) {
+    RADIOLIB_DEBUG_BASIC_PRINTLN("SX128x LoRa begin() failed at setBandwidth(%.3f kHz) [%d]", bw, state);
+  }
   RADIOLIB_ASSERT(state);
 
   state = setSpreadingFactor(sf);
+  if(state != RADIOLIB_ERR_NONE) {
+    RADIOLIB_DEBUG_BASIC_PRINTLN("SX128x LoRa begin() failed at setSpreadingFactor(%d) [%d]", sf, state);
+  }
   RADIOLIB_ASSERT(state);
 
   state = setCodingRate(cr);
+  if(state != RADIOLIB_ERR_NONE) {
+    RADIOLIB_DEBUG_BASIC_PRINTLN("SX128x LoRa begin() failed at setCodingRate(%d) [%d]", cr, state);
+  }
   RADIOLIB_ASSERT(state);
 
   state = setSyncWord(syncWord);
+  if(state != RADIOLIB_ERR_NONE) {
+    RADIOLIB_DEBUG_BASIC_PRINTLN("SX128x LoRa begin() failed at setSyncWord(0x%02X) [%d]", syncWord, state);
+  }
   RADIOLIB_ASSERT(state);
 
   state = setPreambleLength(preambleLength);
+  if(state != RADIOLIB_ERR_NONE) {
+    RADIOLIB_DEBUG_BASIC_PRINTLN("SX128x LoRa begin() failed at setPreambleLength(%d) [%d]", preambleLength, state);
+  }
   RADIOLIB_ASSERT(state);
 
   state = setOutputPower(pwr);
+  if(state != RADIOLIB_ERR_NONE) {
+    RADIOLIB_DEBUG_BASIC_PRINTLN("SX128x LoRa begin() failed at setOutputPower(%d dBm) [%d]", pwr, state);
+  }
   RADIOLIB_ASSERT(state);
 
   return(state);


### PR DESCRIPTION
## Problem

When `SX128x::begin()` fails, the caller receives only a numeric error code. With `RADIOLIB_DEBUG_BASIC` enabled the existing output identifies the chip-not-found case but gives no indication of *which configuration step* failed or *with what parameter*. This makes debugging parameter errors (wrong bandwidth, out-of-range power, etc.) unnecessarily difficult.

## Fix

Replace the silent `RADIOLIB_ASSERT(state)` calls in `SX128x::begin()` with explicit checks that emit a `RADIOLIB_DEBUG_BASIC_PRINTLN` message on failure, including the step name, the parameter value passed, and the error code:

```
SX128x LoRa begin() failed at setBandwidth(203.000 kHz) [-8]
SX128x LoRa begin() failed at setOutputPower(25 dBm) [-13]
SX128x LoRa begin() failed at setFrequency(9999.000 MHz) [-12]
```

Output is **gated behind `RADIOLIB_DEBUG_BASIC`** — release builds are completely unaffected. Error code semantics and return values are unchanged.

## Related

- #1757 — root cause that surfaced this gap (bandwidth parameter mismatch hard to diagnose)
- PR #1756 — BW snapping fix