### PR TITLE
docs(SX1278): document NRESET=NC crystal startup workaround in reset()

### DIFF
--- a/src/modules/SX127x/SX1278.cpp
+++ b/src/modules/SX127x/SX1278.cpp
@@ -74,6 +74,21 @@ int16_t SX1278::beginFSK(float freq, float br, float freqDev, float rxBw, int8_t
 }
 
 void SX1278::reset() {
+  // When NRESET is RADIOLIB_NC the GPIO calls below are no-ops (ArduinoHal
+  // skips NC pins) but the delays still execute. This occurs on designs where
+  // NRESET is tied to the board power-enable line (e.g. ESP32 CHIP_PU) rather
+  // than a dedicated GPIO. In that case no actual chip reset occurs and the
+  // crystal oscillator state is unchanged.
+  //
+  // Consequence for begin(): the SX127x powers on in FSK sleep mode with the
+  // crystal stopped. RadioLib's begin() transitions sleep -> standby in ~20 µs
+  // (a register write), which is too fast for a cold crystal start (~2-5 ms).
+  // Intermittent CHIP_NOT_FOUND or corrupted register reads can result.
+  //
+  // Workaround when NRESET=RADIOLIB_NC: before calling begin(), manually step
+  // the chip through FSK sleep -> LoRa sleep (5 ms) -> LoRa standby via raw
+  // SPI register writes. This pre-warms the crystal so begin() sees a stable
+  // oscillator. See SX1278 datasheet §5.4.8 and application note AN1200.24.
   Module* mod = this->getMod();
   mod->hal->pinMode(mod->getRst(), mod->hal->GpioModeOutput);
   mod->hal->digitalWrite(mod->getRst(), mod->hal->GpioLevelLow);


### PR DESCRIPTION
## Summary

Adds a documentation comment to `SX1278::reset()` (and by inheritance `SX1276::reset()`) explaining the behavior and workaround when `NRESET=RADIOLIB_NC`.

Fixes #1759.

## What changed

`SX1278::reset()` — added a block comment explaining:

- When `NRESET=RADIOLIB_NC`, the `ArduinoHal` skips all GPIO operations, so no actual chip reset occurs
- The SX127x starts in FSK sleep with the crystal stopped; `begin()`'s sleep → standby transition is ~20 µs, too short for cold crystal startup (~2–5 ms)
- This causes intermittent `CHIP_NOT_FOUND` (-2) or corrupted register reads on affected hardware
- Workaround: manually step FSK sleep → LoRa sleep → LoRa standby via raw SPI before calling `begin()`

No behavior change — comment only.

## Test plan

- [ ] Verify no compilation errors (`SX1276`, `SX1278`, `SX1272` targets)
- [ ] Verify `SX1278::reset()` behavior is unchanged on hardware with NRESET connected