### PR TITLE
fix(SX128x): send NOP wakeup in reset() before standby

### DIFF
--- a/src/modules/SX128x/SX128x.cpp
+++ b/src/modules/SX128x/SX128x.cpp
@@ -201,11 +201,12 @@ int16_t SX128x::reset(bool verify) {
     return(RADIOLIB_ERR_NONE);
   }
 
-  // set mode to standby
+  // set mode to standby - send NOP first to wake the chip if it is in sleep
+  // (in sleep BUSY is HIGH; without the NOP the standby command never gets through)
   RadioLibTime_t start = this->mod->hal->millis();
   while(true) {
     // try to set mode to standby
-    int16_t state = standby();
+    int16_t state = standby(RADIOLIB_SX128X_STANDBY_RC, true);
     if(state == RADIOLIB_ERR_NONE) {
       // standby command successful
       return(RADIOLIB_ERR_NONE);


### PR DESCRIPTION
## Summary

Fixes #1761.

`reset()` called `standby()` without `wakeup=true`. When the chip is in sleep mode, BUSY is HIGH and the chip ignores all SPI commands until a NOP is received. Every `standby()` attempt timed out, causing `findChip()` to return `CHIP_NOT_FOUND` after the 3-second retry window.

## Change

`src/modules/SX128x/SX128x.cpp` — one line in `reset()`:

```cpp
// before
int16_t state = standby();

// after  
int16_t state = standby(RADIOLIB_SX128X_STANDBY_RC, true);
```

`standby(..., true)` sends a NOP command (0xC0) before SetStandby, waking the chip from sleep before attempting the standby transition. Sending NOP to an already-awake chip is a no-op per the datasheet.

## Test plan

- [ ] `begin()` succeeds after `sleep()` without requiring a hardware power cycle
- [ ] `begin()` still succeeds on fresh power-on (NOP to awake chip is harmless)
- [ ] No regression on SX1280/SX1281/SX1282 targets