### PR TITLE
[LR11x0][LR2021] Add support for duty cycle Rx

### DIFF
--- a/src/modules/LR11x0/LR11x0.cpp
+++ b/src/modules/LR11x0/LR11x0.cpp
@@ -416,6 +416,28 @@ int16_t LR11x0::startReceiveDutyCycle(uint32_t rxPeriod, uint32_t sleepPeriod, R
   return(this->setRxDutyCycle(rxPeriodRaw, sleepPeriodRaw, RADIOLIB_LR11X0_RX_DUTY_CYCLE_MODE_RX));
 }
 
+int16_t LR11x0::startReceiveDutyCycleAuto(uint16_t senderPreambleLength, uint16_t minSymbols, RadioLibIrqFlags_t irqFlags, RadioLibIrqFlags_t irqMask) {
+  // calculate the sleep and wake periods
+  uint32_t wakePeriod = 0;
+  uint32_t sleepPeriod = 0;
+  DataRate_t dr = {
+    .lora = {
+      .spreadingFactor = this->spreadingFactor,
+      .bandwidth = this->bandwidthKhz,
+      .codingRate = this->codingRate,
+    }
+  };
+  int16_t state = calculateRxDutyCycle(senderPreambleLength, this->preambleLengthLoRa, minSymbols, &dr, &wakePeriod, &sleepPeriod);
+  RADIOLIB_ASSERT(state);
+
+  // If our sleep period is shorter than our transition time, just use the standard startReceive
+  if(sleepPeriod < this->tcxoDelay + 1016) {
+    return(startReceive(RADIOLIB_LR11X0_RX_TIMEOUT_INF, irqFlags, irqMask));
+  }
+
+  return(startReceiveDutyCycle(wakePeriod, sleepPeriod, irqFlags, irqMask));
+}
+
 int16_t LR11x0::readData(uint8_t* data, size_t len) {
   // check active modem
   int16_t state = RADIOLIB_ERR_NONE;

--- a/src/modules/LR11x0/LR11x0.cpp
+++ b/src/modules/LR11x0/LR11x0.cpp
@@ -1733,6 +1733,13 @@ int16_t LR11x0::config(uint8_t modem) {
   RADIOLIB_ASSERT(state);
   #endif
 
+  // enable driving DIOs in sleep mode
+  // this prevents IRQ going high when the device goes to sleep
+  // especially when using Rx duty cycle, this woukld make it look like received packets
+  // there seems to be no measurable impact on power consumption in sleep mode
+  state = this->driveDiosInSleepMode(true);
+  RADIOLIB_ASSERT(state);
+
   // set modem
   state = this->setPacketType(modem);
   return(state);

--- a/src/modules/LR11x0/LR11x0.cpp
+++ b/src/modules/LR11x0/LR11x0.cpp
@@ -382,6 +382,40 @@ int16_t LR11x0::startReceive() {
   return(this->startReceive(RADIOLIB_LR11X0_RX_TIMEOUT_INF, RADIOLIB_IRQ_RX_DEFAULT_FLAGS, RADIOLIB_IRQ_RX_DEFAULT_MASK, 0));
 }
 
+int16_t LR11x0::startReceiveDutyCycle(uint32_t rxPeriod, uint32_t sleepPeriod, RadioLibIrqFlags_t irqFlags, RadioLibIrqFlags_t irqMask) {
+  // datasheet claims time to go to sleep is ~500us, same to wake up, compensate for that with 1 ms + TCXO delay
+  uint32_t transitionTime = this->tcxoDelay + 1000;
+  sleepPeriod -= transitionTime;
+
+  // divide by 30.517 microseconds (RTC period, 1/32.768 kHz)
+  uint32_t rxPeriodRaw = (rxPeriod * 32768UL) / 1000000UL;
+  uint32_t sleepPeriodRaw = (sleepPeriod * 32768UL) / 1000000UL;
+
+  // check 24 bit limit and zero value (likely not intended)
+  if((rxPeriodRaw & 0xFF000000) || (rxPeriodRaw == 0)) {
+    return(RADIOLIB_ERR_INVALID_RX_PERIOD);
+  }
+
+  // this check of the high byte also catches underflow when we subtracted transitionTime
+  if((sleepPeriodRaw & 0xFF000000) || (sleepPeriodRaw == 0)) {
+    return(RADIOLIB_ERR_INVALID_SLEEP_PERIOD);
+  }
+
+  // set up Rx mode
+  RadioModeConfig_t cfg = {
+    .receive = {
+      .timeout = RADIOLIB_LR11X0_RX_TIMEOUT_INF,
+      .irqFlags = irqFlags,
+      .irqMask = irqMask,
+      .len = 0,
+    }
+  };
+  int16_t state = this->stageMode(RADIOLIB_RADIO_MODE_RX, &cfg);
+  RADIOLIB_ASSERT(state);
+
+  return(this->setRxDutyCycle(rxPeriodRaw, sleepPeriodRaw, RADIOLIB_LR11X0_RX_DUTY_CYCLE_MODE_RX));
+}
+
 int16_t LR11x0::readData(uint8_t* data, size_t len) {
   // check active modem
   int16_t state = RADIOLIB_ERR_NONE;
@@ -1032,6 +1066,7 @@ int16_t LR11x0::setTCXO(float voltage, uint32_t delay) {
   }
 
   // calculate delay value
+  this->tcxoDelay = delay;
   uint32_t delayValue = (uint32_t)((float)delay / 30.52f);
   if(delayValue == 0) {
     delayValue = 1;

--- a/src/modules/LR11x0/LR11x0.h
+++ b/src/modules/LR11x0/LR11x0.h
@@ -209,6 +209,20 @@ class LR11x0: public LRxxxx {
     int16_t startReceive() override;
 
     /*!
+      \brief Interrupt-driven receive method where the device mostly sleeps and periodically wakes to listen.
+      Note that this function assumes the unit will take 500us + TCXO_delay to change state.
+      See datasheet section 13.1.7, version 1.2.
+
+      \param rxPeriod The duration the receiver will be in Rx mode, in microseconds.
+      \param sleepPeriod The duration the receiver will not be in Rx mode, in microseconds.
+
+      \param irqFlags Sets the IRQ flags, defaults to RX done, RX timeout, CRC error and header error. 
+      \param irqMask Sets the mask of IRQ flags that will trigger DIO1, defaults to RX done.
+      \returns \ref status_codes
+    */
+    int16_t startReceiveDutyCycle(uint32_t rxPeriod, uint32_t sleepPeriod, RadioLibIrqFlags_t irqFlags = RADIOLIB_IRQ_RX_DEFAULT_FLAGS, RadioLibIrqFlags_t irqMask = RADIOLIB_IRQ_RX_DEFAULT_MASK);
+
+    /*!
       \brief Reads data received after calling startReceive method. When the packet length is not known in advance,
       getPacketLength method must be called BEFORE calling readData!
       \param data Pointer to array to save the received binary data.

--- a/src/modules/LR11x0/LR11x0.h
+++ b/src/modules/LR11x0/LR11x0.h
@@ -223,6 +223,26 @@ class LR11x0: public LRxxxx {
     int16_t startReceiveDutyCycle(uint32_t rxPeriod, uint32_t sleepPeriod, RadioLibIrqFlags_t irqFlags = RADIOLIB_IRQ_RX_DEFAULT_FLAGS, RadioLibIrqFlags_t irqMask = RADIOLIB_IRQ_RX_DEFAULT_MASK);
 
     /*!
+      \brief Calls \ref startReceiveDutyCycle with rxPeriod and sleepPeriod set so the unit shouldn't miss any messages.
+      \param senderPreambleLength Expected preamble length of the messages to receive.
+      If set to zero, the currently configured preamble length will be used. Defaults to zero.
+      This value cannot exceed the configured preamble length. If the sender preamble length is variable, set the
+      maximum expected length by calling setPreambleLength(maximumExpectedLength) prior to this method, and use the
+      minimum expected length here.
+
+      \param minSymbols Ensure that the unit will catch at least this many symbols of any preamble of the specified senderPreambleLength.
+      To reliably latch a preamble, the receiver requires 8 symbols for SF7-12 and 12 symbols for SF5-6 (see datasheet section 6.1.1.1, version 1.2).
+      If set to zero, the minimum required symbols will be used. Defaults to 0.
+
+      If senderPreambleLength is less than 2*minSymbols + 1, this method is equivalent to startReceive().
+
+      \param irqFlags Sets the IRQ flags, defaults to RX done, RX timeout, CRC error and header error.
+      \param irqMask Sets the mask of IRQ flags that will trigger DIO1, defaults to RX done.
+      \returns \ref status_codes
+    */
+    int16_t startReceiveDutyCycleAuto(uint16_t senderPreambleLength = 0, uint16_t minSymbols = 0, RadioLibIrqFlags_t irqFlags = RADIOLIB_IRQ_RX_DEFAULT_FLAGS, RadioLibIrqFlags_t irqMask = RADIOLIB_IRQ_RX_DEFAULT_MASK);
+
+    /*!
       \brief Reads data received after calling startReceive method. When the packet length is not known in advance,
       getPacketLength method must be called BEFORE calling readData!
       \param data Pointer to array to save the received binary data.

--- a/src/modules/LR11x0/LR_common.h
+++ b/src/modules/LR11x0/LR_common.h
@@ -164,6 +164,7 @@ class LRxxxx: public PhysicalLayer {
     
     float freqMHz = 0;
     uint32_t rxTimeout = 0;
+    uint32_t tcxoDelay = 0;
 
     // cached LoRa parameters
     uint8_t bandwidth = 0, spreadingFactor = 0, codingRate = 0, ldrOptimize = 0, crcTypeLoRa = 0, headerType = 0;

--- a/src/modules/LR2021/LR2021.cpp
+++ b/src/modules/LR2021/LR2021.cpp
@@ -448,6 +448,65 @@ int16_t LR2021::startReceive() {
   return(this->startReceive(RADIOLIB_LR2021_RX_TIMEOUT_INF, RADIOLIB_IRQ_RX_DEFAULT_FLAGS, RADIOLIB_IRQ_RX_DEFAULT_MASK, 0));
 }
 
+int16_t LR2021::startReceiveDutyCycle(uint32_t rxPeriod, uint32_t sleepPeriod, RadioLibIrqFlags_t irqFlags, RadioLibIrqFlags_t irqMask) {
+  // datasheet claims time to go to sleep is ~500us, same to wake up, compensate for that with 1 ms + TCXO delay
+  uint32_t transitionTime = this->tcxoDelay + 1000;
+  sleepPeriod -= transitionTime;
+
+  // divide by 30.517 microseconds (RTC period, 1/32.768 kHz)
+  // the datasheet claims the RTC frequency is 32 kHz; however, using that makes the timing inaccurate
+  // so it looks like the actual value is the 32.768 kHz used on the previous LR11xx chips
+  uint32_t rxPeriodRaw = (rxPeriod * 32768UL) / 1000000UL;
+  uint32_t sleepPeriodRaw = (sleepPeriod * 32768UL) / 1000000UL;
+
+  // check 24 bit limit and zero value (likely not intended)
+  if((rxPeriodRaw & 0xFF000000) || (rxPeriodRaw == 0)) {
+    return(RADIOLIB_ERR_INVALID_RX_PERIOD);
+  }
+
+  // this check of the high byte also catches underflow when we subtracted transitionTime
+  if((sleepPeriodRaw & 0xFF000000) || (sleepPeriodRaw == 0)) {
+    return(RADIOLIB_ERR_INVALID_SLEEP_PERIOD);
+  }
+
+  // set up Rx mode
+  RadioModeConfig_t cfg = {
+    .receive = {
+      .timeout = RADIOLIB_LR2021_RX_TIMEOUT_INF,
+      .irqFlags = irqFlags,
+      .irqMask = irqMask,
+      .len = 0,
+    }
+  };
+  int16_t state = this->stageMode(RADIOLIB_RADIO_MODE_RX, &cfg);
+  RADIOLIB_ASSERT(state);
+
+  // on LR2021, the second parameter is total period of the cycle, not the sleep duration
+  return(this->setRxDutyCycle(rxPeriodRaw, rxPeriodRaw + sleepPeriodRaw, RADIOLIB_LR2021_RX_DUTY_CYCLE_MODE_RX));
+}
+
+int16_t LR2021::startReceiveDutyCycleAuto(uint16_t senderPreambleLength, uint16_t minSymbols, RadioLibIrqFlags_t irqFlags, RadioLibIrqFlags_t irqMask) {
+  // calculate the sleep and wake periods
+  uint32_t wakePeriod = 0;
+  uint32_t sleepPeriod = 0;
+  DataRate_t dr = {
+    .lora = {
+      .spreadingFactor = this->spreadingFactor,
+      .bandwidth = this->bandwidthKhz,
+      .codingRate = this->codingRate,
+    }
+  };
+  int16_t state = calculateRxDutyCycle(senderPreambleLength, this->preambleLengthLoRa, minSymbols, &dr, &wakePeriod, &sleepPeriod);
+  RADIOLIB_ASSERT(state);
+
+  // If our sleep period is shorter than our transition time, just use the standard startReceive
+  if(sleepPeriod < this->tcxoDelay + 1016) {
+    return(startReceive(RADIOLIB_LR2021_RX_TIMEOUT_INF, irqFlags, irqMask));
+  }
+
+  return(startReceiveDutyCycle(wakePeriod, sleepPeriod, irqFlags, irqMask));
+}
+
 int16_t LR2021::readData(uint8_t* data, size_t len) {
   // check active modem
   int16_t state = RADIOLIB_ERR_NONE;

--- a/src/modules/LR2021/LR2021.cpp
+++ b/src/modules/LR2021/LR2021.cpp
@@ -752,7 +752,7 @@ int16_t LR2021::config(uint8_t modem) {
 
   // set the DIO to IRQ
   // DIO5 can only be pull up
-  uint8_t pull = this->irqDioNum == 5 ? RADIOLIB_LR2021_DIO_SLEEP_PULL_UP : RADIOLIB_LR2021_DIO_SLEEP_PULL_NONE;
+  uint8_t pull = this->irqDioNum == 5 ? RADIOLIB_LR2021_DIO_SLEEP_PULL_UP : RADIOLIB_LR2021_DIO_SLEEP_PULL_DOWN;
   state = this->setDioFunction(this->irqDioNum, RADIOLIB_LR2021_DIO_FUNCTION_IRQ, pull);
   RADIOLIB_ASSERT(state);
 

--- a/src/modules/LR2021/LR2021.h
+++ b/src/modules/LR2021/LR2021.h
@@ -44,7 +44,7 @@ class LR2021: public LRxxxx {
 
     /*! 
       \brief Determines the type of Lora CAD to perform, either "standard" CAD
-      (same as is implem,ented LR11x0, SX126x and others), or a "fast" CAD if set to true.
+      (same as is implemented LR11x0, SX126x and others), or a "fast" CAD if set to true.
       If there is no signal to be detected, fast CAD should return faster than standard CAD.
     */
     bool fastCad = false;

--- a/src/modules/LR2021/LR2021.h
+++ b/src/modules/LR2021/LR2021.h
@@ -253,6 +253,40 @@ class LR2021: public LRxxxx {
     int16_t startReceive() override;
 
     /*!
+      \brief Interrupt-driven receive method where the device mostly sleeps and periodically wakes to listen.
+      Note that this function assumes the unit will take 500us + TCXO_delay to change state.
+      See datasheet section 13.1.7, version 1.2.
+
+      \param rxPeriod The duration the receiver will be in Rx mode, in microseconds.
+      \param sleepPeriod The duration the receiver will not be in Rx mode, in microseconds.
+
+      \param irqFlags Sets the IRQ flags, defaults to RX done, RX timeout, CRC error and header error. 
+      \param irqMask Sets the mask of IRQ flags that will trigger DIO1, defaults to RX done.
+      \returns \ref status_codes
+    */
+    int16_t startReceiveDutyCycle(uint32_t rxPeriod, uint32_t sleepPeriod, RadioLibIrqFlags_t irqFlags = RADIOLIB_IRQ_RX_DEFAULT_FLAGS, RadioLibIrqFlags_t irqMask = RADIOLIB_IRQ_RX_DEFAULT_MASK);
+
+    /*!
+      \brief Calls \ref startReceiveDutyCycle with rxPeriod and sleepPeriod set so the unit shouldn't miss any messages.
+      \param senderPreambleLength Expected preamble length of the messages to receive.
+      If set to zero, the currently configured preamble length will be used. Defaults to zero.
+      This value cannot exceed the configured preamble length. If the sender preamble length is variable, set the
+      maximum expected length by calling setPreambleLength(maximumExpectedLength) prior to this method, and use the
+      minimum expected length here.
+
+      \param minSymbols Ensure that the unit will catch at least this many symbols of any preamble of the specified senderPreambleLength.
+      To reliably latch a preamble, the receiver requires 8 symbols for SF7-12 and 12 symbols for SF5-6 (see datasheet section 6.1.1.1, version 1.2).
+      If set to zero, the minimum required symbols will be used. Defaults to 0.
+
+      If senderPreambleLength is less than 2*minSymbols + 1, this method is equivalent to startReceive().
+
+      \param irqFlags Sets the IRQ flags, defaults to RX done, RX timeout, CRC error and header error.
+      \param irqMask Sets the mask of IRQ flags that will trigger DIO1, defaults to RX done.
+      \returns \ref status_codes
+    */
+    int16_t startReceiveDutyCycleAuto(uint16_t senderPreambleLength = 0, uint16_t minSymbols = 0, RadioLibIrqFlags_t irqFlags = RADIOLIB_IRQ_RX_DEFAULT_FLAGS, RadioLibIrqFlags_t irqMask = RADIOLIB_IRQ_RX_DEFAULT_MASK);
+
+    /*!
       \brief Reads data received after calling startReceive method. When the packet length is not known in advance,
       getPacketLength method must be called BEFORE calling readData!
       \param data Pointer to array to save the received binary data.
@@ -746,7 +780,7 @@ class LR2021: public LRxxxx {
     int16_t setRx(uint32_t timeout);
     int16_t setTx(uint32_t timeout);
     int16_t setRxTxFallbackMode(uint8_t mode);
-    int16_t setRxDutyCycle(uint32_t rxMaxTime, uint32_t cycleTime, uint8_t cfg);
+    int16_t setRxDutyCycle(uint32_t rxMaxTime, uint32_t cycleTime, uint8_t mode);
     int16_t autoTxRx(uint32_t delay, uint8_t mode, uint32_t timeout);
     int16_t getRxPktLength(uint16_t* len);
     int16_t resetRxStats(void);

--- a/src/modules/LR2021/LR2021_cmds_chip_control.cpp
+++ b/src/modules/LR2021/LR2021_cmds_chip_control.cpp
@@ -104,11 +104,11 @@ int16_t LR2021::setRxTxFallbackMode(uint8_t mode) {
   return(this->SPIcommand(RADIOLIB_LR2021_CMD_SET_RX_TX_FALLBACK_MODE, true, &mode, sizeof(mode)));
 }
 
-int16_t LR2021::setRxDutyCycle(uint32_t rxMaxTime, uint32_t cycleTime, uint8_t cfg) {
+int16_t LR2021::setRxDutyCycle(uint32_t rxMaxTime, uint32_t cycleTime, uint8_t mode) {
   uint8_t buff[] = {
     (uint8_t)((rxMaxTime >> 16) & 0xFF), (uint8_t)((rxMaxTime >> 8) & 0xFF), (uint8_t)(rxMaxTime & 0xFF),
     (uint8_t)((cycleTime >> 16) & 0xFF), (uint8_t)((cycleTime >> 8) & 0xFF), (uint8_t)(cycleTime & 0xFF),
-    cfg
+    (uint8_t)(mode << 4),
   };
   return(this->SPIcommand(RADIOLIB_LR2021_CMD_SET_RX_DUTY_CYCLE, true, buff, sizeof(buff)));
 }

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -512,44 +512,18 @@ int16_t SX126x::startReceiveDutyCycle(uint32_t rxPeriod, uint32_t sleepPeriod, R
 }
 
 int16_t SX126x::startReceiveDutyCycleAuto(uint16_t senderPreambleLength, uint16_t minSymbols, RadioLibIrqFlags_t irqFlags, RadioLibIrqFlags_t irqMask) {
-  if(senderPreambleLength == 0) {
-    senderPreambleLength = this->preambleLengthLoRa;
-  } else if (senderPreambleLength > this->preambleLengthLoRa) {
-    // the unit must be configured to expect a preamble length at least as long as the sender is using
-    return(RADIOLIB_ERR_INVALID_PREAMBLE_LENGTH);
-  }
-  if(minSymbols == 0) {
-    if (this->spreadingFactor <= 6) {
-      minSymbols = 12;
-    } else {
-      minSymbols = 8;
+  // calculate the sleep and wake periods
+  uint32_t wakePeriod = 0;
+  uint32_t sleepPeriod = 0;
+  DataRate_t dr = {
+    .lora = {
+      .spreadingFactor = this->spreadingFactor,
+      .bandwidth = this->bandwidthKhz,
+      .codingRate = this->codingRate,
     }
-  }
-
-  // worst case is that the sender starts transmitting when we're just less than minSymbols from going back to sleep.
-  // in this case, we don't catch minSymbols before going to sleep,
-  // so we must be awake for at least that long before the sender stops transmitting.
-  uint16_t sleepSymbols = senderPreambleLength - 2 * minSymbols;
-
-  // if we're not to sleep at all, just use the standard startReceive.
-  if(2 * minSymbols > senderPreambleLength) {
-    return(startReceive(RADIOLIB_SX126X_RX_TIMEOUT_INF, irqFlags, irqMask));
-  }
-
-  uint32_t symbolLength = ((uint32_t)(10 * 1000) << this->spreadingFactor) / (10 * this->bandwidthKhz);
-  uint32_t sleepPeriod = symbolLength * sleepSymbols;
-  RADIOLIB_DEBUG_BASIC_PRINTLN("Auto sleep period: %lu", (long unsigned int)sleepPeriod);
-
-  // when the unit detects a preamble, it starts a timer that will timeout if it doesn't receive a header in time.
-  // the duration is sleepPeriod + 2 * wakePeriod.
-  // The sleepPeriod doesn't take into account shutdown and startup time for the unit (~1ms)
-  // We need to ensure that the timeout is longer than senderPreambleLength.
-  // So we must satisfy: wakePeriod > (preamblePeriod - (sleepPeriod - 1000)) / 2. (A)
-  // we also need to ensure the unit is awake to see at least minSymbols. (B)
-  uint32_t wakePeriod = RADIOLIB_MAX(
-    (symbolLength * (senderPreambleLength + 1) - (sleepPeriod - 1000)) / 2, // (A)
-    symbolLength * (minSymbols + 1)); //(B)
-  RADIOLIB_DEBUG_BASIC_PRINTLN("Auto wake period: %lu", (long unsigned int)wakePeriod);
+  };
+  int16_t state = calculateRxDutyCycle(senderPreambleLength, this->preambleLengthLoRa, minSymbols, &dr, &wakePeriod, &sleepPeriod);
+  RADIOLIB_ASSERT(state);
 
   // If our sleep period is shorter than our transition time, just use the standard startReceive
   if(sleepPeriod < this->tcxoDelay + 1016) {

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -494,7 +494,16 @@ int16_t SX126x::startReceiveDutyCycle(uint32_t rxPeriod, uint32_t sleepPeriod, R
     return(RADIOLIB_ERR_INVALID_SLEEP_PERIOD);
   }
 
-  int16_t state = startReceiveCommon(RADIOLIB_SX126X_RX_TIMEOUT_INF, irqFlags, irqMask);
+  // set up Rx mode
+  RadioModeConfig_t cfg = {
+    .receive = {
+      .timeout = RADIOLIB_SX126X_RX_TIMEOUT_INF,
+      .irqFlags = irqFlags,
+      .irqMask = irqMask,
+      .len = 0,
+    }
+  };
+  int16_t state = this->stageMode(RADIOLIB_RADIO_MODE_RX, &cfg);
   RADIOLIB_ASSERT(state);
 
   const uint8_t data[6] = {(uint8_t)((rxPeriodRaw >> 16) & 0xFF), (uint8_t)((rxPeriodRaw >> 8) & 0xFF), (uint8_t)(rxPeriodRaw & 0xFF),
@@ -548,40 +557,6 @@ int16_t SX126x::startReceiveDutyCycleAuto(uint16_t senderPreambleLength, uint16_
   }
 
   return(startReceiveDutyCycle(wakePeriod, sleepPeriod, irqFlags, irqMask));
-}
-
-int16_t SX126x::startReceiveCommon(uint32_t timeout, RadioLibIrqFlags_t irqFlags, RadioLibIrqFlags_t irqMask) {
-  // ensure we are in standby
-  int16_t state = standby();
-  RADIOLIB_ASSERT(state);
-
-  // set DIO mapping
-  if(timeout != RADIOLIB_SX126X_RX_TIMEOUT_INF) {
-    irqMask |= (1UL << RADIOLIB_IRQ_TIMEOUT);
-  }
-  state = setDioIrqParams(getIrqMapped(irqFlags), getIrqMapped(irqMask));
-  RADIOLIB_ASSERT(state);
-
-  // set buffer pointers
-  state = setBufferBaseAddress();
-  RADIOLIB_ASSERT(state);
-
-  // clear interrupt flags
-  state = clearIrqStatus();
-  RADIOLIB_ASSERT(state);
-
-  // restore original packet length
-  uint8_t modem = getPacketType();
-  if(modem == RADIOLIB_SX126X_PACKET_TYPE_LORA) {
-    state = setPacketParams(this->preambleLengthLoRa, this->crcTypeLoRa, this->implicitLen, this->headerType, this->invertIQEnabled);
-  } else if(modem == RADIOLIB_SX126X_PACKET_TYPE_GFSK) {
-    state = setPacketParamsFSK(this->preambleLengthFSK, this->preambleDetLength, this->crcTypeFSK, this->syncWordLength, RADIOLIB_SX126X_GFSK_ADDRESS_FILT_OFF, this->whitening,
-      this->packetType, (this->packetType == RADIOLIB_SX126X_GFSK_PACKET_FIXED) ? this->implicitLen : RADIOLIB_SX126X_MAX_PACKET_LENGTH);
-  } else {
-    return(RADIOLIB_ERR_UNKNOWN);
-  }
-
-  return(state);
 }
 
 int16_t SX126x::readData(uint8_t* data, size_t len) {
@@ -1006,8 +981,35 @@ int16_t SX126x::stageMode(RadioModeType_t mode, RadioModeConfig_t* cfg) {
         this->implicitLen = cfg->receive.len;
       }
 
-      state = startReceiveCommon(cfg->receive.timeout, cfg->receive.irqFlags, cfg->receive.irqMask);
+      // ensure we are in standby
+      state = standby();
       RADIOLIB_ASSERT(state);
+
+      // set DIO mapping
+      if(cfg->receive.timeout != RADIOLIB_SX126X_RX_TIMEOUT_INF) {
+        cfg->receive.irqMask |= (1UL << RADIOLIB_IRQ_TIMEOUT);
+      }
+      state = setDioIrqParams(getIrqMapped(cfg->receive.irqFlags), getIrqMapped(cfg->receive.irqMask));
+      RADIOLIB_ASSERT(state);
+
+      // set buffer pointers
+      state = setBufferBaseAddress();
+      RADIOLIB_ASSERT(state);
+
+      // clear interrupt flags
+      state = clearIrqStatus();
+      RADIOLIB_ASSERT(state);
+
+      // restore original packet length
+      uint8_t modem = getPacketType();
+      if(modem == RADIOLIB_SX126X_PACKET_TYPE_LORA) {
+        state = setPacketParams(this->preambleLengthLoRa, this->crcTypeLoRa, this->implicitLen, this->headerType, this->invertIQEnabled);
+      } else if(modem == RADIOLIB_SX126X_PACKET_TYPE_GFSK) {
+        state = setPacketParamsFSK(this->preambleLengthFSK, this->preambleDetLength, this->crcTypeFSK, this->syncWordLength, RADIOLIB_SX126X_GFSK_ADDRESS_FILT_OFF, this->whitening,
+          this->packetType, (this->packetType == RADIOLIB_SX126X_GFSK_PACKET_FIXED) ? this->implicitLen : RADIOLIB_SX126X_MAX_PACKET_LENGTH);
+      } else {
+        return(RADIOLIB_ERR_UNKNOWN);
+      }
 
       // if max(uint32_t) is used, revert to RxContinuous
       if(cfg->receive.timeout == 0xFFFFFFFF) {

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -934,7 +934,6 @@ class SX126x: public PhysicalLayer {
     int16_t modSetup(float tcxoVoltage, bool useRegulatorLDO, uint8_t modem);
     int16_t config(uint8_t modem);
     bool findChip(const char* verStr);
-    int16_t startReceiveCommon(uint32_t timeout = RADIOLIB_SX126X_RX_TIMEOUT_INF, RadioLibIrqFlags_t irqFlags = RADIOLIB_IRQ_RX_DEFAULT_FLAGS, RadioLibIrqFlags_t irqMask = RADIOLIB_IRQ_RX_DEFAULT_MASK);
     int16_t setPacketMode(uint8_t mode, uint8_t len);
     int16_t setHeaderType(uint8_t hdrType, size_t len = 0xFF);
     int16_t directMode();

--- a/src/protocols/PhysicalLayer/PhysicalLayer.cpp
+++ b/src/protocols/PhysicalLayer/PhysicalLayer.cpp
@@ -577,3 +577,53 @@ void PhysicalLayer::setTimerFlag() {
   mod->TimerFlag = true;
 }
 #endif
+
+int16_t PhysicalLayer::calculateRxDutyCycle(size_t txPreLen, size_t rxPreLen, uint16_t minSymbols, DataRate_t* dr, uint32_t* wakePeriod, uint32_t* sleepPeriod) {
+  RADIOLIB_ASSERT_PTR(dr);
+  RADIOLIB_ASSERT_PTR(wakePeriod);
+  RADIOLIB_ASSERT_PTR(sleepPeriod);
+  
+  uint16_t senderPreambleLength = txPreLen;
+  if(senderPreambleLength == 0) {
+    senderPreambleLength = rxPreLen;
+  } else if(senderPreambleLength > rxPreLen) {
+    // the unit must be configured to expect a preamble length at least as long as the sender is using
+    return(RADIOLIB_ERR_INVALID_PREAMBLE_LENGTH);
+  }
+  if(minSymbols == 0) {
+    if(dr->lora.spreadingFactor <= 6) {
+      minSymbols = 12;
+    } else {
+      minSymbols = 8;
+    }
+  }
+
+  // if we're not to sleep at all, just use the standard startReceive
+  if(2 * minSymbols > senderPreambleLength) {
+    *sleepPeriod = 0;
+    RADIOLIB_DEBUG_BASIC_PRINTLN("Auto sleep period too short");
+    return(RADIOLIB_ERR_NONE);
+  }
+
+  // worst case is that the sender starts transmitting when we're just less than minSymbols from going back to sleep.
+  // in this case, we don't catch minSymbols before going to sleep,
+  // so we must be awake for at least that long before the sender stops transmitting.
+  uint16_t sleepSymbols = senderPreambleLength - 2 * minSymbols;
+
+  uint32_t symbolLength = ((uint32_t)(10 * 1000) << dr->lora.spreadingFactor) / (10 * dr->lora.bandwidth);
+  *sleepPeriod = symbolLength * sleepSymbols;
+  RADIOLIB_DEBUG_BASIC_PRINTLN("Auto sleep period: %lu", (long unsigned int)*sleepPeriod);
+
+  // when the unit detects a preamble, it starts a timer that will timeout if it doesn't receive a header in time.
+  // the duration is sleepPeriod + 2 * wakePeriod.
+  // The sleepPeriod doesn't take into account shutdown and startup time for the unit (~1ms)
+  // We need to ensure that the timeout is longer than senderPreambleLength.
+  // So we must satisfy: wakePeriod > (preamblePeriod - (sleepPeriod - 1000)) / 2. (A)
+  // we also need to ensure the unit is awake to see at least minSymbols. (B)
+  *wakePeriod = RADIOLIB_MAX(
+    (symbolLength * (senderPreambleLength + 1) - (*sleepPeriod - 1000)) / 2, // (A)
+    symbolLength * (minSymbols + 1)); //(B)
+  RADIOLIB_DEBUG_BASIC_PRINTLN("Auto wake period: %lu", (long unsigned int)*wakePeriod);
+
+  return(RADIOLIB_ERR_NONE);
+}

--- a/src/protocols/PhysicalLayer/PhysicalLayer.h
+++ b/src/protocols/PhysicalLayer/PhysicalLayer.h
@@ -825,6 +825,25 @@ class PhysicalLayer {
 
     #endif
 
+    /*!
+      \brief Calculates sleep and wake cycles for startReceiveDutyCycle methods so that the receiver should not miss any messages.
+      Useful only for LoRa modems. 
+      \param txPreLen Expected preamble length of the messages to receive.
+      If set to zero, the receiver preamble length will be used.
+      This value cannot exceed the configured preamble length. If the sender preamble length is variable, set the
+      maximum expected length by calling setPreambleLength(maximumExpectedLength) prior to this method, and use the
+      minimum expected length here.
+      \param rxPreLen Currently configured preamble length of the receiver (this radio).
+      \param minSymbols Ensure that the unit will catch at least this many symbols of any preamble of the specified senderPreambleLength.
+      To reliably latch a preamble, the receiver requires 8 symbols for SF7-12 and 12 symbols for SF5-6.
+      If set to zero, the minimum required symbols will be used.
+      \param dr Pointer to structure holding LoRa data rate information (only spreading factor and bandwidth are used).
+      \param wakePeriod Pointer to variable where the calculated wake period in microseconds will be stored.
+      \param sleePeriod Pointer to variable where the calculated sleep period in microseconds will be stored.
+      \returns \ref status_codes
+    */
+    int16_t calculateRxDutyCycle(size_t txPreLen, size_t rxPreLen, uint16_t minSymbols, DataRate_t* dr, uint32_t* wakePeriod, uint32_t* sleepPeriod);
+
 #if !RADIOLIB_GODMODE
   protected:
 #endif


### PR DESCRIPTION
This PR adds support for duty-cycle Rx with the same interface that is present on SX126x. It also does a minor change for LR11x0 DIO pins, which are now being driven in sleep mode. It doesn't seem to have any impact on power consumption, but without it, DIO pins on LR11x0 would float in sleep mode, which caused spurious interrupts being detected in the host MCU.

Similar issue is also present on LR2021 and is handled there by enabling pull-downs by default. An important note is that DIO5 on LR2021 can only have a pullup in sleep mode, making it unusable as IRQ when duty cycle is used.

Two cases were tested, `startReceiveDutyCycleAuto(16, 6);` and `startReceiveDutyCycle(5000000, 1000000);`. The latter allowed to measure the sleep/Rx periods with oscilloscope (when DIO pins start to float after entering sleep mode).

Closes #1769 