### PR TITLE
[LR11x0] Add SF6 compatibility with SX127x

### DIFF
--- a/src/modules/LR11x0/LR11x0.cpp
+++ b/src/modules/LR11x0/LR11x0.cpp
@@ -565,9 +565,11 @@ int16_t LR11x0::setSpreadingFactor(uint8_t sf, bool legacy) {
 
   RADIOLIB_CHECK_RANGE(sf, 5, 12, RADIOLIB_ERR_INVALID_SPREADING_FACTOR);
 
-  // TODO enable SF6 legacy mode
   if(legacy && (sf == 6)) {
-    //this->mod->SPIsetRegValue(RADIOLIB_LR11X0_REG_SF6_SX127X_COMPAT, RADIOLIB_LR11X0_SF6_SX127X, 18, 18);
+    // Enable LR1121 SF6 compatibility with SX127x family
+    // Register 0xF20414: bit18 = 1, bit23 = 0
+    state = this->writeRegMemMask32(RADIOLIB_LR11X0_REG_SF6_SX127X_COMPAT, (0x1UL << 18) | (0x1UL << 23), RADIOLIB_LR11X0_SF6_SX127X);
+    RADIOLIB_ASSERT(state);
   }
 
   // update modulation parameters


### PR DESCRIPTION
Adds proper SF6 compatibility mode support for LR1121 to match legacy SX127x family.

This configures register `0xF20414`:

* bit 18 = 1
* bit 23 = 0

