### PR TITLE
LR1121: override getVersionInfo to skip WiFi/GNSS reads

### DIFF
--- a/src/modules/LR11x0/LR1121.cpp
+++ b/src/modules/LR11x0/LR1121.cpp
@@ -5,4 +5,26 @@ LR1121::LR1121(Module* mod) : LR1120(mod) {
   chipType = RADIOLIB_LR11X0_DEVICE_LR1121;
 }
 
+int16_t LR1121::getVersionInfo(LR11x0VersionInfo_t* info) {
+  if(!info) {
+    return(RADIOLIB_ERR_MEMORY_ALLOCATION_FAILED);
+  }
+
+  // LR1121 only implements GetVersion. WiFi-scanning and GNSS-scanning
+  // firmware blocks don't exist on this silicon, so the corresponding
+  // SPI commands return errors. Reading just the GetVersion fields is
+  // sufficient for findChip() and any caller that wants the device
+  // identifier or base firmware version.
+  int16_t state = this->getVersion(&info->hardware, &info->device,
+                                   &info->fwMajor, &info->fwMinor);
+  RADIOLIB_ASSERT(state);
+
+  // Zero the LR1110 / LR1120-only fields so callers don't see garbage.
+  info->fwMajorWiFi = 0;
+  info->fwMinorWiFi = 0;
+  info->fwGNSS      = 0;
+  info->almanacGNSS = 0;
+  return(RADIOLIB_ERR_NONE);
+}
+
 #endif

--- a/src/modules/LR11x0/LR1121.h
+++ b/src/modules/LR11x0/LR1121.h
@@ -21,6 +21,17 @@ class LR1121: public LR1120 {
     */
     LR1121(Module* mod); // cppcheck-suppress noExplicitConstructor
 
+    /*!
+      \brief Read the chip's hardware / device / firmware version. Overrides
+      the LR11x0 implementation so it does NOT issue the WiFi-scanning and
+      GNSS-scanning version commands, which only exist on LR1110 / LR1120
+      silicon. On LR1121 those commands return an error, causing the
+      inherited findChip() to incorrectly report RADIOLIB_ERR_CHIP_NOT_FOUND
+      even when the GetVersion command returned the correct device ID.
+      \param info Pointer to LR11x0VersionInfo_t to fill in.
+    */
+    int16_t getVersionInfo(LR11x0VersionInfo_t* info) override;
+
 #if !RADIOLIB_GODMODE
   private:
 #endif

--- a/src/modules/LR11x0/LR11x0.h
+++ b/src/modules/LR11x0/LR11x0.h
@@ -688,7 +688,7 @@ class LR11x0: public LRxxxx {
       \param info Pointer to LR11x0VersionInfo_t structure to populate.
       \returns \ref status_codes
     */
-    int16_t getVersionInfo(LR11x0VersionInfo_t* info);
+    virtual int16_t getVersionInfo(LR11x0VersionInfo_t* info);
     
     /*!
       \brief Method to upload new firmware image to the device.


### PR DESCRIPTION
## Problem

`LR1121::begin()` returns `RADIOLIB_ERR_CHIP_NOT_FOUND (-2)` on real
LR1121 silicon even though the chip is alive and the `GetVersion`
command returns the correct device ID `0x03`.

Repro on a Lilygo T3S3 LR1121 board with this library at 6.5.0 and
6.6.0:

```
RLB_DBG: LR11x0 not found! (1 of 10 tries) RADIOLIB_LR11X0_CMD_GET_VERSION = 0x03
RLB_DBG: Expected: 0x03
... (10 attempts, every one reports the correct device byte)
RLB_DBG: No LR11x0 found!
```

## Root cause

`LR11x0::findChip(uint8_t ver)` calls `getVersionInfo(&info)` which
issues three SPI commands:

- `GetVersion` — works on every LR11x0 family member
- `WifiReadVersion` — implemented on LR1110/LR1120 only
- `GnssReadVersion` — implemented on LR1110/LR1120 only

On LR1121 the WiFi/GNSS commands return errors. `RADIOLIB_ASSERT`
propagates the error out of `getVersionInfo`, and `findChip` falls
into the not-found branch even though `info.device` is `0x03`.

This was anticipated — `LR1121.h` previously contained a `TODO` for
exactly this case:

```cpp
// TODO this is where overrides to disable GNSS+WiFi scanning methods on LR1121
// will be put once those are implemented
```

## Fix

Override `getVersionInfo()` in `LR1121` to call only `getVersion()`
and zero the LR1110/LR1120-only fields. Adds the `virtual` keyword
to `LR11x0::getVersionInfo()` so the override actually dispatches.

## Tested on

- Lilygo T3S3 with LR1121 module, sub-GHz HF, 869.85 MHz, EU868.
- Custom embedded firmware build. After the fix, `radio.begin()`
  returns `RADIOLIB_ERR_NONE`, the chip identifies as device `0x03`
  on the first attempt, and `setFrequency` / `setOutputPower` /
  `transmit` / `startReceive` all work as expected for a sub-GHz
  LoRa mesh.

## Notes

- No change to LR1110 or LR1120 behaviour — they continue using the
  inherited `LR11x0::getVersionInfo()` implementation.