### PR TITLE
Fix out-of-bounds read and memory leak in LoRaWAN parseDownlink

### DIFF
--- a/src/protocols/LoRaWAN/LoRaWAN.cpp
+++ b/src/protocols/LoRaWAN/LoRaWAN.cpp
@@ -1899,6 +1899,9 @@ int16_t LoRaWANNode::parseDownlink(uint8_t* data, size_t* len, uint8_t window, L
   // guard against integer underflow when downlinkMsgLen is too short
   uint8_t minLen = 1 + 4 + 1 + 2 + fOptsLen + 4;
   if(downlinkMsgLen < minLen) {
+    #if !RADIOLIB_STATIC_ONLY
+      delete[] downlinkMsg;
+    #endif
     return(RADIOLIB_ERR_DOWNLINK_MALFORMED);
   }
   uint8_t payLen = downlinkMsgLen - minLen;
@@ -1942,7 +1945,7 @@ int16_t LoRaWANNode::parseDownlink(uint8_t* data, size_t* len, uint8_t window, L
       isAppDownlink = true;
     }
     // check if any of the packages use this FPort
-    if(fPort >= RADIOLIB_LORAWAN_FPORT_RESERVED && this->packages[fPort - RADIOLIB_LORAWAN_FPORT_RESERVED].enabled) {
+    if(fPort >= RADIOLIB_LORAWAN_FPORT_RESERVED && (fPort - RADIOLIB_LORAWAN_FPORT_RESERVED) < RADIOLIB_LORAWAN_NUM_RESERVED_PACKAGES && this->packages[fPort - RADIOLIB_LORAWAN_FPORT_RESERVED].enabled) {
       ok = true;
       isAppDownlink = this->packages[fPort - RADIOLIB_LORAWAN_FPORT_RESERVED].isAppPack;
     }


### PR DESCRIPTION
Following up on our email correspondence, this PR addresses two bugs discovered in the LoRaWAN packet parsing logic during a fuzzing campaign.

### 1. Out-of-bounds Read in FPort Validation
When validating reserved ports in `LoRaWANNode::parseDownlink`, the offset calculation `(fPort - RADIOLIB_LORAWAN_FPORT_RESERVED)` could exceed the bounds of the `this->packages` array (which has a fixed size of `RADIOLIB_LORAWAN_NUM_RESERVED_PACKAGES`, i.e., 3) if a malformed `fPort` value is received. 
**Fix:** Added a boundary check `(fPort - RADIOLIB_LORAWAN_FPORT_RESERVED) < RADIOLIB_LORAWAN_NUM_RESERVED_PACKAGES` before accessing the array to prevent memory corruption.

### 2. Heap Memory Leak on Malformed Downlink
In the same function, if the parsed packet length is smaller than `minLen`, the function returns early with `RADIOLIB_ERR_DOWNLINK_MALFORMED`. However, the dynamically allocated `downlinkMsg` buffer was not freed before this return, causing a memory leak when processing malformed frames.
**Fix:** Added `delete[] downlinkMsg;` (guarded by `#if !RADIOLIB_STATIC_ONLY`) right before the early return.

### Testing & Verification
Both issues were discovered and verified using **libFuzzer** combined with **AddressSanitizer (ASan)** and **LeakSanitizer (LSan)**. 
I created a custom C++ harness that feeds mutated raw byte arrays directly into the `parseDownlink()` method. The fuzzing setup explored the state machine with thousands of executions per second. With these patches applied, the fuzzer runs stably with no crashes or leaks detected.

Please let me know if any further adjustments are needed!