### PR TITLE
[LR2021] Expose detector index from getLoRaPacketStatus

### DIFF
--- a/src/modules/LR2021/LR2021.h
+++ b/src/modules/LR2021/LR2021.h
@@ -803,9 +803,10 @@ class LR2021: public LRxxxx {
       \param snrPacket SNR of the last received packet in dB
       \param rssiPacket RSSI of the last received packet in dBm
       \param rssiSignalPacket Estimation of the RSSI of LoRa signal after despreading in dBm
+      \param detector Index of the detector that received the packet: 0 = main, 1 = side 1, 2 = side 2, 3 = side 3
       \returns \ref status_codes
     */
-    int16_t getLoRaPacketStatus(uint8_t* cr, bool* crc, uint8_t* packetLen = NULL, float* snrPacket = NULL, float* rssiPacket = NULL, float* rssiSignalPacket = NULL);
+    int16_t getLoRaPacketStatus(uint8_t* cr, bool* crc, uint8_t* packetLen = NULL, float* snrPacket = NULL, float* rssiPacket = NULL, float* rssiSignalPacket = NULL, uint8_t* detector = NULL);
 
     /*!
       \brief Get LoRa header information from last received packet. Implementation based on getLoRaPacketStatus.

--- a/src/modules/LR2021/LR2021_cmds_lora.cpp
+++ b/src/modules/LR2021/LR2021_cmds_lora.cpp
@@ -72,7 +72,7 @@ int16_t LR2021::getLoRaRxStats(uint16_t* pktRxTotal, uint16_t* pktCrcError, uint
   return(state);
 }
 
-int16_t LR2021::getLoRaPacketStatus(uint8_t* cr, bool* crc, uint8_t* packetLen, float* snrPacket, float* rssiPacket, float* rssiSignalPacket) {
+int16_t LR2021::getLoRaPacketStatus(uint8_t* cr, bool* crc, uint8_t* packetLen, float* snrPacket, float* rssiPacket, float* rssiSignalPacket, uint8_t* detector) {
   uint8_t buff[6] = { 0 };
   int16_t state = this->SPIcommand(RADIOLIB_LR2021_CMD_GET_LORA_PACKET_STATUS, false, buff, sizeof(buff));
   uint16_t raw;
@@ -89,6 +89,13 @@ int16_t LR2021::getLoRaPacketStatus(uint8_t* cr, bool* crc, uint8_t* packetLen, 
     raw = (uint16_t)buff[4] << 1;
     raw |= buff[5] & 0x01;
     *rssiSignalPacket = (float)raw / -2.0f;
+  }
+  if(detector) {
+    uint8_t det = (buff[5] >> 2) & 0x0F;
+    if(det == 0x01) { *detector = 0; }
+    else if(det == 0x02) { *detector = 1; }
+    else if(det == 0x04) { *detector = 2; }
+    else if(det == 0x08) { *detector = 3; }
   }
   return(state);
 }


### PR DESCRIPTION
Adds optional 7th parameter to report which detector (0 = main, 1-3 = side) received the packet. One-hot value from buff[5] bits 5:2 is translated to a 0-3 index. Defaults to NULL for backward compatibility.

Code has been tested with Meshtastic compiled to run on Semtech LR2021 LoRa Plus Evaluation Kit-US915 ShortFast Ch 15  with Cross-SF communication between it and a stock Meshtastic 2.7.16 running on Heltec WiFi LoRa 32 v4  LongFast Ch 15 and a stock Meshtastic 2.7.15 on Muzi Duo MediumFast Ch 15.

PR for feature discussed in https://github.com/jgromes/RadioLib/issues/1799 

Code was created with assistance from Claude AI. 