### PR TITLE
fix(SX127x): update ldroEnabled in setSpreadingFactor so getTimeOnAir is correct at high SF

### DIFF
--- a/extras/test/unit/tests/TestCalculateTimeOnAir.cpp
+++ b/extras/test/unit/tests/TestCalculateTimeOnAir.cpp
@@ -23,6 +23,7 @@ static std::vector<RadioConfig> allConfigs = {
 
     { "SX127x", RADIOLIB_MODEM_LORA, {.lora={6,125,6}}, {.lora={8,false,true,false}}, {7,23,98,156}, {23000,39000,115000,174000} }, // 20.61, 39.04, 115.84, 174.21 
     { "SX127x", RADIOLIB_MODEM_LORA, {.lora={8,250,8}}, {.lora={32,true,true,false}}, {10,20,80,160}, {70000,87000,210000,373000} }, // 69.89, 86.27, 209.15, 372.99
+    { "SX127x", RADIOLIB_MODEM_LORA, {.lora={12,125,7}}, {.lora={8,false,true,true}}, {1,24,64,128}, {893000,1811000,3646000,6628000} }, // 892.93, 1810.43, 3645.50, 6627.59
     { "SX127x", RADIOLIB_MODEM_FSK,  {.fsk={100,5}},    {.fsk={16,16,3}}, {1,16,32,61}, {640,1840,3120,5440} },
 
     { "SX128x", RADIOLIB_MODEM_LORA, {.lora={5,400,5}}, {.lora={8,false,true,false}}, {1,50,200}, {2580,10179,34180} }, // 2.54, 10.02, 33.65

--- a/src/modules/SX127x/SX1272.cpp
+++ b/src/modules/SX127x/SX1272.cpp
@@ -199,8 +199,10 @@ int16_t SX1272::setSpreadingFactor(uint8_t sf) {
       float symbolLength = (float)(uint32_t(1) << SX127x::spreadingFactor) / (float)SX127x::bandwidth;
       Module* mod = this->getMod();
       if(symbolLength >= 16.0f) {
+        this->ldroEnabled = true;
         state = mod->SPIsetRegValue(RADIOLIB_SX127X_REG_MODEM_CONFIG_1, RADIOLIB_SX1272_LOW_DATA_RATE_OPT_ON, 0, 0);
       } else {
+        this->ldroEnabled = false;
         state = mod->SPIsetRegValue(RADIOLIB_SX127X_REG_MODEM_CONFIG_1, RADIOLIB_SX1272_LOW_DATA_RATE_OPT_OFF, 0, 0);
       }
     }

--- a/src/modules/SX127x/SX1278.cpp
+++ b/src/modules/SX127x/SX1278.cpp
@@ -220,8 +220,10 @@ int16_t SX1278::setSpreadingFactor(uint8_t sf) {
       float symbolLength = (float)(uint32_t(1) << SX127x::spreadingFactor) / (float)SX127x::bandwidth;
       Module* mod = this->getMod();
       if(symbolLength >= 16.0f) {
+        this->ldroEnabled = true;
         state = mod->SPIsetRegValue(RADIOLIB_SX1278_REG_MODEM_CONFIG_3, RADIOLIB_SX1278_LOW_DATA_RATE_OPT_ON, 3, 3);
       } else {
+        this->ldroEnabled = false;
         state = mod->SPIsetRegValue(RADIOLIB_SX1278_REG_MODEM_CONFIG_3, RADIOLIB_SX1278_LOW_DATA_RATE_OPT_OFF, 3, 3);
       }
     }


### PR DESCRIPTION
> Note: this PR was written with AI assistance (the fix and description were reviewed by a human).

### Problem

On SX127x, `getTimeOnAir()` underestimates LoRa airtime by one code block at SF11/SF12. For example at SF12 / BW125 / CR4-7 / explicit header / CRC on with a 24-byte payload it returns ~1582 ms instead of the correct ~1810 ms.

### Cause

`setBandwidth()` updates both the LDRO register and the cached `this->ldroEnabled` member. `setSpreadingFactor()` only writes the register — it never updates the member. `getTimeOnAir()` reads the member (`SX127x.cpp`: `pc.lora.ldrOptimize = this->ldroEnabled;`).

Since `begin()` calls `setBandwidth()` (while SF is still the default 9, so LDRO computes as off) *before* `setSpreadingFactor()`, the member stays `false` even though `setSpreadingFactor()` correctly turns the LDRO register on for SF11/SF12. The radio transmits fine; only the airtime estimate is wrong.

### Fix

Set `this->ldroEnabled` in `setSpreadingFactor()` next to the register write, mirroring what `setBandwidth()` already does. Applied to both `SX1278` (SX1276/77/78/79) and `SX1272` (SX1272/73). No transmission behavior changes — only the cached value `getTimeOnAir()` reads. The existing workaround (re-calling `setBandwidth()` after `begin()`) is no longer needed.

SX126x is unaffected: there both setters route through `setModulationParams()`, which recomputes `ldrOptimize` from current SF+BW each call. (#1591 was a separate prior LDRO fix on that family.)

### Repro

```cpp
SX1278 radio = new Module(/* pins */);
radio.begin(434.0, 125.0, 12, 7);       // SF12, BW125, CR4-7
Serial.println(radio.getTimeOnAir(24));  // before: ~1582000 us, after: ~1810000 us
```