### PR TITLE
[LoRaWAN] Improve persistence and session handling (breaking) (#1789)

### DIFF
--- a/extras/test/fuzz/tests/FuzzLoRaWAN.cpp
+++ b/extras/test/fuzz/tests/FuzzLoRaWAN.cpp
@@ -1,6 +1,8 @@
 #include "MockPhysicalLayer.hpp"
 
-extern "C" int FuzzLoRaWAN(const uint8_t* data, size_t size) {
+#include <string.h>
+
+extern "C" int FuzzLoRaWANDownlink(const uint8_t* data, size_t size) {
   if(size < 10) { return(0); }
 
   // initialize default software AES-128
@@ -31,6 +33,44 @@ extern "C" int FuzzLoRaWAN(const uint8_t* data, size_t size) {
   uint8_t outBuffer[256] = {0};
   LoRaWANEvent_t event;
   node.parseDownlink(outBuffer, &outLen, RADIOLIB_LORAWAN_RX1, &event);
+
+  return(0);
+}
+
+static FuzzPhysicalLayer phy;
+static void FuzzLoRaWANPersistCallback(uint8_t* buf, size_t len) {
+  memcpy(buf, phy.currentPacketData, len);
+}
+
+extern "C" int FuzzLoRaWANPersistBuffer(const uint8_t* data, size_t size) {
+  if(size < RADIOLIB_LORAWAN_SESSION_BUF_SIZE) { return(0); }
+
+  // initialize default software AES-128
+  FuzzHal hal;
+  static RadioLibSoftwareAES128 RadioLibAES128Instance;
+  hal.aes128 = &RadioLibAES128Instance;
+
+  // create a FuzzPhysicalLayer with a mock module
+  Module mod(&hal, 1, 2, 3, 4);
+  phy.mod = &mod;
+
+  // pass the input from the fuzzer
+  phy.currentPacketLength = size;
+  phy.currentPacketData = data;
+
+  // set some default AES keys
+  uint8_t defaultKey[16] = { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff };
+
+  // instantiate EU868 band (or any other band)
+  LoRaWANNode node(&phy, &EU868);
+
+  // set persistent buffer callbacks and try to "load" a buffer
+  node.setCallbackRestorePersistence(FuzzLoRaWANPersistCallback);
+  node.setCallbackRestoreSession(FuzzLoRaWANPersistCallback);
+  node.loadBuffers();
+
+  // configure node with keys and addresses
+  node.beginABP(0x12345678, defaultKey, defaultKey, defaultKey, defaultKey);
 
   return(0);
 }

--- a/extras/test/fuzz/tests/FuzzMain.cpp
+++ b/extras/test/fuzz/tests/FuzzMain.cpp
@@ -2,8 +2,11 @@
 #include <stddef.h>
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
-  extern int FuzzLoRaWAN(const uint8_t* data, size_t size);
-  FuzzLoRaWAN(data, size);
+  extern int FuzzLoRaWANDownlink(const uint8_t* data, size_t size);
+  FuzzLoRaWANDownlink(data, size);
+
+  extern int FuzzLoRaWANPersistBuffer(const uint8_t* data, size_t size);
+  FuzzLoRaWANPersistBuffer(data, size);
 
   extern int FuzzPager(const uint8_t* data, size_t size);
   FuzzPager(data, size);

--- a/src/protocols/LoRaWAN/LoRaWAN.cpp
+++ b/src/protocols/LoRaWAN/LoRaWAN.cpp
@@ -299,10 +299,13 @@ int16_t LoRaWANNode::sendReceive(const uint8_t* dataUp, size_t lenUp, uint8_t fP
 }
 
 void LoRaWANNode::clearPersistence() {
-  // clear & set all the device credentials
+  // clear all the persistent values
   memset(this->bufferPersist, 0, RADIOLIB_LORAWAN_PERSISTENCE_BUF_SIZE);
+  // reset TS004's fragmentation nonces to 0xFFFF to accept initial value 0
   memset(&this->bufferPersist[RADIOLIB_LORAWAN_PERSISTENCE_TS004], 0xFF, 8);
-  memset(&this->bufferPersist[RADIOLIB_LORAWAN_PERSISTENCE_TS009], 0x01, 1);
+  // allow enabling of TS009's test mode by setting to 1
+  this->bufferPersist[RADIOLIB_LORAWAN_PERSISTENCE_TS009] = 0x01;
+
   this->keyCheckSum = 0;
   this->devNonce = 0;
   this->joinNonce = 0;

--- a/src/protocols/LoRaWAN/LoRaWAN.cpp
+++ b/src/protocols/LoRaWAN/LoRaWAN.cpp
@@ -203,6 +203,7 @@ int16_t LoRaWANNode::sendReceive(const uint8_t* dataUp, size_t lenUp, uint8_t fP
       // sometimes, a spurious error can occur even though the uplink was transmitted
       // therefore, just to be safe, increase frame counter by one for the next uplink
       this->fCntUp += 1;
+      this->saveSessionBuffer();
 
       #if !RADIOLIB_STATIC_ONLY
       delete[] uplinkMsg;
@@ -265,6 +266,7 @@ int16_t LoRaWANNode::sendReceive(const uint8_t* dataUp, size_t lenUp, uint8_t fP
 
   // if a hardware error occurred, return
   if(state < RADIOLIB_ERR_NONE) {
+    this->saveSessionBuffer();
     return(state);
   }
 
@@ -278,11 +280,16 @@ int16_t LoRaWANNode::sendReceive(const uint8_t* dataUp, size_t lenUp, uint8_t fP
     }
     // remove only non-persistent MAC commands, the other commands should be re-sent until downlink is received
     LoRaWANNode::clearMacCommands(this->fOptsUp, &this->fOptsUpLen, RADIOLIB_LORAWAN_UPLINK);
+    this->saveSessionBuffer();
     return(rxWindow);
   }
   
+  // parse the contents - if there is a parsing error, silently drop it
   state = this->parseDownlink(dataDown, lenDown, rxWindow, eventDown);
   RADIOLIB_ASSERT(state);
+
+  // parsed all nicely, save the buffer
+  this->saveSessionBuffer();
 
   // open RxC window (this returns if not applicable)
   this->receiveClassC();
@@ -291,63 +298,79 @@ int16_t LoRaWANNode::sendReceive(const uint8_t* dataUp, size_t lenUp, uint8_t fP
   return(rxWindow);
 }
 
-void LoRaWANNode::clearNonces() {
+void LoRaWANNode::clearPersistence() {
   // clear & set all the device credentials
-  memset(this->bufferNonces, 0, RADIOLIB_LORAWAN_NONCES_BUF_SIZE);
+  memset(this->bufferPersist, 0, RADIOLIB_LORAWAN_PERSISTENCE_BUF_SIZE);
+  memset(&this->bufferPersist[RADIOLIB_LORAWAN_PERSISTENCE_TS004], 0xFF, 8);
+  memset(&this->bufferPersist[RADIOLIB_LORAWAN_PERSISTENCE_TS009], 0x01, 1);
   this->keyCheckSum = 0;
   this->devNonce = 0;
   this->joinNonce = 0;
   this->sessionStatus = RADIOLIB_LORAWAN_SESSION_NONE;
 }
 
-uint8_t* LoRaWANNode::getBufferNonces() {
+void LoRaWANNode::savePersistenceBuffer() {
+  if(!this->storePersistenceBufferCb) {
+    return;
+  }
+
   // set the device credentials
-  LoRaWANNode::hton<uint16_t>(&this->bufferNonces[RADIOLIB_LORAWAN_NONCES_VERSION], RADIOLIB_LORAWAN_NONCES_VERSION_VAL);
-  LoRaWANNode::hton<uint16_t>(&this->bufferNonces[RADIOLIB_LORAWAN_NONCES_MODE], this->lwMode);
-  LoRaWANNode::hton<uint8_t>(&this->bufferNonces[RADIOLIB_LORAWAN_NONCES_PLAN], this->band->bandNum);
-  LoRaWANNode::hton<uint16_t>(&this->bufferNonces[RADIOLIB_LORAWAN_NONCES_CHECKSUM], this->keyCheckSum);
+  LoRaWANNode::hton<uint8_t>(&this->bufferPersist[RADIOLIB_LORAWAN_PERSISTENCE_SIZE], RADIOLIB_LORAWAN_PERSISTENCE_BUF_SIZE);
+  LoRaWANNode::hton<uint16_t>(&this->bufferPersist[RADIOLIB_LORAWAN_PERSISTENCE_VERSION], RADIOLIB_LORAWAN_NONCES_VERSION_VAL);
+  LoRaWANNode::hton<uint32_t>(&this->bufferPersist[RADIOLIB_LORAWAN_PERSISTENCE_KEYS], this->keyCheckSum);
+  LoRaWANNode::hton<uint32_t>(&this->bufferPersist[RADIOLIB_LORAWAN_PERSISTENCE_JOIN_NONCE], this->joinNonce, 3);
+  LoRaWANNode::hton<uint16_t>(&this->bufferPersist[RADIOLIB_LORAWAN_PERSISTENCE_DEV_NONCE], this->devNonce);
+  // RJ_COUNT: future version 1.2
+  // TS004: set by package manager
+  // TS009: set by package manager
 
-  // generate the signature of the Nonces buffer, and store it in the last two bytes of the Nonces buffer
-  uint16_t signature = LoRaWANNode::checkSum16(this->bufferNonces, RADIOLIB_LORAWAN_NONCES_BUF_SIZE - 2);
-  LoRaWANNode::hton<uint16_t>(&this->bufferNonces[RADIOLIB_LORAWAN_NONCES_SIGNATURE], signature);
+  // generate the signature of the Persistence buffer, 
+  // and store it in the last four bytes of the Persistence buffer
+  uint32_t signature = LoRaWANNode::checkSum<uint32_t>(this->bufferPersist, RADIOLIB_LORAWAN_PERSISTENCE_BUF_SIZE - sizeof(uint32_t));
+  LoRaWANNode::hton<uint32_t>(&this->bufferPersist[RADIOLIB_LORAWAN_PERSISTENCE_SIGNATURE], signature);
+  
+  // trigger the callback
+  this->storePersistenceBufferCb(this->bufferPersist, RADIOLIB_LORAWAN_PERSISTENCE_BUF_SIZE);
 
-  return(this->bufferNonces);
+  // also update the signature in the session buffer
+  LoRaWANNode::hton<uint32_t>(&this->bufferSession[RADIOLIB_LORAWAN_SESSION_NONCES_SIGNATURE], signature);
 }
 
-int16_t LoRaWANNode::setBufferNonces(const uint8_t* persistentBuffer) {
+int16_t LoRaWANNode::loadPersistenceBuffer() {
+  if(!this->restorePersistenceBufferCb) {
+    return(RADIOLIB_ERR_NULL_POINTER);
+  }
+  
   if(this->isActivated()) {
     RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Did not update buffer: session already active");
     return(RADIOLIB_ERR_NONE);
   }
 
-  // // this code can be used in case breaking chances must be caught:
-  // uint8_t nvm_table_version = this->bufferNonces[RADIOLIB_LORAWAN_NONCES_VERSION];
-  // if (RADIOLIB_LORAWAN_NONCES_VERSION_VAL > nvm_table_version) {
-  //  // set default values for variables that are new or something
-  // }
+  uint8_t buff[RADIOLIB_LORAWAN_PERSISTENCE_BUF_SIZE];
+  this->restorePersistenceBufferCb(buff, RADIOLIB_LORAWAN_PERSISTENCE_BUF_SIZE);
 
-  int16_t state = LoRaWANNode::checkBufferCommon(persistentBuffer, RADIOLIB_LORAWAN_NONCES_BUF_SIZE);
+  // can parse old versions here if necessary
+
+  // check the buffer signature
+  int16_t state = LoRaWANNode::checkBufferCommon(buff, RADIOLIB_LORAWAN_PERSISTENCE_BUF_SIZE);
   RADIOLIB_ASSERT(state);
 
-  bool isSameKeys = LoRaWANNode::ntoh<uint16_t>(&persistentBuffer[RADIOLIB_LORAWAN_NONCES_CHECKSUM]) == this->keyCheckSum;
-  bool isSameMode = LoRaWANNode::ntoh<uint16_t>(&persistentBuffer[RADIOLIB_LORAWAN_NONCES_MODE]) == this->lwMode;
-  bool isSamePlan  = LoRaWANNode::ntoh<uint8_t>(&persistentBuffer[RADIOLIB_LORAWAN_NONCES_PLAN]) == this->band->bandNum;
-
-  // check if Nonces buffer matches the current configuration
-  if(!isSameKeys || !isSameMode || !isSamePlan) {
+  // check if Persistence buffer matches the current configuration
+  uint32_t testCheckSum = LoRaWANNode::ntoh<uint32_t>(&buff[RADIOLIB_LORAWAN_PERSISTENCE_KEYS]);
+  if(testCheckSum != this->keyCheckSum) {
     // if configuration did not match, discard whatever is currently in the buffers and start fresh
-    RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Configuration mismatch (keys: %d, mode: %d, plan: %d)", isSameKeys, isSameMode, isSamePlan);
-    RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Discarding the Nonces buffer:");
-    RADIOLIB_DEBUG_PROTOCOL_HEXDUMP(persistentBuffer, RADIOLIB_LORAWAN_NONCES_BUF_SIZE);
+    RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Configuration mismatch (key checksum: %08lX, got: %08lX)", this->keyCheckSum, testCheckSum);
     return(RADIOLIB_ERR_NONCES_DISCARDED);
   }
 
   // copy the whole buffer over
-  memcpy(this->bufferNonces, persistentBuffer, RADIOLIB_LORAWAN_NONCES_BUF_SIZE);
+  memcpy(this->bufferPersist, buff, RADIOLIB_LORAWAN_PERSISTENCE_BUF_SIZE);
 
-  this->devNonce  = LoRaWANNode::ntoh<uint16_t>(&this->bufferNonces[RADIOLIB_LORAWAN_NONCES_DEV_NONCE]);
-  this->joinNonce = LoRaWANNode::ntoh<uint32_t>(&this->bufferNonces[RADIOLIB_LORAWAN_NONCES_JOIN_NONCE], 3);
-
+  this->devNonce  = LoRaWANNode::ntoh<uint16_t>(&this->bufferPersist[RADIOLIB_LORAWAN_PERSISTENCE_DEV_NONCE]);
+  this->joinNonce = LoRaWANNode::ntoh<uint32_t>(&this->bufferPersist[RADIOLIB_LORAWAN_PERSISTENCE_JOIN_NONCE], 3);
+  // RJ_COUNT: future version 1.2
+  // TS004: retrieved by package manager
+  // TS009: retrieved by package manager
   return(state);
 }
 
@@ -504,7 +527,11 @@ void LoRaWANNode::createSession() {
   this->sessionStatus = RADIOLIB_LORAWAN_SESSION_ACTIVATING;
 }
 
-uint8_t* LoRaWANNode::getBufferSession() {
+void LoRaWANNode::saveSessionBuffer() {
+  if(!this->storeSessionBufferCb) {
+    return;
+  }
+
   // store all frame counters
   LoRaWANNode::hton<uint32_t>(&this->bufferSession[RADIOLIB_LORAWAN_SESSION_A_FCNT_DOWN], this->aFCntDown);
   LoRaWANNode::hton<uint32_t>(&this->bufferSession[RADIOLIB_LORAWAN_SESSION_N_FCNT_DOWN], this->nFCntDown);
@@ -527,32 +554,40 @@ uint8_t* LoRaWANNode::getBufferSession() {
   LoRaWANNode::hton<uint8_t>(&this->bufferSession[RADIOLIB_LORAWAN_SESSION_STATUS], this->sessionStatus);
 
   // generate the signature of the Session buffer, and store it in the last two bytes of the Session buffer
-  uint16_t signature = LoRaWANNode::checkSum16(this->bufferSession, RADIOLIB_LORAWAN_SESSION_BUF_SIZE - 2);
-  LoRaWANNode::hton<uint16_t>(&this->bufferSession[RADIOLIB_LORAWAN_SESSION_SIGNATURE], signature);
-  
-  return(this->bufferSession);
+  uint32_t signature = LoRaWANNode::checkSum<uint32_t>(this->bufferSession, RADIOLIB_LORAWAN_SESSION_BUF_SIZE - sizeof(uint32_t));
+  LoRaWANNode::hton<uint32_t>(&this->bufferSession[RADIOLIB_LORAWAN_SESSION_SIGNATURE], signature);
+
+  // trigger the callback
+  this->storeSessionBufferCb(this->bufferSession, RADIOLIB_LORAWAN_SESSION_BUF_SIZE);
 }
 
-int16_t LoRaWANNode::setBufferSession(const uint8_t* persistentBuffer) {
+int16_t LoRaWANNode::loadSessionBuffer() {
+  if(!this->restoreSessionBufferCb) {
+    return(RADIOLIB_ERR_NULL_POINTER);
+  }
+  
   if(this->isActivated()) {
     RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Did not update buffer: session already active");
     return(RADIOLIB_ERR_NONE);
   }
 
-  int16_t state = LoRaWANNode::checkBufferCommon(persistentBuffer, RADIOLIB_LORAWAN_SESSION_BUF_SIZE);
+  uint8_t buff[RADIOLIB_LORAWAN_SESSION_BUF_SIZE];
+  this->restoreSessionBufferCb(buff, RADIOLIB_LORAWAN_SESSION_BUF_SIZE);
+
+  int16_t state = LoRaWANNode::checkBufferCommon(buff, RADIOLIB_LORAWAN_SESSION_BUF_SIZE);
   RADIOLIB_ASSERT(state);
 
-  // the Nonces buffer holds a checksum signature - compare this to the signature that is in the session buffer
-  uint16_t signatureNonces = LoRaWANNode::ntoh<uint16_t>(&this->bufferNonces[RADIOLIB_LORAWAN_NONCES_SIGNATURE]);
-  uint16_t signatureInSession = LoRaWANNode::ntoh<uint16_t>(&persistentBuffer[RADIOLIB_LORAWAN_SESSION_NONCES_SIGNATURE]);
-  if(signatureNonces != signatureInSession) {
-    RADIOLIB_DEBUG_PROTOCOL_PRINTLN("The Session buffer (%04x) does not match the Nonces buffer (%04x)",
-                                    signatureInSession, signatureNonces);
+  // the Persistence buffer holds a checksum signature - compare this to the signature that is in the session buffer
+  uint32_t signaturePersist = LoRaWANNode::ntoh<uint32_t>(&this->bufferPersist[RADIOLIB_LORAWAN_PERSISTENCE_SIGNATURE]);
+  uint32_t signatureSession = LoRaWANNode::ntoh<uint32_t>(&buff[RADIOLIB_LORAWAN_SESSION_NONCES_SIGNATURE]);
+  if(signaturePersist != signatureSession) {
+    RADIOLIB_DEBUG_PROTOCOL_PRINTLN("The Session signature (%08lX) does not match the Persistence signature (%08lX)",
+                                    signatureSession, signaturePersist);
     return(RADIOLIB_ERR_SESSION_DISCARDED);
   }
 
   // copy the whole buffer over
-  memcpy(this->bufferSession, persistentBuffer, RADIOLIB_LORAWAN_SESSION_BUF_SIZE);
+  memcpy(this->bufferSession, buff, RADIOLIB_LORAWAN_SESSION_BUF_SIZE);
 
   // setup the default channels
   if(this->band->bandType == RADIOLIB_LORAWAN_BAND_DYNAMIC) {
@@ -655,7 +690,7 @@ int16_t LoRaWANNode::setBufferSession(const uint8_t* persistentBuffer) {
   this->fCntUp       = LoRaWANNode::ntoh<uint32_t>(&this->bufferSession[RADIOLIB_LORAWAN_SESSION_FCNT_UP]);
   this->rxAFCnt      = LoRaWANNode::ntoh<uint32_t>(&this->bufferSession[RADIOLIB_LORAWAN_SESSION_RX_A_FCNT]);
 
-  // as both the Nonces and session are restored, revert to active session
+  // as both the persistence and session are restored, revert to active session
   this->sessionStatus = RADIOLIB_LORAWAN_SESSION_PENDING;
 
   return(state);
@@ -666,7 +701,7 @@ int16_t LoRaWANNode::beginOTAA(uint64_t joinEUI, uint64_t devEUI, const uint8_t*
     return(RADIOLIB_ERR_NULL_POINTER);
   }
   // clear all the device parameters in case there were any
-  this->clearNonces();
+  this->clearPersistence();
   this->clearSession();
 
   this->joinEUI = joinEUI;
@@ -678,11 +713,12 @@ int16_t LoRaWANNode::beginOTAA(uint64_t joinEUI, uint64_t devEUI, const uint8_t*
   }
 
   // generate activation key checksum
-  this->keyCheckSum ^= LoRaWANNode::checkSum16(reinterpret_cast<uint8_t*>(&joinEUI), sizeof(uint64_t));
-  this->keyCheckSum ^= LoRaWANNode::checkSum16(reinterpret_cast<uint8_t*>(&devEUI), sizeof(uint64_t));
-  this->keyCheckSum ^= LoRaWANNode::checkSum16(appKey, RADIOLIB_AES128_KEY_SIZE);
+  this->keyCheckSum = 0;
+  this->keyCheckSum ^= LoRaWANNode::checkSum<uint32_t>(reinterpret_cast<uint8_t*>(&joinEUI), sizeof(uint64_t));
+  this->keyCheckSum ^= LoRaWANNode::checkSum<uint32_t>(reinterpret_cast<uint8_t*>(&devEUI), sizeof(uint64_t));
+  this->keyCheckSum ^= LoRaWANNode::checkSum<uint32_t>(appKey, RADIOLIB_AES128_KEY_SIZE);
   if(nwkKey) {
-    this->keyCheckSum ^= LoRaWANNode::checkSum16(nwkKey, RADIOLIB_AES128_KEY_SIZE);
+    this->keyCheckSum ^= LoRaWANNode::checkSum<uint32_t>(nwkKey, RADIOLIB_AES128_KEY_SIZE);
   }
 
   this->lwMode = RADIOLIB_LORAWAN_MODE_OTAA;
@@ -695,7 +731,7 @@ int16_t LoRaWANNode::beginABP(uint32_t addr, const uint8_t* fNwkSIntKey, const u
     return(RADIOLIB_ERR_NULL_POINTER);
   }
   // clear all the device parameters in case there were any
-  this->clearNonces();
+  this->clearPersistence();
   this->clearSession();
 
   this->devAddr = addr;
@@ -711,11 +747,11 @@ int16_t LoRaWANNode::beginABP(uint32_t addr, const uint8_t* fNwkSIntKey, const u
   }
 
   // generate activation key checksum
-  this->keyCheckSum ^= LoRaWANNode::checkSum16(reinterpret_cast<uint8_t*>(&addr), sizeof(uint32_t));
-  this->keyCheckSum ^= LoRaWANNode::checkSum16(nwkSEncKey, RADIOLIB_AES128_KEY_SIZE);
-  this->keyCheckSum ^= LoRaWANNode::checkSum16(appSKey, RADIOLIB_AES128_KEY_SIZE);
-  if(fNwkSIntKey) { this->keyCheckSum ^= LoRaWANNode::checkSum16(fNwkSIntKey, RADIOLIB_AES128_KEY_SIZE); }
-  if(sNwkSIntKey) { this->keyCheckSum ^= LoRaWANNode::checkSum16(sNwkSIntKey, RADIOLIB_AES128_KEY_SIZE); }
+  this->keyCheckSum = addr;
+  this->keyCheckSum ^= LoRaWANNode::checkSum<uint32_t>(nwkSEncKey, RADIOLIB_AES128_KEY_SIZE);
+  this->keyCheckSum ^= LoRaWANNode::checkSum<uint32_t>(appSKey, RADIOLIB_AES128_KEY_SIZE);
+  if(fNwkSIntKey) { this->keyCheckSum ^= LoRaWANNode::checkSum<uint32_t>(fNwkSIntKey, RADIOLIB_AES128_KEY_SIZE); }
+  if(sNwkSIntKey) { this->keyCheckSum ^= LoRaWANNode::checkSum<uint32_t>(sNwkSIntKey, RADIOLIB_AES128_KEY_SIZE); }
 
   this->lwMode = RADIOLIB_LORAWAN_MODE_ABP;
 
@@ -910,8 +946,6 @@ int16_t LoRaWANNode::processJoinAccept(LoRaWANJoinEvent_t *joinEvent) {
     RADIOLIB_ASSERT(state);
   }
 
-  LoRaWANNode::hton<uint32_t>(&this->bufferNonces[RADIOLIB_LORAWAN_NONCES_JOIN_NONCE], this->joinNonce, 3);
-
   // store DevAddr and all keys
   LoRaWANNode::hton<uint32_t>(&this->bufferSession[RADIOLIB_LORAWAN_SESSION_DEV_ADDR], this->devAddr);
   memcpy(&this->bufferSession[RADIOLIB_LORAWAN_SESSION_APP_SKEY], this->appSKey, RADIOLIB_AES128_KEY_SIZE);
@@ -991,13 +1025,11 @@ int16_t LoRaWANNode::activateOTAA(LoRaWANJoinEvent_t *joinEvent) {
                                 RADIOLIB_LORAWAN_JOIN_REQUEST_LEN);
   RADIOLIB_ASSERT(state);
 
-  // JoinRequest successfully sent, so increase & save devNonce
+  // JoinRequest successfully sent, so increase devNonce for next time
   this->devNonce += 1;
-  LoRaWANNode::hton<uint16_t>(&this->bufferNonces[RADIOLIB_LORAWAN_NONCES_DEV_NONCE], this->devNonce);
 
-  // update the Nonces buffer and generate its signature - also store it in the Session buffer
-  (void)this->getBufferNonces();
-  memcpy(&this->bufferSession[RADIOLIB_LORAWAN_SESSION_NONCES_SIGNATURE], &this->bufferNonces[RADIOLIB_LORAWAN_NONCES_SIGNATURE], 2);
+  // save persistence buffer with updated devNonce before waiting for JoinAccept
+  this->savePersistenceBuffer();
 
   // configure Rx1 and Rx2 delay for JoinAccept message - these are re-configured once a valid JoinAccept is received
   this->rxDelays[1] = RADIOLIB_LORAWAN_JOIN_ACCEPT_DELAY_1_MS;
@@ -1015,9 +1047,9 @@ int16_t LoRaWANNode::activateOTAA(LoRaWANJoinEvent_t *joinEvent) {
   state = this->processJoinAccept(joinEvent);
   RADIOLIB_ASSERT(state);
 
-  // regenerate the Nonces buffer as we received a new JoinNonce in the JoinAccept
-  (void)this->getBufferNonces();
-  memcpy(&this->bufferSession[RADIOLIB_LORAWAN_SESSION_NONCES_SIGNATURE], &this->bufferNonces[RADIOLIB_LORAWAN_NONCES_SIGNATURE], 2);
+  // save both buffers after a successful join (new joinNonce + fresh session keys)
+  this->savePersistenceBuffer();
+  this->saveSessionBuffer();
 
   this->sessionStatus = RADIOLIB_LORAWAN_SESSION_ACTIVE;
 
@@ -1051,17 +1083,13 @@ int16_t LoRaWANNode::activateABP() {
     this->createSession();
   }
 
-  // update the Nonces buffer and generate its signature - also store it in the Session buffer
-  (void)this->getBufferNonces();
-  memcpy(&this->bufferSession[RADIOLIB_LORAWAN_SESSION_NONCES_SIGNATURE], &this->bufferNonces[RADIOLIB_LORAWAN_NONCES_SIGNATURE], 2);
-
   // store DevAddr and all keys
   LoRaWANNode::hton<uint32_t>(&this->bufferSession[RADIOLIB_LORAWAN_SESSION_DEV_ADDR], this->devAddr);
   memcpy(&this->bufferSession[RADIOLIB_LORAWAN_SESSION_APP_SKEY], this->appSKey, RADIOLIB_AES128_BLOCK_SIZE);
   memcpy(&this->bufferSession[RADIOLIB_LORAWAN_SESSION_NWK_SENC_KEY], this->nwkSEncKey, RADIOLIB_AES128_BLOCK_SIZE);
   memcpy(&this->bufferSession[RADIOLIB_LORAWAN_SESSION_FNWK_SINT_KEY], this->fNwkSIntKey, RADIOLIB_AES128_BLOCK_SIZE);
   memcpy(&this->bufferSession[RADIOLIB_LORAWAN_SESSION_SNWK_SINT_KEY], this->sNwkSIntKey, RADIOLIB_AES128_BLOCK_SIZE);
-  
+
   // store network parameters
   LoRaWANNode::hton<uint8_t>(&this->bufferSession[RADIOLIB_LORAWAN_SESSION_VERSION], this->rev);
 
@@ -1070,6 +1098,10 @@ int16_t LoRaWANNode::activateABP() {
   }
 
   this->sessionStatus = RADIOLIB_LORAWAN_SESSION_ACTIVE;
+
+  // save both buffers for the new ABP session
+  this->savePersistenceBuffer();
+  this->saveSessionBuffer();
 
   return(RADIOLIB_LORAWAN_NEW_SESSION);
 }
@@ -3300,6 +3332,38 @@ void LoRaWANNode::setActivityLeds(const uint32_t pins[4]) {
   }
 }
 
+void LoRaWANNode::getPersistencePackage(uint8_t pIndex, uint8_t* buff) {
+  switch(pIndex) {
+    case(RADIOLIB_LORAWAN_PERSISTENCE_TS004): {
+      memcpy(buff, &this->bufferSession[RADIOLIB_LORAWAN_PERSISTENCE_TS004], 8);
+    } break;
+    case(RADIOLIB_LORAWAN_PERSISTENCE_TS009): {
+      memcpy(buff, &this->bufferSession[RADIOLIB_LORAWAN_PERSISTENCE_TS009], 1);
+    } break;
+    default: {
+      // just ignore
+    } break;
+  }
+}
+
+void LoRaWANNode::setPersistencePackage(uint8_t pIndex, uint8_t* buff) {
+  switch(pIndex) {
+    case(RADIOLIB_LORAWAN_PERSISTENCE_TS004): {
+      memcpy(&this->bufferSession[RADIOLIB_LORAWAN_PERSISTENCE_TS004], buff, 8);
+    } break;
+    case(RADIOLIB_LORAWAN_PERSISTENCE_TS009): {
+      memcpy(&this->bufferSession[RADIOLIB_LORAWAN_PERSISTENCE_TS009], buff, 1);
+    } break;
+    default: {
+      // just ignore
+    } break;
+  }
+
+  // trigger an update of the buffer and session
+  this->savePersistenceBuffer();
+  this->saveSessionBuffer();
+}
+
 void LoRaWANNode::scheduleTransmission(RadioLibTime_t tUplink) {
   this->tUplink = tUplink;
 }
@@ -3823,6 +3887,34 @@ void LoRaWANNode::setSleepFunction(SleepCb_t cb) {
   this->sleepCb = cb;
 }
 
+void LoRaWANNode::setCallbackStorePersistence(BufferCb_t cb) {
+  this->storePersistenceBufferCb = cb;
+}
+
+void LoRaWANNode::setCallbackRestorePersistence(BufferCb_t cb) {
+  this->restorePersistenceBufferCb = cb;
+}
+
+void LoRaWANNode::setCallbackStoreSession(BufferCb_t cb) {
+  this->storeSessionBufferCb = cb;
+}
+
+void LoRaWANNode::setCallbackRestoreSession(BufferCb_t cb) {
+  this->restoreSessionBufferCb = cb;
+}
+
+int16_t LoRaWANNode::loadBuffers() {
+  int16_t state = RADIOLIB_ERR_NONE;
+  if(this->restorePersistenceBufferCb) {
+    state = this->loadPersistenceBuffer();
+    RADIOLIB_ASSERT(state);
+  }
+  if(this->restoreSessionBufferCb) {
+    state = this->loadSessionBuffer();
+  }
+  return(state);
+}
+
 int16_t LoRaWANNode::addAppPackage(uint8_t fPort) {
   return(this->addPackage(fPort, true));
 }
@@ -3920,37 +4012,27 @@ void LoRaWANNode::sleepDelay(RadioLibTime_t ms, bool radioOff) {
 }
 
 int16_t LoRaWANNode::checkBufferCommon(const uint8_t *buffer, uint16_t size) {
-  // check if there are actually values in the buffer
+  // if the buffer was all 0x00 or 0xFF, the checksum would be OK but this is not a valid buffer
+  // so we check if there are actually values in the buffer
   size_t i = 0;
   for(; i < size; i++) {
-    if(buffer[i]) {
+    if(buffer[i] != 0x00 && buffer[i] != 0xFF) {
       break;
     }
   }
   if(i == size) {
-    return(RADIOLIB_ERR_NETWORK_NOT_JOINED);
+    return(RADIOLIB_ERR_CHECKSUM_MISMATCH);
   }
 
   // check integrity of the whole buffer (compare checksum to included checksum)
-  uint16_t checkSum = LoRaWANNode::checkSum16(buffer, size - 2);
-  uint16_t signature = LoRaWANNode::ntoh<uint16_t>(&buffer[size - 2]);
+  uint32_t checkSum = LoRaWANNode::checkSum<uint32_t>(buffer, size - sizeof(uint32_t));
+  uint32_t signature = LoRaWANNode::ntoh<uint32_t>(&buffer[size - sizeof(uint32_t)]);
   if(signature != checkSum) {
-    RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Calculated checksum: %04x, expected: %04x", checkSum, signature);
+    RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Calculated checksum: %08lX, expected: %08lX", checkSum, signature);
     return(RADIOLIB_ERR_CHECKSUM_MISMATCH);
   }
   return(RADIOLIB_ERR_NONE);
 }
 
-uint16_t LoRaWANNode::checkSum16(const uint8_t *key, uint16_t keyLen) {
-  uint16_t checkSum = 0;
-  for(uint16_t i = 0; i < keyLen; i += 2) {
-    uint16_t word = (key[i] << 8);
-    if(i + 1 < keyLen) {
-      word |= key[i + 1];
-    }
-    checkSum ^= word;
-  }
-  return(checkSum);
-}
 
 #endif

--- a/src/protocols/LoRaWAN/LoRaWAN.h
+++ b/src/protocols/LoRaWAN/LoRaWAN.h
@@ -272,18 +272,21 @@ struct LoRaWANPackage_t {
   bool isAppPack;
 };
 
-#define RADIOLIB_LORAWAN_NONCES_VERSION_VAL (0x0003)
+#define RADIOLIB_LORAWAN_NONCES_VERSION_VAL (0x0004)
 
-enum LoRaWANSchemeBase_t {
-  RADIOLIB_LORAWAN_NONCES_START       = 0x00,
-  RADIOLIB_LORAWAN_NONCES_VERSION     = RADIOLIB_LORAWAN_NONCES_START,                            // 2 bytes
-  RADIOLIB_LORAWAN_NONCES_MODE        = RADIOLIB_LORAWAN_NONCES_VERSION + sizeof(uint16_t),       // 2 bytes
-  RADIOLIB_LORAWAN_NONCES_PLAN        = RADIOLIB_LORAWAN_NONCES_MODE + sizeof(uint16_t),          // 1 byte
-  RADIOLIB_LORAWAN_NONCES_CHECKSUM    = RADIOLIB_LORAWAN_NONCES_PLAN + sizeof(uint8_t),           // 2 bytes
-  RADIOLIB_LORAWAN_NONCES_DEV_NONCE   = RADIOLIB_LORAWAN_NONCES_CHECKSUM + sizeof(uint16_t),      // 2 bytes
-  RADIOLIB_LORAWAN_NONCES_JOIN_NONCE  = RADIOLIB_LORAWAN_NONCES_DEV_NONCE + sizeof(uint16_t),     // 3 bytes
-  RADIOLIB_LORAWAN_NONCES_SIGNATURE   = RADIOLIB_LORAWAN_NONCES_JOIN_NONCE + 3,                   // 2 bytes
-  RADIOLIB_LORAWAN_NONCES_BUF_SIZE    = RADIOLIB_LORAWAN_NONCES_SIGNATURE + sizeof(uint16_t)      // Nonces buffer size
+enum LoRaWANSchemePersistence_t {
+  RADIOLIB_LORAWAN_NONCES_START           = 0x00,
+  RADIOLIB_LORAWAN_PERSISTENCE_SIZE       = RADIOLIB_LORAWAN_NONCES_START,
+  RADIOLIB_LORAWAN_PERSISTENCE_VERSION    = RADIOLIB_LORAWAN_PERSISTENCE_SIZE + 1,
+  RADIOLIB_LORAWAN_PERSISTENCE_KEYS       = RADIOLIB_LORAWAN_PERSISTENCE_VERSION + 2,
+  RADIOLIB_LORAWAN_PERSISTENCE_JOIN_NONCE = RADIOLIB_LORAWAN_PERSISTENCE_KEYS + 4,
+  RADIOLIB_LORAWAN_PERSISTENCE_DEV_NONCE  = RADIOLIB_LORAWAN_PERSISTENCE_JOIN_NONCE + 3,
+  RADIOLIB_LORAWAN_PERSISTENCE_RJ_COUNT   = RADIOLIB_LORAWAN_PERSISTENCE_DEV_NONCE + 2,
+  RADIOLIB_LORAWAN_PERSISTENCE_TS004      = RADIOLIB_LORAWAN_PERSISTENCE_RJ_COUNT + 2,
+  RADIOLIB_LORAWAN_PERSISTENCE_TS009      = RADIOLIB_LORAWAN_PERSISTENCE_TS004 + 8,
+  RADIOLIB_LORAWAN_PERSISTENCE_RFU        = RADIOLIB_LORAWAN_PERSISTENCE_TS009 + 1,
+  RADIOLIB_LORAWAN_PERSISTENCE_SIGNATURE  = RADIOLIB_LORAWAN_PERSISTENCE_RFU + 5,
+  RADIOLIB_LORAWAN_PERSISTENCE_BUF_SIZE   = RADIOLIB_LORAWAN_PERSISTENCE_SIGNATURE + 4
 };
 
 enum LoRaWANSchemeSession_t {
@@ -295,7 +298,7 @@ enum LoRaWANSchemeSession_t {
   RADIOLIB_LORAWAN_SESSION_SNWK_SINT_KEY      = RADIOLIB_LORAWAN_SESSION_FNWK_SINT_KEY + RADIOLIB_AES128_KEY_SIZE,  // 16 bytes
   RADIOLIB_LORAWAN_SESSION_DEV_ADDR           = RADIOLIB_LORAWAN_SESSION_SNWK_SINT_KEY + RADIOLIB_AES128_KEY_SIZE,  // 4 bytes
   RADIOLIB_LORAWAN_SESSION_NONCES_SIGNATURE   = RADIOLIB_LORAWAN_SESSION_DEV_ADDR + sizeof(uint32_t),               // 2 bytes
-  RADIOLIB_LORAWAN_SESSION_FCNT_UP            = RADIOLIB_LORAWAN_SESSION_NONCES_SIGNATURE + sizeof(uint16_t),       // 4 bytes
+  RADIOLIB_LORAWAN_SESSION_FCNT_UP            = RADIOLIB_LORAWAN_SESSION_NONCES_SIGNATURE + sizeof(uint32_t),       // 4 bytes
   RADIOLIB_LORAWAN_SESSION_N_FCNT_DOWN        = RADIOLIB_LORAWAN_SESSION_FCNT_UP + sizeof(uint32_t),        // 4 bytes
   RADIOLIB_LORAWAN_SESSION_A_FCNT_DOWN        = RADIOLIB_LORAWAN_SESSION_N_FCNT_DOWN + sizeof(uint32_t),    // 4 bytes
   RADIOLIB_LORAWAN_SESSION_ADR_FCNT           = RADIOLIB_LORAWAN_SESSION_A_FCNT_DOWN + sizeof(uint32_t),    // 4 bytes
@@ -318,8 +321,8 @@ enum LoRaWANSchemeSession_t {
   RADIOLIB_LORAWAN_SESSION_AVAILABLE_CHANNELS = RADIOLIB_LORAWAN_SESSION_DL_CHANNELS + RADIOLIB_LORAWAN_MAX_NUM_DYNAMIC_CHANNELS*4, // 2 bytes
   RADIOLIB_LORAWAN_SESSION_MAC_QUEUE          = RADIOLIB_LORAWAN_SESSION_AVAILABLE_CHANNELS + RADIOLIB_LORAWAN_MAX_NUM_SUBBANDS,    // 12 bytes                   // 15 bytes
   RADIOLIB_LORAWAN_SESSION_MAC_QUEUE_LEN      = RADIOLIB_LORAWAN_SESSION_MAC_QUEUE + RADIOLIB_LORAWAN_FHDR_FOPTS_MAX_LEN,           // 1 byte
-  RADIOLIB_LORAWAN_SESSION_SIGNATURE          = RADIOLIB_LORAWAN_SESSION_MAC_QUEUE_LEN + sizeof(uint8_t),   // 2 bytes
-  RADIOLIB_LORAWAN_SESSION_BUF_SIZE           = RADIOLIB_LORAWAN_SESSION_SIGNATURE + sizeof(uint16_t)       // Session buffer size
+  RADIOLIB_LORAWAN_SESSION_SIGNATURE          = RADIOLIB_LORAWAN_SESSION_MAC_QUEUE_LEN + sizeof(uint8_t),   // 4 bytes
+  RADIOLIB_LORAWAN_SESSION_BUF_SIZE           = RADIOLIB_LORAWAN_SESSION_SIGNATURE + sizeof(uint32_t)       // Session buffer size
 };
 
 /*!
@@ -561,35 +564,46 @@ class LoRaWANNode {
     LoRaWANNode(PhysicalLayer* phy, const LoRaWANBand_t* band, uint8_t subBand = 0);
 
     /*!
-      \brief Returns the pointer to the internal buffer that holds the LW base parameters
-      \returns Pointer to uint8_t array of size RADIOLIB_LORAWAN_NONCES_BUF_SIZE
-    */
-    uint8_t* getBufferNonces();
-
-    /*!
-      \brief Fill the internal buffer that holds the LW base parameters with a supplied buffer
-      \param persistentBuffer Buffer that should match the internal format (previously extracted using getBufferNonces)
-      \returns \ref status_codes
-    */
-    int16_t setBufferNonces(const uint8_t* persistentBuffer);
-
-    /*!
       \brief Clear an active session. This requires the device to rejoin the network.
     */
     void clearSession();
 
-    /*!
-      \brief Returns the pointer to the internal buffer that holds the LW session parameters
-      \returns Pointer to uint8_t array of size RADIOLIB_LORAWAN_SESSION_BUF_SIZE
-    */
-    uint8_t* getBufferSession();
+    /*! \brief Callback signature for buffer save/load operations. */
+    typedef void (*BufferCb_t)(uint8_t* buf, size_t len);
 
     /*!
-      \brief Fill the internal buffer that holds the LW session parameters with a supplied buffer
-      \param persistentBuffer Buffer that should match the internal format (previously extracted using getBufferSession)
+      \brief Register a callback invoked by the library when the persistence buffer needs to be saved.
+      The callback receives a pointer to the serialized buffer and its length; the user should
+      write this data to non-volatile storage (flash, EEPROM, etc.).
+    */
+    void setCallbackStorePersistence(BufferCb_t cb);
+
+    /*!
+      \brief Register a callback invoked by the library when the persistence buffer needs to be loaded.
+      The callback receives a pointer to the buffer and its length; the user should fill it with
+      data previously saved by the savePersistenceBuffer callback.
+    */
+    void setCallbackRestorePersistence(BufferCb_t cb);
+
+    /*!
+      \brief Register a callback invoked by the library when the session buffer needs to be saved.
+      The callback receives a pointer to the serialized buffer and its length; the user should
+      write this data to persistent RAM on platforms that do not retain normal RAM during sleep.
+    */
+    void setCallbackStoreSession(BufferCb_t cb);
+
+    /*!
+      \brief Register a callback invoked by the library when the session buffer needs to be loaded.
+      The callback receives a pointer to the buffer and its length; the user should fill it with
+      data previously saved by the savePersistenceBuffer callback.
+    */
+    void setCallbackRestoreSession(BufferCb_t cb);
+
+    /*!
+      \brief Trigger the registered buffer callbacks to restore persistence and session buffers.
       \returns \ref status_codes
     */
-    int16_t setBufferSession(const uint8_t* persistentBuffer);
+    int16_t loadBuffers();
 
     /*!
       \brief Set the device credentials and activation configuration
@@ -847,6 +861,18 @@ class LoRaWANNode {
     void setActivityLeds(const uint32_t pins[4]);
 
     /*!
+      \brief Get the persistent buffer for a certain package.
+      NOTE: Do NOT use, for Packages only!
+    */
+    void getPersistencePackage(uint8_t pIndex, uint8_t* buff);
+
+    /*!
+      \brief Set the persistent buffer for a certain package.
+      NOTE: Do NOT use, for Packages only!
+    */
+    void setPersistencePackage(uint8_t pIndex, uint8_t* buff);
+
+    /*!
       \brief Set the exact time a transmission should occur. Note: this is the internal clock time.
       On Arduino platforms, this is the usual time supplied by millis().
       If the supplied time is larger than the current time, sendReceive() or uplink() will delay
@@ -996,7 +1022,7 @@ class LoRaWANNode {
     const LoRaWANBand_t* band = NULL;
 
     // a buffer that holds all LW base parameters that should persist at all times!
-    uint8_t bufferNonces[RADIOLIB_LORAWAN_NONCES_BUF_SIZE] = { 0 };
+    uint8_t bufferPersist[RADIOLIB_LORAWAN_PERSISTENCE_BUF_SIZE] = { 0 };
 
     // a buffer that holds all LW session parameters that preferably persist, but can be afforded to get lost
     uint8_t bufferSession[RADIOLIB_LORAWAN_SESSION_BUF_SIZE] = { 0 };
@@ -1024,7 +1050,7 @@ class LoRaWANNode {
     uint8_t nwkSEncKey[RADIOLIB_AES128_KEY_SIZE] = { 0 };
     uint8_t jSIntKey[RADIOLIB_AES128_KEY_SIZE] = { 0 };
 
-    uint16_t keyCheckSum = 0;
+    uint32_t keyCheckSum = 0;
     
     // device-specific parameters, persistent through sessions
     uint16_t devNonce = 0;
@@ -1125,11 +1151,29 @@ class LoRaWANNode {
     // user-provided sleep callback
     SleepCb_t sleepCb = nullptr;
 
+    // user-provided buffer callbacks
+    BufferCb_t storePersistenceBufferCb = nullptr;
+    BufferCb_t restorePersistenceBufferCb = nullptr;
+    BufferCb_t storeSessionBufferCb = nullptr;
+    BufferCb_t restoreSessionBufferCb = nullptr;
+
     // this will reset the device credentials, so the device starts completely new
-    void clearNonces();
+    void clearPersistence();
+
+    // trigger a save of the persistence buffer
+    void savePersistenceBuffer();
+
+    // load the persistence buffer from non-volatile storage.
+    int16_t loadPersistenceBuffer();
 
     // setup an empty session with default parameters
     void createSession();
+
+    // returns the pointer to the internal buffer that holds the LW session parameters
+    void saveSessionBuffer();
+
+    // fill the internal buffer that holds the LW session parameters with a supplied buffer
+    int16_t loadSessionBuffer();
 
     // setup Join-Request payload
     void composeJoinRequest(uint8_t* joinRequestMsg);
@@ -1248,10 +1292,11 @@ class LoRaWANNode {
     // function that allows sleeping via user-provided callback
     void sleepDelay(RadioLibTime_t ms, bool radioOff = true);
 
-    // 16-bit checksum method that takes a uint8_t array of even length and calculates the checksum
-    static uint16_t checkSum16(const uint8_t *key, uint16_t keyLen);
+    // checksum over a byte array, XOR-ing sizeof(T)-byte big-endian words
+    template<typename T>
+    static T checkSum(const uint8_t* buff, size_t size);
 
-    // check the integrity of a buffer using a 16-bit checksum located in the last two bytes of the buffer
+    // check the integrity of a buffer using a 32-bit checksum located in the last four bytes of the buffer
     static int16_t checkBufferCommon(const uint8_t *buffer, uint16_t size);
 
     // network-to-host conversion method - takes data from network packet and converts it to the host endians
@@ -1287,6 +1332,22 @@ void LoRaWANNode::hton(uint8_t* buff, T val, size_t size) {
   for(size_t i = 0; i < targetSize; i++) {
     *(buffPtr++) = val >> 8*i;
   }
+}
+
+template<typename T>
+T LoRaWANNode::checkSum(const uint8_t* buff, size_t size) {
+  T result = 0;
+  for(uint16_t i = 0; i < size; i += sizeof(T)) {
+    T word = 0;
+    for(size_t j = 0; j < sizeof(T); j++) {
+      word <<= 8;
+      if(i + j < size) {
+        word |= buff[i + j];
+      }
+    }
+    result ^= word;
+  }
+  return(result);
 }
 
 #endif


### PR DESCRIPTION
This PR proposes a rework of the persistence buffer (previously nonces buffer) including some collateral.

There are two main changes:
1. Modified the contents of the persistence buffer as outlined in fix #1789.
2. Moved to a callback system. 

Some packages need persistent values (TS004 and TS009), and having a separate buffer again for the package manager adds double work and overhead. Moreover, these packages - as well as LoRaWAN v1.2 to be released - may update persistent values while a session is running. 
With the current logic, the user would have to check continuously whether something changed and only then write, to prevent wearing NVS. This is very prone to mistakes and wear. With callbacks, the stack can dictate when to save in order to minimize the number of writes.

Passes user tests on a Heltec v3 with TTN; ready for review of the callback system, keeping as draft until verified by LCTT.

Note: the persistence repository must be updated when merging `8.0.0-staging` into `8.0.0`.  
Note2: implement a porting function to update existing persistence buffers to the new format.