### PR TITLE
[PHY][LoRaWAN] Implement LoRa symbol timeout

### DIFF
--- a/extras/test/fuzz/tests/FuzzLoRaWAN.cpp
+++ b/extras/test/fuzz/tests/FuzzLoRaWAN.cpp
@@ -1,6 +1,8 @@
 #include "MockPhysicalLayer.hpp"
 
-extern "C" int FuzzLoRaWAN(const uint8_t* data, size_t size) {
+#include <string.h>
+
+extern "C" int FuzzLoRaWANDownlink(const uint8_t* data, size_t size) {
   if(size < 10) { return(0); }
 
   // initialize default software AES-128
@@ -31,6 +33,44 @@ extern "C" int FuzzLoRaWAN(const uint8_t* data, size_t size) {
   uint8_t outBuffer[256] = {0};
   LoRaWANEvent_t event;
   node.parseDownlink(outBuffer, &outLen, RADIOLIB_LORAWAN_RX1, &event);
+
+  return(0);
+}
+
+static FuzzPhysicalLayer phy;
+static void FuzzLoRaWANPersistCallback(uint8_t* buf, size_t len) {
+  memcpy(buf, phy.currentPacketData, len);
+}
+
+extern "C" int FuzzLoRaWANPersistBuffer(const uint8_t* data, size_t size) {
+  if(size < RADIOLIB_LORAWAN_SESSION_BUF_SIZE) { return(0); }
+
+  // initialize default software AES-128
+  FuzzHal hal;
+  static RadioLibSoftwareAES128 RadioLibAES128Instance;
+  hal.aes128 = &RadioLibAES128Instance;
+
+  // create a FuzzPhysicalLayer with a mock module
+  Module mod(&hal, 1, 2, 3, 4);
+  phy.mod = &mod;
+
+  // pass the input from the fuzzer
+  phy.currentPacketLength = size;
+  phy.currentPacketData = data;
+
+  // set some default AES keys
+  uint8_t defaultKey[16] = { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff };
+
+  // instantiate EU868 band (or any other band)
+  LoRaWANNode node(&phy, &EU868);
+
+  // set persistent buffer callbacks and try to "load" a buffer
+  node.setCallbackRestorePersistence(FuzzLoRaWANPersistCallback);
+  node.setCallbackRestoreSession(FuzzLoRaWANPersistCallback);
+  node.loadBuffers();
+
+  // configure node with keys and addresses
+  node.beginABP(0x12345678, defaultKey, defaultKey, defaultKey, defaultKey);
 
   return(0);
 }

--- a/extras/test/fuzz/tests/FuzzMain.cpp
+++ b/extras/test/fuzz/tests/FuzzMain.cpp
@@ -2,8 +2,11 @@
 #include <stddef.h>
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
-  extern int FuzzLoRaWAN(const uint8_t* data, size_t size);
-  FuzzLoRaWAN(data, size);
+  extern int FuzzLoRaWANDownlink(const uint8_t* data, size_t size);
+  FuzzLoRaWANDownlink(data, size);
+
+  extern int FuzzLoRaWANPersistBuffer(const uint8_t* data, size_t size);
+  FuzzLoRaWANPersistBuffer(data, size);
 
   extern int FuzzPager(const uint8_t* data, size_t size);
   FuzzPager(data, size);

--- a/extras/test/unit/tests/TestPhyComplete.cpp
+++ b/extras/test/unit/tests/TestPhyComplete.cpp
@@ -184,7 +184,7 @@ BOOST_FIXTURE_TEST_CASE(PhyComplete_AllRadios, ModuleFixture) {
     state = radio.phy->getModem(&modem);
     BOOST_TEST(state != RADIOLIB_ERR_UNSUPPORTED);
     
-    RadioModeConfig_t cfg = { .receive = { .timeout = 0, .irqFlags = RADIOLIB_IRQ_RX_DEFAULT_FLAGS, 
+    RadioModeConfig_t cfg = { .receive = { .timeout = 0, .syncSymbols = 0, .irqFlags = RADIOLIB_IRQ_RX_DEFAULT_FLAGS,
       .irqMask = RADIOLIB_IRQ_RX_DEFAULT_MASK, .len = 0 }};
     state = radio.phy->stageMode(RADIOLIB_RADIO_MODE_RX, &cfg);
     BOOST_TEST(state != RADIOLIB_ERR_UNSUPPORTED);

--- a/src/modules/LR11x0/LR11x0.cpp
+++ b/src/modules/LR11x0/LR11x0.cpp
@@ -405,6 +405,7 @@ int16_t LR11x0::startReceiveDutyCycle(uint32_t rxPeriod, uint32_t sleepPeriod, R
   RadioModeConfig_t cfg = {
     .receive = {
       .timeout = RADIOLIB_LR11X0_RX_TIMEOUT_INF,
+      .syncSymbols = 0,
       .irqFlags = irqFlags,
       .irqMask = irqMask,
       .len = 0,
@@ -1505,10 +1506,28 @@ int16_t LR11x0::stageMode(RadioModeType_t mode, RadioModeConfig_t* cfg) {
 
       // restore maximum allowed received packet length (may have been changed by previous Tx)
       if(modem == RADIOLIB_LR11X0_PACKET_TYPE_LORA) {
-        state = setPacketParamsLoRa(this->preambleLengthLoRa, this->headerType, 
-          (this->headerType == RADIOLIB_LRXXXX_LORA_HEADER_IMPLICIT) ? this->implicitLen : RADIOLIB_LR11X0_MAX_PACKET_LENGTH, 
+        state = setPacketParamsLoRa(this->preambleLengthLoRa, this->headerType,
+          (this->headerType == RADIOLIB_LRXXXX_LORA_HEADER_IMPLICIT) ? this->implicitLen : RADIOLIB_LR11X0_MAX_PACKET_LENGTH,
           this->crcTypeLoRa, this->invertIQEnabled);
-      
+        RADIOLIB_ASSERT(state);
+
+        // set the LoRa sync (symbol-number) timeout
+        bool mantissa = false;
+        uint8_t numSymbols = 0;
+        if(cfg->receive.syncSymbols < 0xFF) {
+          numSymbols = cfg->receive.syncSymbols;
+        } else {
+          uint16_t mant = cfg->receive.syncSymbols >> 1;
+          uint8_t exp = 0;
+          while(mant > 31) {
+            mant = (mant + 3) >> 2;
+            exp++;
+          }
+          mantissa = true;
+          numSymbols = (mant << 3) + exp;
+        }
+        state = setLoRaSynchTimeout(numSymbols, mantissa);
+
       } else {
         state = setPacketParamsGFSK(this->preambleLengthGFSK, this->preambleDetLength, this->syncWordLength, this->addrComp, this->packetType, 
           (this->packetType == RADIOLIB_LR11X0_GFSK_PACKET_LENGTH_FIXED) ? this->implicitLen : RADIOLIB_LR11X0_MAX_PACKET_LENGTH,

--- a/src/modules/LR11x0/LR11x0.cpp
+++ b/src/modules/LR11x0/LR11x0.cpp
@@ -1511,22 +1511,7 @@ int16_t LR11x0::stageMode(RadioModeType_t mode, RadioModeConfig_t* cfg) {
           this->crcTypeLoRa, this->invertIQEnabled);
         RADIOLIB_ASSERT(state);
 
-        // set the LoRa sync (symbol-number) timeout
-        bool mantissa = false;
-        uint8_t numSymbols = 0;
-        if(cfg->receive.syncSymbols < 0xFF) {
-          numSymbols = cfg->receive.syncSymbols;
-        } else {
-          uint16_t mant = cfg->receive.syncSymbols >> 1;
-          uint8_t exp = 0;
-          while(mant > 31) {
-            mant = (mant + 3) >> 2;
-            exp++;
-          }
-          mantissa = true;
-          numSymbols = (mant << 3) + exp;
-        }
-        state = setLoRaSynchTimeout(numSymbols, mantissa);
+        state = setLoRaSynchTimeout(cfg->receive.syncSymbols);
 
       } else {
         state = setPacketParamsGFSK(this->preambleLengthGFSK, this->preambleDetLength, this->syncWordLength, this->addrComp, this->packetType, 

--- a/src/modules/LR11x0/LR11x0.h
+++ b/src/modules/LR11x0/LR11x0.h
@@ -858,7 +858,7 @@ class LR11x0: public LRxxxx {
     int16_t setCad(void);
     int16_t setTxCw(void);
     int16_t setTxInfinitePreamble(void);
-    int16_t setLoRaSynchTimeout(uint8_t symbolNum, bool format);
+    int16_t setLoRaSynchTimeout(uint16_t numSymbols);
     int16_t setRangingAddr(uint32_t addr, uint8_t checkLen);
     int16_t setRangingReqAddr(uint32_t addr);
     int16_t getRangingResult(uint8_t type, float* res);

--- a/src/modules/LR11x0/LR11x0.h
+++ b/src/modules/LR11x0/LR11x0.h
@@ -858,7 +858,7 @@ class LR11x0: public LRxxxx {
     int16_t setCad(void);
     int16_t setTxCw(void);
     int16_t setTxInfinitePreamble(void);
-    int16_t setLoRaSynchTimeout(uint8_t symbolNum);
+    int16_t setLoRaSynchTimeout(uint8_t symbolNum, bool format);
     int16_t setRangingAddr(uint32_t addr, uint8_t checkLen);
     int16_t setRangingReqAddr(uint32_t addr);
     int16_t getRangingResult(uint8_t type, float* res);

--- a/src/modules/LR11x0/LR11x0_commands.cpp
+++ b/src/modules/LR11x0/LR11x0_commands.cpp
@@ -563,8 +563,10 @@ int16_t LR11x0::setTxInfinitePreamble(void) {
   return(this->SPIcommand(RADIOLIB_LR11X0_CMD_SET_TX_INFINITE_PREAMBLE, true, NULL, 0));
 }
 
-int16_t LR11x0::setLoRaSynchTimeout(uint8_t symbolNum) {
-  uint8_t buff[1] = { symbolNum };
+// this implementation is not documented in the datasheet, but taken from SWL2001
+// https://github.com/Lora-net/SWL2001/blob/a8ddc544043e72807cf7db532478e1dda734ae7c/lbm_lib/smtc_modem_core/radio_drivers/lr11xx_driver/src/lr11xx_radio.c#L95
+int16_t LR11x0::setLoRaSynchTimeout(uint8_t symbolNum, bool format) {
+  uint8_t buff[2] = { symbolNum, (uint8_t)format };
   return(this->SPIcommand(RADIOLIB_LR11X0_CMD_SET_LORA_SYNCH_TIMEOUT, true, buff, sizeof(buff)));
 }
 

--- a/src/modules/LR11x0/LR11x0_commands.cpp
+++ b/src/modules/LR11x0/LR11x0_commands.cpp
@@ -565,8 +565,22 @@ int16_t LR11x0::setTxInfinitePreamble(void) {
 
 // this implementation is not documented in the datasheet, but taken from SWL2001
 // https://github.com/Lora-net/SWL2001/blob/a8ddc544043e72807cf7db532478e1dda734ae7c/lbm_lib/smtc_modem_core/radio_drivers/lr11xx_driver/src/lr11xx_radio.c#L95
-int16_t LR11x0::setLoRaSynchTimeout(uint8_t symbolNum, bool format) {
-  uint8_t buff[2] = { symbolNum, (uint8_t)format };
+int16_t LR11x0::setLoRaSynchTimeout(uint16_t numSymbols) {
+  bool mantissa = false;
+  uint8_t val = 0;
+  if(numSymbols <= 0xFF) {
+    val = numSymbols;
+  } else {
+    uint16_t mant = numSymbols >> 1;
+    uint8_t exp = 0;
+    while(mant > 31) {
+      mant = (mant + 3) >> 2;
+      exp++;
+    }
+    mantissa = true;
+    val = (mant << 3) + exp;
+  }
+  uint8_t buff[2] = { val, (uint8_t)mantissa };
   return(this->SPIcommand(RADIOLIB_LR11X0_CMD_SET_LORA_SYNCH_TIMEOUT, true, buff, sizeof(buff)));
 }
 

--- a/src/modules/LR2021/LR2021.cpp
+++ b/src/modules/LR2021/LR2021.cpp
@@ -997,22 +997,7 @@ int16_t LR2021::stageMode(RadioModeType_t mode, RadioModeConfig_t* cfg) {
           this->crcTypeLoRa, this->invertIQEnabled);
         RADIOLIB_ASSERT(state);
 
-        // set the LoRa sync (symbol-number) timeout
-        bool mantissa = false;
-        uint8_t numSymbols = 0;
-        if(cfg->receive.syncSymbols < 0xFF) {
-          numSymbols = cfg->receive.syncSymbols;
-        } else {
-          uint16_t mant = cfg->receive.syncSymbols >> 1;
-          uint8_t exp = 0;
-          while(mant > 31) {
-            mant = (mant + 3) >> 2;
-            exp++;
-          }
-          mantissa = true;
-          numSymbols = (mant << 3) + exp;
-        }
-        state = setLoRaSynchTimeout(numSymbols, mantissa);
+        state = setLoRaSynchTimeout(cfg->receive.syncSymbols);
 
       } else if(modem == RADIOLIB_LR2021_PACKET_TYPE_GFSK) {
         state = setGfskPacketParams(this->preambleLengthGFSK, this->preambleDetLength, false, false, this->addrComp, this->packetType,

--- a/src/modules/LR2021/LR2021.cpp
+++ b/src/modules/LR2021/LR2021.cpp
@@ -529,6 +529,7 @@ int16_t LR2021::startReceiveDutyCycle(uint32_t rxPeriod, uint32_t sleepPeriod, R
   RadioModeConfig_t cfg = {
     .receive = {
       .timeout = RADIOLIB_LR2021_RX_TIMEOUT_INF,
+      .syncSymbols = 0,
       .irqFlags = irqFlags,
       .irqMask = irqMask,
       .len = 0,
@@ -991,9 +992,27 @@ int16_t LR2021::stageMode(RadioModeType_t mode, RadioModeConfig_t* cfg) {
 
       // restore maximum allowed received packet length (may have been changed by previous Tx)
       if(modem == RADIOLIB_LR2021_PACKET_TYPE_LORA) {
-        state = setLoRaPacketParams(this->preambleLengthLoRa, this->headerType, 
-          (this->headerType == RADIOLIB_LRXXXX_LORA_HEADER_IMPLICIT) ? this->implicitLen : RADIOLIB_LR2021_MAX_PACKET_LENGTH, 
+        state = setLoRaPacketParams(this->preambleLengthLoRa, this->headerType,
+          (this->headerType == RADIOLIB_LRXXXX_LORA_HEADER_IMPLICIT) ? this->implicitLen : RADIOLIB_LR2021_MAX_PACKET_LENGTH,
           this->crcTypeLoRa, this->invertIQEnabled);
+        RADIOLIB_ASSERT(state);
+
+        // set the LoRa sync (symbol-number) timeout
+        bool mantissa = false;
+        uint8_t numSymbols = 0;
+        if(cfg->receive.syncSymbols < 0xFF) {
+          numSymbols = cfg->receive.syncSymbols;
+        } else {
+          uint16_t mant = cfg->receive.syncSymbols >> 1;
+          uint8_t exp = 0;
+          while(mant > 31) {
+            mant = (mant + 3) >> 2;
+            exp++;
+          }
+          mantissa = true;
+          numSymbols = (mant << 3) + exp;
+        }
+        state = setLoRaSynchTimeout(numSymbols, mantissa);
 
       } else if(modem == RADIOLIB_LR2021_PACKET_TYPE_GFSK) {
         state = setGfskPacketParams(this->preambleLengthGFSK, this->preambleDetLength, false, false, this->addrComp, this->packetType,

--- a/src/modules/LR2021/LR2021.h
+++ b/src/modules/LR2021/LR2021.h
@@ -916,7 +916,7 @@ class LR2021: public LRxxxx {
     // LoRa commands
     int16_t setLoRaModulationParams(uint8_t sf, uint8_t bw, uint8_t cr, uint8_t ldro);
     int16_t setLoRaPacketParams(uint16_t preambleLen, uint8_t hdrType, uint8_t payloadLen, uint8_t crcType, uint8_t invertIQ);
-    int16_t setLoRaSynchTimeout(uint8_t numSymbols, bool format);
+    int16_t setLoRaSynchTimeout(uint16_t numSymbols);
     int16_t setLoRaSyncword(uint8_t syncword);
     int16_t setLoRaSideDetConfig(uint8_t* configs, size_t numSideDets);
     int16_t setLoRaSideDetSyncword(uint8_t* syncwords, size_t numSideDets);

--- a/src/modules/LR2021/LR2021_cmds_lora.cpp
+++ b/src/modules/LR2021/LR2021_cmds_lora.cpp
@@ -32,8 +32,22 @@ int16_t LR2021::setLoRaPacketParams(uint16_t preambleLen, uint8_t hdrType, uint8
   return(this->SPIcommand(RADIOLIB_LR2021_CMD_SET_LORA_PACKET_PARAMS, true, buff, sizeof(buff)));
 }
 
-int16_t LR2021::setLoRaSynchTimeout(uint8_t numSymbols, bool format) {
-  uint8_t buff[] = { numSymbols, (uint8_t)format };
+int16_t LR2021::setLoRaSynchTimeout(uint16_t numSymbols) {
+  bool mantissa = false;
+  uint8_t val = 0;
+  if(numSymbols <= 0xFF) {
+    val = numSymbols;
+  } else {
+    uint16_t mant = numSymbols >> 1;
+    uint8_t exp = 0;
+    while(mant > 31) {
+      mant = (mant + 3) >> 2;
+      exp++;
+    }
+    mantissa = true;
+    val = (mant << 3) + exp;
+  }
+  uint8_t buff[2] = { val, (uint8_t)mantissa };
   return(this->SPIcommand(RADIOLIB_LR2021_CMD_SET_LORA_SYNCH_TIMEOUT, true, buff, sizeof(buff)));
 }
 

--- a/src/modules/SX126x/SX126x.cpp
+++ b/src/modules/SX126x/SX126x.cpp
@@ -497,6 +497,7 @@ int16_t SX126x::startReceiveDutyCycle(uint32_t rxPeriod, uint32_t sleepPeriod, R
   RadioModeConfig_t cfg = {
     .receive = {
       .timeout = RADIOLIB_SX126X_RX_TIMEOUT_INF,
+      .syncSymbols = 0,
       .irqFlags = irqFlags,
       .irqMask = irqMask,
       .len = 0,
@@ -977,6 +978,10 @@ int16_t SX126x::stageMode(RadioModeType_t mode, RadioModeConfig_t* cfg) {
       uint8_t modem = getPacketType();
       if(modem == RADIOLIB_SX126X_PACKET_TYPE_LORA) {
         state = setPacketParams(this->preambleLengthLoRa, this->crcTypeLoRa, this->implicitLen, this->headerType, this->invertIQEnabled);
+        RADIOLIB_ASSERT(state);
+
+        // set the LoRa symbol-number (sync) timeout
+        state = setLoRaSymbNumTimeout((cfg->receive.syncSymbols > 0xFF) ? 0xFF : (uint8_t)cfg->receive.syncSymbols);
       } else if(modem == RADIOLIB_SX126X_PACKET_TYPE_GFSK) {
         state = setPacketParamsFSK(this->preambleLengthFSK, this->preambleDetLength, this->crcTypeFSK, this->syncWordLength, RADIOLIB_SX126X_GFSK_ADDRESS_FILT_OFF, this->whitening,
           this->packetType, (this->packetType == RADIOLIB_SX126X_GFSK_PACKET_FIXED) ? this->implicitLen : RADIOLIB_SX126X_MAX_PACKET_LENGTH);

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -674,15 +674,6 @@ class SX126x: public PhysicalLayer {
     int16_t explicitHeader();
 
     /*!
-      \brief Set the LoRa sync (symbol-number) timeout. In single reception mode, the radio will
-      abort reception if no valid preamble/header is detected within this many LoRa symbols.
-      Only available in LoRa mode.
-      \param symbolNum Number of LoRa symbols to wait for. Set to 0 to disable the timeout.
-      \returns \ref status_codes
-    */
-    int16_t setLoRaSymbNumTimeout(uint8_t symbolNum);
-
-    /*!
       \brief Set regulator mode to LDO.
       \returns \ref status_codes
     */
@@ -893,6 +884,7 @@ class SX126x: public PhysicalLayer {
     int16_t setPacketParamsBPSK(uint8_t payloadLen, uint16_t rampUpDelay, uint16_t rampDownDelay, uint16_t payloadLenBits);
     int16_t setBufferBaseAddress(uint8_t txBaseAddress = 0x00, uint8_t rxBaseAddress = 0x00);
     int16_t setRegulatorMode(uint8_t mode);
+    int16_t setLoRaSymbNumTimeout(uint8_t symbolNum);
     uint8_t getStatus();
     uint32_t getPacketStatus();
     uint16_t getDeviceErrors();

--- a/src/modules/SX126x/SX126x.h
+++ b/src/modules/SX126x/SX126x.h
@@ -674,6 +674,15 @@ class SX126x: public PhysicalLayer {
     int16_t explicitHeader();
 
     /*!
+      \brief Set the LoRa sync (symbol-number) timeout. In single reception mode, the radio will
+      abort reception if no valid preamble/header is detected within this many LoRa symbols.
+      Only available in LoRa mode.
+      \param symbolNum Number of LoRa symbols to wait for. Set to 0 to disable the timeout.
+      \returns \ref status_codes
+    */
+    int16_t setLoRaSymbNumTimeout(uint8_t symbolNum);
+
+    /*!
       \brief Set regulator mode to LDO.
       \returns \ref status_codes
     */

--- a/src/modules/SX126x/SX126x_commands.cpp
+++ b/src/modules/SX126x/SX126x_commands.cpp
@@ -101,6 +101,31 @@ int16_t SX126x::setRx(uint32_t timeout) {
   return(this->mod->SPIwriteStream(RADIOLIB_SX126X_CMD_SET_RX, data, 3, true, false));
 }
 
+// this implementation is not documented in the datasheet, but taken from LoRaMac-node
+// https://github.com/Lora-net/LoRaMac-node/blob/dcbcfb329b4a343ab007bc19ac43a8dc952b3354/src/radio/sx126x/sx126x.c#L367
+int16_t SX126x::setLoRaSymbNumTimeout(uint8_t symbolNum) {
+  // the symbol number timeout is encoded as a mantissa-exponent pair
+  // before being passed to the command
+  uint8_t mant = (symbolNum > RADIOLIB_SX126X_MAX_LORA_SYMB_NUM_TIMEOUT ? RADIOLIB_SX126X_MAX_LORA_SYMB_NUM_TIMEOUT : symbolNum) >> 1;
+  uint8_t exp = 0;
+  while(mant > 31) {
+    mant = (mant + 3) >> 2;
+    exp++;
+  }
+
+  // pass the encoded value to the command
+  uint8_t reg = mant << (2*exp + 1);
+  int16_t state = this->mod->SPIwriteStream(RADIOLIB_SX126X_CMD_SET_LORA_SYMB_NUM_TIMEOUT, &reg, 1);
+  RADIOLIB_ASSERT(state);
+
+  // for non-zero timeouts, the mantissa-exponent value must also be written to a register
+  if(symbolNum != 0) {
+    reg = exp + (mant << 3);
+    state = this->writeRegister(RADIOLIB_SX126X_REG_LORA_SYNC_TIMEOUT, &reg, 1);
+  }
+  return(state);
+}
+
 int16_t SX126x::setCad(uint8_t symbolNum, uint8_t detPeak, uint8_t detMin, uint8_t exitMode, RadioLibTime_t timeout) {
   // default CAD parameters are selected according to recommendations on Semtech DS.SX1261-2.W.APP rev. 1.1, page 92.
 

--- a/src/modules/SX126x/SX126x_commands.h
+++ b/src/modules/SX126x/SX126x_commands.h
@@ -302,6 +302,9 @@
 #define RADIOLIB_SX126X_SCAN_INTERVAL_8_20_US                   11          //  7     0                          8.20 us
 #define RADIOLIB_SX126X_SCAN_INTERVAL_8_68_US                   12          //  7     0                          8.68 us
 
+//RADIOLIB_SX126X_CMD_SET_LORA_SYMB_NUM_TIMEOUT
+#define RADIOLIB_SX126X_MAX_LORA_SYMB_NUM_TIMEOUT               248         //  7     0   maximum supported LoRa symbol number timeout
+
 #endif
 
 #endif

--- a/src/modules/SX127x/SX127x.cpp
+++ b/src/modules/SX127x/SX127x.cpp
@@ -1284,6 +1284,24 @@ RadioLibTime_t SX127x::calculateRxTimeout(RadioLibTime_t timeoutUs) {
   return(timeout);
 }
 
+int16_t SX127x::setLoRaSymbNumTimeout(uint16_t numSymbols) {
+  // this method is only available in LoRa mode
+  if(getActiveModem() != RADIOLIB_SX127X_LORA) {
+    return(RADIOLIB_ERR_WRONG_MODEM);
+  }
+
+  // the symbol timeout is a 10-bit value, split across two registers:
+  // the 2 most significant bits are in REG_MODEM_CONFIG_2, the 8 least significant bits in REG_SYMB_TIMEOUT_LSB
+  if(numSymbols > 0x3FF) {
+    numSymbols = 0x3FF;
+  }
+  uint8_t msb = (uint8_t)((numSymbols >> 8) & 0x03);
+  uint8_t lsb = (uint8_t)(numSymbols & 0xFF);
+  int16_t state = this->mod->SPIsetRegValue(RADIOLIB_SX127X_REG_MODEM_CONFIG_2, msb, 1, 0);
+  state |= this->mod->SPIsetRegValue(RADIOLIB_SX127X_REG_SYMB_TIMEOUT_LSB, lsb);
+  return(state);
+}
+
 uint32_t SX127x::getIrqFlags() {
   return((uint32_t)this->getIRQFlags());
 }
@@ -1767,15 +1785,23 @@ int16_t SX127x::stageMode(RadioModeType_t mode, RadioModeConfig_t* cfg) {
         if(cfg->receive.timeout == 0xFFFFFFFF) {
           cfg->receive.timeout = 0;
         }
-        if(cfg->receive.timeout != 0) {
-          // for non-zero timeout value, change mode to Rx single and set the timeout
-          this->rxMode = RADIOLIB_SX127X_RXSINGLE;
-          uint8_t msb_sym = (cfg->receive.timeout > 0x3FF) ? 0x3 : (uint8_t)(cfg->receive.timeout >> 8);
-          uint8_t lsb_sym = (cfg->receive.timeout > 0x3FF) ? 0xFF : (uint8_t)(cfg->receive.timeout & 0xFF);
-          state = this->mod->SPIsetRegValue(RADIOLIB_SX127X_REG_MODEM_CONFIG_2, msb_sym, 1, 0);
-          state |= this->mod->SPIsetRegValue(RADIOLIB_SX127X_REG_SYMB_TIMEOUT_LSB, lsb_sym);
-          RADIOLIB_ASSERT(state);
+
+        // the SX127x LoRa modem has no dedicated Rx window timer - the only available
+        // timeout is the symbol (sync) timeout. Use the explicit syncSymbols if provided,
+        // otherwise fall back to the timeout value (which is expressed in symbols on this chip).
+        uint16_t symbNum = cfg->receive.syncSymbols;
+        if((symbNum == 0) && (cfg->receive.timeout != 0)) {
+          symbNum = (cfg->receive.timeout > 0x3FF) ? 0x3FF : (uint16_t)cfg->receive.timeout;
         }
+
+        // for non-zero timeout value, set mode to Rx single and set the timeout
+        if(cfg->receive.timeout != 0) {
+          this->rxMode = RADIOLIB_SX127X_RXSINGLE;
+        }
+
+        // set the LoRa symbol-number (sync) timeout
+        state = this->setLoRaSymbNumTimeout(symbNum);
+        RADIOLIB_ASSERT(state);
 
         // in FHSS mode, enable channel change interrupt
         if(this->mod->SPIgetRegValue(RADIOLIB_SX127X_REG_HOP_PERIOD) > RADIOLIB_SX127X_HOP_PERIOD_OFF) {

--- a/src/modules/SX127x/SX127x.h
+++ b/src/modules/SX127x/SX127x.h
@@ -1113,6 +1113,15 @@ class SX127x: public PhysicalLayer {
     RadioLibTime_t calculateRxTimeout(RadioLibTime_t timeoutUs) override;
 
     /*!
+      \brief Set the LoRa sync (symbol-number) timeout. In single reception mode, the radio will
+      abort reception if no valid preamble/header is detected within this many LoRa symbols.
+      Only available in LoRa mode.
+      \param numSymbols Number of LoRa symbols to wait for (0 - 1023). Set to 0 to disable the timeout.
+      \returns \ref status_codes
+    */
+    int16_t setLoRaSymbNumTimeout(uint16_t numSymbols);
+
+    /*!
       \brief Read currently active IRQ flags.
       \returns IRQ flags.
     */

--- a/src/protocols/LoRaWAN/LoRaWAN.cpp
+++ b/src/protocols/LoRaWAN/LoRaWAN.cpp
@@ -1708,7 +1708,7 @@ int16_t LoRaWANNode::receiveClassA(uint8_t dir, const LoRaWANChannel_t* dlChanne
 
   // if we didn't get an IRQ, return 0 for no downlink
   if(!downlinkAction) {
-    RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Downlink missing!");
+    RADIOLIB_DEBUG_PROTOCOL_PRINTLN("No downlink!");
     return(0);
   }
   downlinkAction = false;
@@ -3445,10 +3445,10 @@ int16_t LoRaWANNode::setPhyProperties(const LoRaWANChannel_t* chnl, uint8_t dir,
       syncWordLen = 3;
       RADIOLIB_DEBUG_PROTOCOL_PRINT("[FSK] BR = ");
       RADIOLIB_DEBUG_PROTOCOL_PRINT_FLOAT_NOTAG((double)dr->fsk.bitRate, 1);
-      RADIOLIB_DEBUG_PROTOCOL_PRINT(", FD = ");
+      RADIOLIB_DEBUG_PROTOCOL_PRINT_NOTAG(", FD = ");
       RADIOLIB_DEBUG_PROTOCOL_PRINT_FLOAT_NOTAG((double)dr->fsk.freqDev, 1);
       RADIOLIB_DEBUG_PROTOCOL_PRINTLN_NOTAG(" kHz");
-                                      
+
     } break;
 
     case(ModemType_t::RADIOLIB_MODEM_LORA): {

--- a/src/protocols/LoRaWAN/LoRaWAN.cpp
+++ b/src/protocols/LoRaWAN/LoRaWAN.cpp
@@ -1674,7 +1674,8 @@ int16_t LoRaWANNode::receiveClassA(uint8_t dir, const LoRaWANChannel_t* dlChanne
   }
   
   // use a software window length of minimum 16ms (regardless of modulation) up to max time-on-air
-  RadioLibTime_t windowLength = RADIOLIB_MAX(16, toaMaxUs / 1000);
+  // add an 11% padding to the maximum time on air to give some slack for the interrupt
+  RadioLibTime_t windowLength = RADIOLIB_MAX(16, toaMaxUs / 900);
   RadioLibTime_t tWindowClose = tWindowOpen + windowLength + this->scanGuard;
 
   // wait for the DIO interrupt to fire (RxDone or RxTimeout)
@@ -1765,6 +1766,7 @@ int16_t LoRaWANNode::receiveClassC(RadioLibTime_t timeout) {
   modeCfg.receive.len = 0;
   modeCfg.receive.timeout = 0xFFFFFFFF;   // max(uint32_t) is used for RxContinuous
   modeCfg.receive.syncSymbols = 0;        // disable preamble timeout for RxContinuous
+
   state = this->phyLayer->stageMode(RADIOLIB_RADIO_MODE_RX, &modeCfg);
   RADIOLIB_ASSERT(state);
 

--- a/src/protocols/LoRaWAN/LoRaWAN.cpp
+++ b/src/protocols/LoRaWAN/LoRaWAN.cpp
@@ -1567,7 +1567,7 @@ int16_t LoRaWANNode::transmitUplink(const LoRaWANChannel_t* chnl, uint8_t* in, u
     // yield for multi-threaded platforms
     mod->hal->yield();
 
-    if(mod->hal->millis() > txEnd + this->scanGuard) {
+    if(mod->hal->millis() > txEnd + toa) {
       return(RADIOLIB_ERR_TX_TIMEOUT);
     }
   }
@@ -1600,39 +1600,41 @@ static void LoRaWANNodeOnDownlinkAction(void) {
 }
 
 int16_t LoRaWANNode::receiveClassA(uint8_t dir, const LoRaWANChannel_t* dlChannel, uint8_t window, const RadioLibTime_t dlDelay, RadioLibTime_t tReference) {
-  Module* mod = this->phyLayer->getMod();
-
-  int16_t state = RADIOLIB_ERR_UNKNOWN;
-
-  // either both must be set or none
-  if((dlDelay == 0 && tReference > 0) || (dlDelay > 0 && tReference == 0)) {
+  // Class A windows must be timed
+  if(dlDelay == 0 || tReference == 0) {
     return(RADIOLIB_ERR_NO_RX_WINDOW);
   }
 
-  const uint8_t currentDr = dlChannel->dr;
-  const ModemType_t modem = this->band->dataRates[currentDr].modem;
-  const DataRate_t* dr = &this->band->dataRates[currentDr].dr;
-  const PacketConfig_t* pc = &this->band->dataRates[currentDr].pc;
-  RadioLibTime_t toaMinUs = this->phyLayer->calculateTimeOnAir(modem, *dr, *pc, 0);
-
-  // get the maximum allowed Time-on-Air of a packet given the current datarate
-  uint8_t maxPayLen = this->band->payloadLenMax[currentDr];
-  
-  RadioLibTime_t toaMaxMs = this->phyLayer->calculateTimeOnAir(modem, *dr, *pc, maxPayLen + 13) / 1000;
-
   // set the physical layer configuration for downlink
-  state = this->setPhyProperties(dlChannel, dir, this->txPowerMax - 2*this->txPowerSteps);
+  int16_t state = this->setPhyProperties(dlChannel, dir, this->txPowerMax - 2*this->txPowerSteps);
   RADIOLIB_ASSERT(state);
-
-  // calculate the timeout of an empty packet plus scanGuard
-  RadioLibTime_t timeoutUs = toaMinUs + this->scanGuard*1000;
+  
+  // get the maximum allowed Time-on-Air of a packet given the current datarate
+  uint8_t currentDr = dlChannel->dr;
+  uint8_t maxPayLen = this->band->payloadLenMax[currentDr];
+  RadioLibTime_t toaMaxUs = this->phyLayer->getTimeOnAir(maxPayLen + 13);
 
   // set the radio Rx parameters
   RadioModeConfig_t modeCfg;
   modeCfg.receive.irqFlags = RADIOLIB_IRQ_RX_DEFAULT_FLAGS;
   modeCfg.receive.irqMask = RADIOLIB_IRQ_RX_DEFAULT_MASK;
   modeCfg.receive.len = 0;
-  modeCfg.receive.timeout = this->phyLayer->calculateRxTimeout(timeoutUs);
+  modeCfg.receive.syncSymbols = 0;
+  modeCfg.receive.timeout = 0;
+  
+  // for LoRa, use at least 6 symbols and at least 16ms
+  ModemType_t modem = this->band->dataRates[currentDr].modem;
+  if(this->band->dataRates[currentDr].modem == RADIOLIB_MODEM_LORA) {
+    const DataRate_t* dr = &this->band->dataRates[currentDr].dr;
+    uint32_t tSymbUs = ((1UL << dr->lora.spreadingFactor) * 1000) / dr->lora.bandwidth;
+    if(6 * tSymbUs > (16 + this->scanGuard) * 1000) {
+      modeCfg.receive.syncSymbols = 6;
+    } else {
+      modeCfg.receive.syncSymbols = ((16 + this->scanGuard) * 1000) / tSymbUs + 1;
+    }
+    modeCfg.receive.timeout = this->phyLayer->calculateRxTimeout(toaMaxUs * 1.1);
+  }
+  // for FSK, there is no timeout register, so we just use the 16ms software timeout
 
   state = this->phyLayer->stageMode(RADIOLIB_RADIO_MODE_RX, &modeCfg);
   RADIOLIB_ASSERT(state);
@@ -1641,38 +1643,53 @@ int16_t LoRaWANNode::receiveClassA(uint8_t dir, const LoRaWANChannel_t* dlChanne
   this->phyLayer->setPacketReceivedAction(LoRaWANNodeOnDownlinkAction);
   downlinkAction = false;
 
-  // if the Rx window must be awaited, do so
-  RadioLibTime_t tNow = mod->hal->millis();
-  if(dlDelay > 0 && tReference > 0) {
-    // calculate time at which the window should open
-    // - the launch of Rx window takes a few milliseconds, so shorten the waitLen a bit (launchDuration)
-    // - the Rx window is padded using scanGuard, so shorten the waitLen a bit (scanGuard / 2)
-    RadioLibTime_t tWindow = tReference + dlDelay - this->launchDuration - this->scanGuard / 2;
-    if(tNow > tWindow) {
-      RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Window too late by %d ms", tNow - tWindow);
-      return(RADIOLIB_ERR_NO_RX_WINDOW);
-    }
-    this->sleepDelay(tWindow - tNow);
-  }
+  // calculate time at which the window should open
+  // - the launch of Rx window takes a few milliseconds, so compensate for that (launchDuration)
+  // - the Rx window is padded using scanGuard, so compensate for that (scanGuard / 2)
+  RadioLibTime_t tWindowOpen = tReference + dlDelay - this->launchDuration - this->scanGuard / 2;
 
+  Module* mod = this->phyLayer->getMod();
+  RadioLibTime_t tNow = mod->hal->millis();
+  if(tNow > tWindowOpen) {
+    RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Window too late by %d ms", tNow - tWindowOpen);
+    return(RADIOLIB_ERR_NO_RX_WINDOW);
+  }
+  
+  // wait until the Rx window must open minus launchDuration
+  this->sleepDelay(tWindowOpen - tNow);
+  
+  // open Rx window by starting receive
+  state = this->phyLayer->launchMode();
+  
+  // get all window timings
+  tWindowOpen = mod->hal->millis(); // this should be exactly `launchDuration` later than the calculated value
+  
+  RADIOLIB_ASSERT(state);
+  RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Rx%d window open (%lu ms)", window, this->scanGuard);
+  
+  // enable the LED if used
   if(window < 4 && this->ledPins[window] != RADIOLIB_NC) {
     mod->hal->digitalWrite(this->ledPins[window], mod->hal->GpioLevelHigh);
   }
+  
+  // use a software window length of minimum 16ms (regardless of modulation) up to max time-on-air
+  RadioLibTime_t windowLength = RADIOLIB_MAX(16, toaMaxUs / 1000);
+  RadioLibTime_t tWindowClose = tWindowOpen + windowLength + this->scanGuard;
 
-  // open Rx window by starting receive with specified timeout
-  state = this->phyLayer->launchMode();
-  RadioLibTime_t tOpen = mod->hal->millis();
-  RADIOLIB_ASSERT(state);
-  RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Rx%d window open (%lu + %lu ms)", window, timeoutUs / 1000UL, this->scanGuard);
-  
-  // sleep for the duration of the padded Rx window
-  this->sleepDelay(timeoutUs / 1000, false);
-  
   // wait for the DIO interrupt to fire (RxDone or RxTimeout)
-  // use a small additional delay in case the RxTimeout interrupt is slow to fire
-  RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Rx%d window closing", window);
-  while(!downlinkAction && mod->hal->millis() - tOpen <= timeoutUs / 1000 + this->scanGuard) {
+  // apply 2ms padding in case the RxTimeout interrupt is slow to fire
+  while(!downlinkAction && mod->hal->millis() <= tWindowClose + 2) {
     mod->hal->yield();
+  }
+
+  // get the actual window close timestamp
+  tWindowClose = mod->hal->millis();
+  RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Rx%d window closed", window);
+
+  this->phyLayer->clearPacketReceivedAction();
+  this->phyLayer->standby();
+  if(window < 4 && this->ledPins[window] != RADIOLIB_NC) {
+    mod->hal->digitalWrite(this->ledPins[window], mod->hal->GpioLevelLow);
   }
 
   // check IRQ bit for RxTimeout
@@ -1680,49 +1697,14 @@ int16_t LoRaWANNode::receiveClassA(uint8_t dir, const LoRaWANChannel_t* dlChanne
   if(timedOut == RADIOLIB_ERR_UNSUPPORTED) {
     return(timedOut);
   }
-
+  
   // if the IRQ bit for RxTimeout is set, put chip in standby and return
-  if(timedOut) {
-    this->phyLayer->clearPacketReceivedAction();
+  if(timedOut) {  
     this->phyLayer->clearIrq(1UL << RADIOLIB_IRQ_TIMEOUT);
-    this->phyLayer->standby();
-    if(window < 4 && this->ledPins[window] != RADIOLIB_NC) {
-      mod->hal->digitalWrite(this->ledPins[window], mod->hal->GpioLevelLow);
-    }
     return(0);  // no downlink
   }
-  
-  // if the IRQ bit for RxTimeout is not set, something is being received, 
-  // so keep listening for maximum ToA waiting for the DIO to fire
-  while(!downlinkAction && mod->hal->millis() - tOpen < toaMaxMs + this->scanGuard) {
-    mod->hal->yield();
-  }
-  
-  // sometimes we can get to a state when reception is still ongoing, but has not finished yet
-  // this has been observed on LR2021 - wait until either timeout, or Rx done is raised
-  // it should never take more than 300 ms
-  RadioLibTime_t start = mod->hal->millis();
-  while(!this->phyLayer->checkIrq(RADIOLIB_IRQ_TIMEOUT) && !this->phyLayer->checkIrq(RADIOLIB_IRQ_RX_DONE)) {
-    mod->hal->yield();
-    if(mod->hal->millis() - start >= 300) {
-      RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Timeout without IRQ!");
-      break;
-    }
-  }
 
-  // update time of downlink reception
-  if(downlinkAction) {
-    this->tDownlink = mod->hal->millis();
-  }
-
-  // we have a message, clear actions, go to standby
-  this->phyLayer->clearPacketReceivedAction();
-  this->phyLayer->standby();
-  if(window < 4 && this->ledPins[window] != RADIOLIB_NC) {
-    mod->hal->digitalWrite(this->ledPins[window], mod->hal->GpioLevelLow);
-  }
-
-  // if all windows passed without receiving anything, return 0 for no window
+  // if we didn't get an IRQ, return 0 for no downlink
   if(!downlinkAction) {
     RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Downlink missing!");
     return(0);
@@ -1735,6 +1717,16 @@ int16_t LoRaWANNode::receiveClassA(uint8_t dir, const LoRaWANChannel_t* dlChanne
   if(this->phyLayer->getPacketLength() > (size_t)(maxPayLen + 13)) {  // mandatory FHDR is 12/13 bytes
     return(0);  // act as if no downlink was received
   }
+  
+  // update time of downlink reception
+  this->tDownlink = tWindowClose;
+#if RADIOLIB_DEBUG_PROTOCOL
+  RadioLibTime_t packetToaMs = this->phyLayer->getTimeOnAir(this->phyLayer->getPacketLength()) / 1000;
+  RadioLibTime_t tHeaderStart = this->tDownlink - packetToaMs;
+  int diff = tHeaderStart - tWindowOpen;
+  RadioLibTime_t diffAbs = RADIOLIB_ABS(diff);
+  RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Rx window timing: %dms %s", diffAbs, diff < 0 ? "late" : "early");
+#endif
 
   // return downlink window number (1/2)
   return(window);
@@ -1767,16 +1759,11 @@ int16_t LoRaWANNode::receiveClassC(RadioLibTime_t timeout) {
   
   // configure radio
   RadioModeConfig_t modeCfg;
-  if(timeout) {
-    timeout -= (mod->hal->millis() - tStart);
-    timeout -= this->launchDuration;
-    modeCfg.receive.timeout = this->phyLayer->calculateRxTimeout(timeout * 1000);
-  } else {
-    modeCfg.receive.timeout = 0xFFFFFFFF; // max(uint32_t) is used for RxContinuous
-  }
   modeCfg.receive.irqFlags = RADIOLIB_IRQ_RX_DEFAULT_FLAGS;
   modeCfg.receive.irqMask = RADIOLIB_IRQ_RX_DEFAULT_MASK;
   modeCfg.receive.len = 0;
+  modeCfg.receive.timeout = 0xFFFFFFFF;   // max(uint32_t) is used for RxContinuous
+  modeCfg.receive.syncSymbols = 0;        // disable preamble timeout for RxContinuous
   state = this->phyLayer->stageMode(RADIOLIB_RADIO_MODE_RX, &modeCfg);
   RADIOLIB_ASSERT(state);
 

--- a/src/protocols/LoRaWAN/LoRaWAN.cpp
+++ b/src/protocols/LoRaWAN/LoRaWAN.cpp
@@ -1665,7 +1665,8 @@ int16_t LoRaWANNode::receiveClassA(uint8_t dir, const LoRaWANChannel_t* dlChanne
   tWindowOpen = mod->hal->millis(); // this should be exactly `launchDuration` later than the calculated value
   
   RADIOLIB_ASSERT(state);
-  RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Rx%d window open (%lu ms)", window, this->scanGuard);
+  RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Rx%d window open (timeout: %lu symbols and %lu units + %dms)", 
+                                  window, modeCfg.receive.syncSymbols, modeCfg.receive.timeout, this->scanGuard);
   
   // enable the LED if used
   if(window < 4 && this->ledPins[window] != RADIOLIB_NC) {

--- a/src/protocols/LoRaWAN/LoRaWAN.cpp
+++ b/src/protocols/LoRaWAN/LoRaWAN.cpp
@@ -203,6 +203,7 @@ int16_t LoRaWANNode::sendReceive(const uint8_t* dataUp, size_t lenUp, uint8_t fP
       // sometimes, a spurious error can occur even though the uplink was transmitted
       // therefore, just to be safe, increase frame counter by one for the next uplink
       this->fCntUp += 1;
+      this->saveSessionBuffer();
 
       #if !RADIOLIB_STATIC_ONLY
       delete[] uplinkMsg;
@@ -265,6 +266,7 @@ int16_t LoRaWANNode::sendReceive(const uint8_t* dataUp, size_t lenUp, uint8_t fP
 
   // if a hardware error occurred, return
   if(state < RADIOLIB_ERR_NONE) {
+    this->saveSessionBuffer();
     return(state);
   }
 
@@ -278,11 +280,16 @@ int16_t LoRaWANNode::sendReceive(const uint8_t* dataUp, size_t lenUp, uint8_t fP
     }
     // remove only non-persistent MAC commands, the other commands should be re-sent until downlink is received
     LoRaWANNode::clearMacCommands(this->fOptsUp, &this->fOptsUpLen, RADIOLIB_LORAWAN_UPLINK);
+    this->saveSessionBuffer();
     return(rxWindow);
   }
   
+  // parse the contents - if there is a parsing error, silently drop it
   state = this->parseDownlink(dataDown, lenDown, rxWindow, eventDown);
   RADIOLIB_ASSERT(state);
+
+  // parsed all nicely, save the buffer
+  this->saveSessionBuffer();
 
   // open RxC window (this returns if not applicable)
   this->receiveClassC();
@@ -291,63 +298,82 @@ int16_t LoRaWANNode::sendReceive(const uint8_t* dataUp, size_t lenUp, uint8_t fP
   return(rxWindow);
 }
 
-void LoRaWANNode::clearNonces() {
-  // clear & set all the device credentials
-  memset(this->bufferNonces, 0, RADIOLIB_LORAWAN_NONCES_BUF_SIZE);
+void LoRaWANNode::clearPersistence() {
+  // clear all the persistent values
+  memset(this->bufferPersist, 0, RADIOLIB_LORAWAN_PERSISTENCE_BUF_SIZE);
+  // reset TS004's fragmentation nonces to 0xFFFF to accept initial value 0
+  memset(&this->bufferPersist[RADIOLIB_LORAWAN_PERSISTENCE_TS004], 0xFF, 8);
+  // allow enabling of TS009's test mode by setting to 1
+  this->bufferPersist[RADIOLIB_LORAWAN_PERSISTENCE_TS009] = 0x01;
+
   this->keyCheckSum = 0;
   this->devNonce = 0;
   this->joinNonce = 0;
   this->sessionStatus = RADIOLIB_LORAWAN_SESSION_NONE;
 }
 
-uint8_t* LoRaWANNode::getBufferNonces() {
+void LoRaWANNode::savePersistenceBuffer() {
+  if(!this->storePersistenceBufferCb) {
+    return;
+  }
+
   // set the device credentials
-  LoRaWANNode::hton<uint16_t>(&this->bufferNonces[RADIOLIB_LORAWAN_NONCES_VERSION], RADIOLIB_LORAWAN_NONCES_VERSION_VAL);
-  LoRaWANNode::hton<uint16_t>(&this->bufferNonces[RADIOLIB_LORAWAN_NONCES_MODE], this->lwMode);
-  LoRaWANNode::hton<uint8_t>(&this->bufferNonces[RADIOLIB_LORAWAN_NONCES_PLAN], this->band->bandNum);
-  LoRaWANNode::hton<uint16_t>(&this->bufferNonces[RADIOLIB_LORAWAN_NONCES_CHECKSUM], this->keyCheckSum);
+  LoRaWANNode::hton<uint8_t>(&this->bufferPersist[RADIOLIB_LORAWAN_PERSISTENCE_SIZE], RADIOLIB_LORAWAN_PERSISTENCE_BUF_SIZE);
+  LoRaWANNode::hton<uint16_t>(&this->bufferPersist[RADIOLIB_LORAWAN_PERSISTENCE_VERSION], RADIOLIB_LORAWAN_NONCES_VERSION_VAL);
+  LoRaWANNode::hton<uint32_t>(&this->bufferPersist[RADIOLIB_LORAWAN_PERSISTENCE_KEYS], this->keyCheckSum);
+  LoRaWANNode::hton<uint32_t>(&this->bufferPersist[RADIOLIB_LORAWAN_PERSISTENCE_JOIN_NONCE], this->joinNonce, 3);
+  LoRaWANNode::hton<uint16_t>(&this->bufferPersist[RADIOLIB_LORAWAN_PERSISTENCE_DEV_NONCE], this->devNonce);
+  // RJ_COUNT: future version 1.2
+  // TS004: set by package manager
+  // TS009: set by package manager
 
-  // generate the signature of the Nonces buffer, and store it in the last two bytes of the Nonces buffer
-  uint16_t signature = LoRaWANNode::checkSum16(this->bufferNonces, RADIOLIB_LORAWAN_NONCES_BUF_SIZE - 2);
-  LoRaWANNode::hton<uint16_t>(&this->bufferNonces[RADIOLIB_LORAWAN_NONCES_SIGNATURE], signature);
+  // generate the signature of the Persistence buffer, 
+  // and store it in the last four bytes of the Persistence buffer
+  uint32_t signature = LoRaWANNode::checkSum<uint32_t>(this->bufferPersist, RADIOLIB_LORAWAN_PERSISTENCE_BUF_SIZE - sizeof(uint32_t));
+  LoRaWANNode::hton<uint32_t>(&this->bufferPersist[RADIOLIB_LORAWAN_PERSISTENCE_SIGNATURE], signature);
+  
+  // trigger the callback
+  this->storePersistenceBufferCb(this->bufferPersist, RADIOLIB_LORAWAN_PERSISTENCE_BUF_SIZE);
 
-  return(this->bufferNonces);
+  // also update the signature in the session buffer
+  LoRaWANNode::hton<uint32_t>(&this->bufferSession[RADIOLIB_LORAWAN_SESSION_NONCES_SIGNATURE], signature);
 }
 
-int16_t LoRaWANNode::setBufferNonces(const uint8_t* persistentBuffer) {
+int16_t LoRaWANNode::loadPersistenceBuffer() {
+  if(!this->restorePersistenceBufferCb) {
+    return(RADIOLIB_ERR_NULL_POINTER);
+  }
+  
   if(this->isActivated()) {
     RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Did not update buffer: session already active");
     return(RADIOLIB_ERR_NONE);
   }
 
-  // // this code can be used in case breaking chances must be caught:
-  // uint8_t nvm_table_version = this->bufferNonces[RADIOLIB_LORAWAN_NONCES_VERSION];
-  // if (RADIOLIB_LORAWAN_NONCES_VERSION_VAL > nvm_table_version) {
-  //  // set default values for variables that are new or something
-  // }
+  uint8_t buff[RADIOLIB_LORAWAN_PERSISTENCE_BUF_SIZE];
+  this->restorePersistenceBufferCb(buff, RADIOLIB_LORAWAN_PERSISTENCE_BUF_SIZE);
 
-  int16_t state = LoRaWANNode::checkBufferCommon(persistentBuffer, RADIOLIB_LORAWAN_NONCES_BUF_SIZE);
+  // can parse old versions here if necessary
+
+  // check the buffer signature
+  int16_t state = LoRaWANNode::checkBufferCommon(buff, RADIOLIB_LORAWAN_PERSISTENCE_BUF_SIZE);
   RADIOLIB_ASSERT(state);
 
-  bool isSameKeys = LoRaWANNode::ntoh<uint16_t>(&persistentBuffer[RADIOLIB_LORAWAN_NONCES_CHECKSUM]) == this->keyCheckSum;
-  bool isSameMode = LoRaWANNode::ntoh<uint16_t>(&persistentBuffer[RADIOLIB_LORAWAN_NONCES_MODE]) == this->lwMode;
-  bool isSamePlan  = LoRaWANNode::ntoh<uint8_t>(&persistentBuffer[RADIOLIB_LORAWAN_NONCES_PLAN]) == this->band->bandNum;
-
-  // check if Nonces buffer matches the current configuration
-  if(!isSameKeys || !isSameMode || !isSamePlan) {
+  // check if Persistence buffer matches the current configuration
+  uint32_t testCheckSum = LoRaWANNode::ntoh<uint32_t>(&buff[RADIOLIB_LORAWAN_PERSISTENCE_KEYS]);
+  if(testCheckSum != this->keyCheckSum) {
     // if configuration did not match, discard whatever is currently in the buffers and start fresh
-    RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Configuration mismatch (keys: %d, mode: %d, plan: %d)", isSameKeys, isSameMode, isSamePlan);
-    RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Discarding the Nonces buffer:");
-    RADIOLIB_DEBUG_PROTOCOL_HEXDUMP(persistentBuffer, RADIOLIB_LORAWAN_NONCES_BUF_SIZE);
+    RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Configuration mismatch (key checksum: %08lX, got: %08lX)", this->keyCheckSum, testCheckSum);
     return(RADIOLIB_ERR_NONCES_DISCARDED);
   }
 
   // copy the whole buffer over
-  memcpy(this->bufferNonces, persistentBuffer, RADIOLIB_LORAWAN_NONCES_BUF_SIZE);
+  memcpy(this->bufferPersist, buff, RADIOLIB_LORAWAN_PERSISTENCE_BUF_SIZE);
 
-  this->devNonce  = LoRaWANNode::ntoh<uint16_t>(&this->bufferNonces[RADIOLIB_LORAWAN_NONCES_DEV_NONCE]);
-  this->joinNonce = LoRaWANNode::ntoh<uint32_t>(&this->bufferNonces[RADIOLIB_LORAWAN_NONCES_JOIN_NONCE], 3);
-
+  this->devNonce  = LoRaWANNode::ntoh<uint16_t>(&this->bufferPersist[RADIOLIB_LORAWAN_PERSISTENCE_DEV_NONCE]);
+  this->joinNonce = LoRaWANNode::ntoh<uint32_t>(&this->bufferPersist[RADIOLIB_LORAWAN_PERSISTENCE_JOIN_NONCE], 3);
+  // RJ_COUNT: future version 1.2
+  // TS004: retrieved by package manager
+  // TS009: retrieved by package manager
   return(state);
 }
 
@@ -504,7 +530,11 @@ void LoRaWANNode::createSession() {
   this->sessionStatus = RADIOLIB_LORAWAN_SESSION_ACTIVATING;
 }
 
-uint8_t* LoRaWANNode::getBufferSession() {
+void LoRaWANNode::saveSessionBuffer() {
+  if(!this->storeSessionBufferCb) {
+    return;
+  }
+
   // store all frame counters
   LoRaWANNode::hton<uint32_t>(&this->bufferSession[RADIOLIB_LORAWAN_SESSION_A_FCNT_DOWN], this->aFCntDown);
   LoRaWANNode::hton<uint32_t>(&this->bufferSession[RADIOLIB_LORAWAN_SESSION_N_FCNT_DOWN], this->nFCntDown);
@@ -527,32 +557,40 @@ uint8_t* LoRaWANNode::getBufferSession() {
   LoRaWANNode::hton<uint8_t>(&this->bufferSession[RADIOLIB_LORAWAN_SESSION_STATUS], this->sessionStatus);
 
   // generate the signature of the Session buffer, and store it in the last two bytes of the Session buffer
-  uint16_t signature = LoRaWANNode::checkSum16(this->bufferSession, RADIOLIB_LORAWAN_SESSION_BUF_SIZE - 2);
-  LoRaWANNode::hton<uint16_t>(&this->bufferSession[RADIOLIB_LORAWAN_SESSION_SIGNATURE], signature);
-  
-  return(this->bufferSession);
+  uint32_t signature = LoRaWANNode::checkSum<uint32_t>(this->bufferSession, RADIOLIB_LORAWAN_SESSION_BUF_SIZE - sizeof(uint32_t));
+  LoRaWANNode::hton<uint32_t>(&this->bufferSession[RADIOLIB_LORAWAN_SESSION_SIGNATURE], signature);
+
+  // trigger the callback
+  this->storeSessionBufferCb(this->bufferSession, RADIOLIB_LORAWAN_SESSION_BUF_SIZE);
 }
 
-int16_t LoRaWANNode::setBufferSession(const uint8_t* persistentBuffer) {
+int16_t LoRaWANNode::loadSessionBuffer() {
+  if(!this->restoreSessionBufferCb) {
+    return(RADIOLIB_ERR_NULL_POINTER);
+  }
+  
   if(this->isActivated()) {
     RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Did not update buffer: session already active");
     return(RADIOLIB_ERR_NONE);
   }
 
-  int16_t state = LoRaWANNode::checkBufferCommon(persistentBuffer, RADIOLIB_LORAWAN_SESSION_BUF_SIZE);
+  uint8_t buff[RADIOLIB_LORAWAN_SESSION_BUF_SIZE];
+  this->restoreSessionBufferCb(buff, RADIOLIB_LORAWAN_SESSION_BUF_SIZE);
+
+  int16_t state = LoRaWANNode::checkBufferCommon(buff, RADIOLIB_LORAWAN_SESSION_BUF_SIZE);
   RADIOLIB_ASSERT(state);
 
-  // the Nonces buffer holds a checksum signature - compare this to the signature that is in the session buffer
-  uint16_t signatureNonces = LoRaWANNode::ntoh<uint16_t>(&this->bufferNonces[RADIOLIB_LORAWAN_NONCES_SIGNATURE]);
-  uint16_t signatureInSession = LoRaWANNode::ntoh<uint16_t>(&persistentBuffer[RADIOLIB_LORAWAN_SESSION_NONCES_SIGNATURE]);
-  if(signatureNonces != signatureInSession) {
-    RADIOLIB_DEBUG_PROTOCOL_PRINTLN("The Session buffer (%04x) does not match the Nonces buffer (%04x)",
-                                    signatureInSession, signatureNonces);
+  // the Persistence buffer holds a checksum signature - compare this to the signature that is in the session buffer
+  uint32_t signaturePersist = LoRaWANNode::ntoh<uint32_t>(&this->bufferPersist[RADIOLIB_LORAWAN_PERSISTENCE_SIGNATURE]);
+  uint32_t signatureSession = LoRaWANNode::ntoh<uint32_t>(&buff[RADIOLIB_LORAWAN_SESSION_NONCES_SIGNATURE]);
+  if(signaturePersist != signatureSession) {
+    RADIOLIB_DEBUG_PROTOCOL_PRINTLN("The Session signature (%08lX) does not match the Persistence signature (%08lX)",
+                                    signatureSession, signaturePersist);
     return(RADIOLIB_ERR_SESSION_DISCARDED);
   }
 
   // copy the whole buffer over
-  memcpy(this->bufferSession, persistentBuffer, RADIOLIB_LORAWAN_SESSION_BUF_SIZE);
+  memcpy(this->bufferSession, buff, RADIOLIB_LORAWAN_SESSION_BUF_SIZE);
 
   // setup the default channels
   if(this->band->bandType == RADIOLIB_LORAWAN_BAND_DYNAMIC) {
@@ -655,7 +693,7 @@ int16_t LoRaWANNode::setBufferSession(const uint8_t* persistentBuffer) {
   this->fCntUp       = LoRaWANNode::ntoh<uint32_t>(&this->bufferSession[RADIOLIB_LORAWAN_SESSION_FCNT_UP]);
   this->rxAFCnt      = LoRaWANNode::ntoh<uint32_t>(&this->bufferSession[RADIOLIB_LORAWAN_SESSION_RX_A_FCNT]);
 
-  // as both the Nonces and session are restored, revert to active session
+  // as both the persistence and session are restored, revert to active session
   this->sessionStatus = RADIOLIB_LORAWAN_SESSION_PENDING;
 
   return(state);
@@ -666,7 +704,7 @@ int16_t LoRaWANNode::beginOTAA(uint64_t joinEUI, uint64_t devEUI, const uint8_t*
     return(RADIOLIB_ERR_NULL_POINTER);
   }
   // clear all the device parameters in case there were any
-  this->clearNonces();
+  this->clearPersistence();
   this->clearSession();
 
   this->joinEUI = joinEUI;
@@ -678,11 +716,12 @@ int16_t LoRaWANNode::beginOTAA(uint64_t joinEUI, uint64_t devEUI, const uint8_t*
   }
 
   // generate activation key checksum
-  this->keyCheckSum ^= LoRaWANNode::checkSum16(reinterpret_cast<uint8_t*>(&joinEUI), sizeof(uint64_t));
-  this->keyCheckSum ^= LoRaWANNode::checkSum16(reinterpret_cast<uint8_t*>(&devEUI), sizeof(uint64_t));
-  this->keyCheckSum ^= LoRaWANNode::checkSum16(appKey, RADIOLIB_AES128_KEY_SIZE);
+  this->keyCheckSum = 0;
+  this->keyCheckSum ^= LoRaWANNode::checkSum<uint32_t>(reinterpret_cast<uint8_t*>(&joinEUI), sizeof(uint64_t));
+  this->keyCheckSum ^= LoRaWANNode::checkSum<uint32_t>(reinterpret_cast<uint8_t*>(&devEUI), sizeof(uint64_t));
+  this->keyCheckSum ^= LoRaWANNode::checkSum<uint32_t>(appKey, RADIOLIB_AES128_KEY_SIZE);
   if(nwkKey) {
-    this->keyCheckSum ^= LoRaWANNode::checkSum16(nwkKey, RADIOLIB_AES128_KEY_SIZE);
+    this->keyCheckSum ^= LoRaWANNode::checkSum<uint32_t>(nwkKey, RADIOLIB_AES128_KEY_SIZE);
   }
 
   this->lwMode = RADIOLIB_LORAWAN_MODE_OTAA;
@@ -695,7 +734,7 @@ int16_t LoRaWANNode::beginABP(uint32_t addr, const uint8_t* fNwkSIntKey, const u
     return(RADIOLIB_ERR_NULL_POINTER);
   }
   // clear all the device parameters in case there were any
-  this->clearNonces();
+  this->clearPersistence();
   this->clearSession();
 
   this->devAddr = addr;
@@ -711,11 +750,11 @@ int16_t LoRaWANNode::beginABP(uint32_t addr, const uint8_t* fNwkSIntKey, const u
   }
 
   // generate activation key checksum
-  this->keyCheckSum ^= LoRaWANNode::checkSum16(reinterpret_cast<uint8_t*>(&addr), sizeof(uint32_t));
-  this->keyCheckSum ^= LoRaWANNode::checkSum16(nwkSEncKey, RADIOLIB_AES128_KEY_SIZE);
-  this->keyCheckSum ^= LoRaWANNode::checkSum16(appSKey, RADIOLIB_AES128_KEY_SIZE);
-  if(fNwkSIntKey) { this->keyCheckSum ^= LoRaWANNode::checkSum16(fNwkSIntKey, RADIOLIB_AES128_KEY_SIZE); }
-  if(sNwkSIntKey) { this->keyCheckSum ^= LoRaWANNode::checkSum16(sNwkSIntKey, RADIOLIB_AES128_KEY_SIZE); }
+  this->keyCheckSum = addr;
+  this->keyCheckSum ^= LoRaWANNode::checkSum<uint32_t>(nwkSEncKey, RADIOLIB_AES128_KEY_SIZE);
+  this->keyCheckSum ^= LoRaWANNode::checkSum<uint32_t>(appSKey, RADIOLIB_AES128_KEY_SIZE);
+  if(fNwkSIntKey) { this->keyCheckSum ^= LoRaWANNode::checkSum<uint32_t>(fNwkSIntKey, RADIOLIB_AES128_KEY_SIZE); }
+  if(sNwkSIntKey) { this->keyCheckSum ^= LoRaWANNode::checkSum<uint32_t>(sNwkSIntKey, RADIOLIB_AES128_KEY_SIZE); }
 
   this->lwMode = RADIOLIB_LORAWAN_MODE_ABP;
 
@@ -910,8 +949,6 @@ int16_t LoRaWANNode::processJoinAccept(LoRaWANJoinEvent_t *joinEvent) {
     RADIOLIB_ASSERT(state);
   }
 
-  LoRaWANNode::hton<uint32_t>(&this->bufferNonces[RADIOLIB_LORAWAN_NONCES_JOIN_NONCE], this->joinNonce, 3);
-
   // store DevAddr and all keys
   LoRaWANNode::hton<uint32_t>(&this->bufferSession[RADIOLIB_LORAWAN_SESSION_DEV_ADDR], this->devAddr);
   memcpy(&this->bufferSession[RADIOLIB_LORAWAN_SESSION_APP_SKEY], this->appSKey, RADIOLIB_AES128_KEY_SIZE);
@@ -991,13 +1028,11 @@ int16_t LoRaWANNode::activateOTAA(LoRaWANJoinEvent_t *joinEvent) {
                                 RADIOLIB_LORAWAN_JOIN_REQUEST_LEN);
   RADIOLIB_ASSERT(state);
 
-  // JoinRequest successfully sent, so increase & save devNonce
+  // JoinRequest successfully sent, so increase devNonce for next time
   this->devNonce += 1;
-  LoRaWANNode::hton<uint16_t>(&this->bufferNonces[RADIOLIB_LORAWAN_NONCES_DEV_NONCE], this->devNonce);
 
-  // update the Nonces buffer and generate its signature - also store it in the Session buffer
-  (void)this->getBufferNonces();
-  memcpy(&this->bufferSession[RADIOLIB_LORAWAN_SESSION_NONCES_SIGNATURE], &this->bufferNonces[RADIOLIB_LORAWAN_NONCES_SIGNATURE], 2);
+  // save persistence buffer with updated devNonce before waiting for JoinAccept
+  this->savePersistenceBuffer();
 
   // configure Rx1 and Rx2 delay for JoinAccept message - these are re-configured once a valid JoinAccept is received
   this->rxDelays[1] = RADIOLIB_LORAWAN_JOIN_ACCEPT_DELAY_1_MS;
@@ -1015,9 +1050,9 @@ int16_t LoRaWANNode::activateOTAA(LoRaWANJoinEvent_t *joinEvent) {
   state = this->processJoinAccept(joinEvent);
   RADIOLIB_ASSERT(state);
 
-  // regenerate the Nonces buffer as we received a new JoinNonce in the JoinAccept
-  (void)this->getBufferNonces();
-  memcpy(&this->bufferSession[RADIOLIB_LORAWAN_SESSION_NONCES_SIGNATURE], &this->bufferNonces[RADIOLIB_LORAWAN_NONCES_SIGNATURE], 2);
+  // save both buffers after a successful join (new joinNonce + fresh session keys)
+  this->savePersistenceBuffer();
+  this->saveSessionBuffer();
 
   this->sessionStatus = RADIOLIB_LORAWAN_SESSION_ACTIVE;
 
@@ -1051,17 +1086,13 @@ int16_t LoRaWANNode::activateABP() {
     this->createSession();
   }
 
-  // update the Nonces buffer and generate its signature - also store it in the Session buffer
-  (void)this->getBufferNonces();
-  memcpy(&this->bufferSession[RADIOLIB_LORAWAN_SESSION_NONCES_SIGNATURE], &this->bufferNonces[RADIOLIB_LORAWAN_NONCES_SIGNATURE], 2);
-
   // store DevAddr and all keys
   LoRaWANNode::hton<uint32_t>(&this->bufferSession[RADIOLIB_LORAWAN_SESSION_DEV_ADDR], this->devAddr);
   memcpy(&this->bufferSession[RADIOLIB_LORAWAN_SESSION_APP_SKEY], this->appSKey, RADIOLIB_AES128_BLOCK_SIZE);
   memcpy(&this->bufferSession[RADIOLIB_LORAWAN_SESSION_NWK_SENC_KEY], this->nwkSEncKey, RADIOLIB_AES128_BLOCK_SIZE);
   memcpy(&this->bufferSession[RADIOLIB_LORAWAN_SESSION_FNWK_SINT_KEY], this->fNwkSIntKey, RADIOLIB_AES128_BLOCK_SIZE);
   memcpy(&this->bufferSession[RADIOLIB_LORAWAN_SESSION_SNWK_SINT_KEY], this->sNwkSIntKey, RADIOLIB_AES128_BLOCK_SIZE);
-  
+
   // store network parameters
   LoRaWANNode::hton<uint8_t>(&this->bufferSession[RADIOLIB_LORAWAN_SESSION_VERSION], this->rev);
 
@@ -1070,6 +1101,10 @@ int16_t LoRaWANNode::activateABP() {
   }
 
   this->sessionStatus = RADIOLIB_LORAWAN_SESSION_ACTIVE;
+
+  // save both buffers for the new ABP session
+  this->savePersistenceBuffer();
+  this->saveSessionBuffer();
 
   return(RADIOLIB_LORAWAN_NEW_SESSION);
 }
@@ -3300,6 +3335,38 @@ void LoRaWANNode::setActivityLeds(const uint32_t pins[4]) {
   }
 }
 
+void LoRaWANNode::getPersistencePackage(uint8_t pIndex, uint8_t* buff) {
+  switch(pIndex) {
+    case(RADIOLIB_LORAWAN_PERSISTENCE_TS004): {
+      memcpy(buff, &this->bufferSession[RADIOLIB_LORAWAN_PERSISTENCE_TS004], 8);
+    } break;
+    case(RADIOLIB_LORAWAN_PERSISTENCE_TS009): {
+      memcpy(buff, &this->bufferSession[RADIOLIB_LORAWAN_PERSISTENCE_TS009], 1);
+    } break;
+    default: {
+      // just ignore
+    } break;
+  }
+}
+
+void LoRaWANNode::setPersistencePackage(uint8_t pIndex, uint8_t* buff) {
+  switch(pIndex) {
+    case(RADIOLIB_LORAWAN_PERSISTENCE_TS004): {
+      memcpy(&this->bufferSession[RADIOLIB_LORAWAN_PERSISTENCE_TS004], buff, 8);
+    } break;
+    case(RADIOLIB_LORAWAN_PERSISTENCE_TS009): {
+      memcpy(&this->bufferSession[RADIOLIB_LORAWAN_PERSISTENCE_TS009], buff, 1);
+    } break;
+    default: {
+      // just ignore
+    } break;
+  }
+
+  // trigger an update of the buffer and session
+  this->savePersistenceBuffer();
+  this->saveSessionBuffer();
+}
+
 void LoRaWANNode::scheduleTransmission(RadioLibTime_t tUplink) {
   this->tUplink = tUplink;
 }
@@ -3823,6 +3890,34 @@ void LoRaWANNode::setSleepFunction(SleepCb_t cb) {
   this->sleepCb = cb;
 }
 
+void LoRaWANNode::setCallbackStorePersistence(BufferCb_t cb) {
+  this->storePersistenceBufferCb = cb;
+}
+
+void LoRaWANNode::setCallbackRestorePersistence(BufferCb_t cb) {
+  this->restorePersistenceBufferCb = cb;
+}
+
+void LoRaWANNode::setCallbackStoreSession(BufferCb_t cb) {
+  this->storeSessionBufferCb = cb;
+}
+
+void LoRaWANNode::setCallbackRestoreSession(BufferCb_t cb) {
+  this->restoreSessionBufferCb = cb;
+}
+
+int16_t LoRaWANNode::loadBuffers() {
+  int16_t state = RADIOLIB_ERR_NONE;
+  if(this->restorePersistenceBufferCb) {
+    state = this->loadPersistenceBuffer();
+    RADIOLIB_ASSERT(state);
+  }
+  if(this->restoreSessionBufferCb) {
+    state = this->loadSessionBuffer();
+  }
+  return(state);
+}
+
 int16_t LoRaWANNode::addAppPackage(uint8_t fPort) {
   return(this->addPackage(fPort, true));
 }
@@ -3920,37 +4015,27 @@ void LoRaWANNode::sleepDelay(RadioLibTime_t ms, bool radioOff) {
 }
 
 int16_t LoRaWANNode::checkBufferCommon(const uint8_t *buffer, uint16_t size) {
-  // check if there are actually values in the buffer
+  // if the buffer was all 0x00 or 0xFF, the checksum would be OK but this is not a valid buffer
+  // so we check if there are actually values in the buffer
   size_t i = 0;
   for(; i < size; i++) {
-    if(buffer[i]) {
+    if(buffer[i] != 0x00 && buffer[i] != 0xFF) {
       break;
     }
   }
   if(i == size) {
-    return(RADIOLIB_ERR_NETWORK_NOT_JOINED);
+    return(RADIOLIB_ERR_CHECKSUM_MISMATCH);
   }
 
   // check integrity of the whole buffer (compare checksum to included checksum)
-  uint16_t checkSum = LoRaWANNode::checkSum16(buffer, size - 2);
-  uint16_t signature = LoRaWANNode::ntoh<uint16_t>(&buffer[size - 2]);
+  uint32_t checkSum = LoRaWANNode::checkSum<uint32_t>(buffer, size - sizeof(uint32_t));
+  uint32_t signature = LoRaWANNode::ntoh<uint32_t>(&buffer[size - sizeof(uint32_t)]);
   if(signature != checkSum) {
-    RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Calculated checksum: %04x, expected: %04x", checkSum, signature);
+    RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Calculated checksum: %08lX, expected: %08lX", checkSum, signature);
     return(RADIOLIB_ERR_CHECKSUM_MISMATCH);
   }
   return(RADIOLIB_ERR_NONE);
 }
 
-uint16_t LoRaWANNode::checkSum16(const uint8_t *key, uint16_t keyLen) {
-  uint16_t checkSum = 0;
-  for(uint16_t i = 0; i < keyLen; i += 2) {
-    uint16_t word = (key[i] << 8);
-    if(i + 1 < keyLen) {
-      word |= key[i + 1];
-    }
-    checkSum ^= word;
-  }
-  return(checkSum);
-}
 
 #endif

--- a/src/protocols/LoRaWAN/LoRaWAN.cpp
+++ b/src/protocols/LoRaWAN/LoRaWAN.cpp
@@ -1650,8 +1650,8 @@ int16_t LoRaWANNode::receiveClassA(uint8_t dir, const LoRaWANChannel_t* dlChanne
 
   Module* mod = this->phyLayer->getMod();
   RadioLibTime_t tNow = mod->hal->millis();
-  if(tNow > tWindowOpen) {
-    RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Window too late by %d ms", tNow - tWindowOpen);
+  if(tNow + this->launchDuration > tWindowOpen) {
+    RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Window too late by %d ms", tNow + this->launchDuration - tWindowOpen);
     return(RADIOLIB_ERR_NO_RX_WINDOW);
   }
   
@@ -1665,7 +1665,7 @@ int16_t LoRaWANNode::receiveClassA(uint8_t dir, const LoRaWANChannel_t* dlChanne
   tWindowOpen = mod->hal->millis(); // this should be exactly `launchDuration` later than the calculated value
   
   RADIOLIB_ASSERT(state);
-  RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Rx%d window open (timeout: %lu symbols and %lu units + %dms)", 
+  RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Rx%d window open (timeout: %lu symbols / %lu ticks + %dms)", 
                                   window, modeCfg.receive.syncSymbols, modeCfg.receive.timeout, this->scanGuard);
   
   // enable the LED if used
@@ -1734,7 +1734,7 @@ int16_t LoRaWANNode::receiveClassA(uint8_t dir, const LoRaWANChannel_t* dlChanne
   return(window);
 }
 
-int16_t LoRaWANNode::receiveClassC(RadioLibTime_t timeout) {
+int16_t LoRaWANNode::receiveClassC(RadioLibTime_t tWindowEnd) {
   // check if Multicast using Class C is active
   if(this->getMulticastClass() == RADIOLIB_LORAWAN_CLASS_C) {
     RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Opening Multicast RxC window");
@@ -1747,8 +1747,6 @@ int16_t LoRaWANNode::receiveClassC(RadioLibTime_t timeout) {
   }
 
   Module* mod = this->phyLayer->getMod();
-  
-  RadioLibTime_t tStart = mod->hal->millis();
 
   // set the physical layer configuration for Class C window
   int16_t state = this->setPhyProperties(&this->channels[RADIOLIB_LORAWAN_RX_BC], RADIOLIB_LORAWAN_DOWNLINK, 
@@ -1778,55 +1776,47 @@ int16_t LoRaWANNode::receiveClassC(RadioLibTime_t timeout) {
   state = this->phyLayer->launchMode();
   RadioLibTime_t tOpen = mod->hal->millis();
   RADIOLIB_ASSERT(state);
-  RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Opened RxC window");
+  RADIOLIB_DEBUG_PROTOCOL_PRINTLN("RxC window open");
 
-  if(timeout) {
+  if(tWindowEnd) {
     // wait for the DIO interrupt to fire (RxDone or RxTimeout)
-    while(!downlinkAction && mod->hal->millis() - tOpen <= timeout) {
+    while(!downlinkAction && mod->hal->millis() < tWindowEnd) {
       mod->hal->yield();
     }
-    RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Closed RxC window");
+    RadioLibTime_t tClose = mod->hal->millis();
+    RADIOLIB_DEBUG_PROTOCOL_PRINTLN("RxC window closed");
 
-    // check IRQ bit for RxTimeout
-    int16_t timedOut = this->phyLayer->checkIrq(RADIOLIB_IRQ_TIMEOUT);
-    if(timedOut == RADIOLIB_ERR_UNSUPPORTED) {
-      return(timedOut);
-    }
-
-    // if the IRQ bit for RxTimeout is set, put chip in standby and return
-    if(timedOut) {
-      this->phyLayer->clearPacketReceivedAction();
-      this->phyLayer->clearIrq(1UL << RADIOLIB_IRQ_TIMEOUT);
-      this->phyLayer->standby();
-      if(this->ledPins[RADIOLIB_LORAWAN_RX_BC] != RADIOLIB_NC) {
-        mod->hal->digitalWrite(this->ledPins[RADIOLIB_LORAWAN_RX_BC], mod->hal->GpioLevelLow);
-      }
-      return(0);  // no downlink
-    }
-
-    // update time of downlink reception
-    if(downlinkAction) {
-      this->tDownlink = mod->hal->millis();
-    }
-
-    // we have a message, clear actions, go to standby
     this->phyLayer->clearPacketReceivedAction();
     this->phyLayer->standby();
     if(this->ledPins[RADIOLIB_LORAWAN_RX_BC] != RADIOLIB_NC) {
       mod->hal->digitalWrite(this->ledPins[RADIOLIB_LORAWAN_RX_BC], mod->hal->GpioLevelLow);
     }
 
+    // check IRQ bit for RxTimeout
+    int16_t timedOut = this->phyLayer->checkIrq(RADIOLIB_IRQ_TIMEOUT);
+    if(timedOut == RADIOLIB_ERR_UNSUPPORTED) {
+      return(timedOut);
+    }
+    
+    // if the IRQ bit for RxTimeout is set, put chip in standby and return
+    if(timedOut) {
+      this->phyLayer->clearIrq(1UL << RADIOLIB_IRQ_TIMEOUT);
+      return(0);  // no downlink
+    }
+    
     // if all windows passed without receiving anything, return 0 for no window
     if(!downlinkAction) {
       return(0);
     }
     downlinkAction = false;
 
+    // update time of downlink reception
+    this->tDownlink = tClose;
+
     // Any frame received by an end-device containing a MACPayload greater than 
     // the specified maximum length M over the data rate used to receive the frame 
     // SHALL be silently discarded.
     uint8_t maxPayLen = this->band->payloadLenMax[this->channels[RADIOLIB_LORAWAN_RX_BC].dr];
-
     if(this->phyLayer->getPacketLength() > (size_t)(maxPayLen + 13)) {  // mandatory FHDR is 12/13 bytes
       return(0);  // act as if no downlink was received
     }
@@ -1842,9 +1832,9 @@ int16_t LoRaWANNode::receiveDownlink() {
   Module* mod = this->phyLayer->getMod();
 
   // if applicable, open Class C between uplink and Rx1
-  RadioLibTime_t timeoutClassC = this->tUplinkEnd + this->rxDelays[RADIOLIB_LORAWAN_RX1] - \
-                                  mod->hal->millis() - 5*this->scanGuard;
-  int16_t state = this->receiveClassC(timeoutClassC);
+  RadioLibTime_t tWindowClose = this->tUplinkEnd + this->rxDelays[RADIOLIB_LORAWAN_RX1] - \
+                                  5*this->launchDuration - this->scanGuard / 2;
+  int16_t state = this->receiveClassC(tWindowClose);
   RADIOLIB_ASSERT(state);
 
   // open Rx1 window
@@ -1861,9 +1851,9 @@ int16_t LoRaWANNode::receiveDownlink() {
   // we choose to ignore this part of the spec and open Rx2 as specified in v1.0.4
 
   // for LoRaWAN v1.0.4 Class C, there is an RxC window between Rx1 and Rx2
-  timeoutClassC = this->tUplinkEnd + this->rxDelays[RADIOLIB_LORAWAN_RX2] - \
-                                  mod->hal->millis() - 5*this->scanGuard;
-  state = this->receiveClassC(timeoutClassC);
+  tWindowClose = this->tUplinkEnd + this->rxDelays[RADIOLIB_LORAWAN_RX2] - \
+                                  5*this->launchDuration - this->scanGuard / 2;
+  state = this->receiveClassC(tWindowClose);
   RADIOLIB_ASSERT(state);
 
   // open Rx2 window

--- a/src/protocols/LoRaWAN/LoRaWAN.h
+++ b/src/protocols/LoRaWAN/LoRaWAN.h
@@ -272,18 +272,21 @@ struct LoRaWANPackage_t {
   bool isAppPack;
 };
 
-#define RADIOLIB_LORAWAN_NONCES_VERSION_VAL (0x0003)
+#define RADIOLIB_LORAWAN_NONCES_VERSION_VAL (0x0004)
 
-enum LoRaWANSchemeBase_t {
-  RADIOLIB_LORAWAN_NONCES_START       = 0x00,
-  RADIOLIB_LORAWAN_NONCES_VERSION     = RADIOLIB_LORAWAN_NONCES_START,                            // 2 bytes
-  RADIOLIB_LORAWAN_NONCES_MODE        = RADIOLIB_LORAWAN_NONCES_VERSION + sizeof(uint16_t),       // 2 bytes
-  RADIOLIB_LORAWAN_NONCES_PLAN        = RADIOLIB_LORAWAN_NONCES_MODE + sizeof(uint16_t),          // 1 byte
-  RADIOLIB_LORAWAN_NONCES_CHECKSUM    = RADIOLIB_LORAWAN_NONCES_PLAN + sizeof(uint8_t),           // 2 bytes
-  RADIOLIB_LORAWAN_NONCES_DEV_NONCE   = RADIOLIB_LORAWAN_NONCES_CHECKSUM + sizeof(uint16_t),      // 2 bytes
-  RADIOLIB_LORAWAN_NONCES_JOIN_NONCE  = RADIOLIB_LORAWAN_NONCES_DEV_NONCE + sizeof(uint16_t),     // 3 bytes
-  RADIOLIB_LORAWAN_NONCES_SIGNATURE   = RADIOLIB_LORAWAN_NONCES_JOIN_NONCE + 3,                   // 2 bytes
-  RADIOLIB_LORAWAN_NONCES_BUF_SIZE    = RADIOLIB_LORAWAN_NONCES_SIGNATURE + sizeof(uint16_t)      // Nonces buffer size
+enum LoRaWANSchemePersistence_t {
+  RADIOLIB_LORAWAN_NONCES_START           = 0x00,
+  RADIOLIB_LORAWAN_PERSISTENCE_SIZE       = RADIOLIB_LORAWAN_NONCES_START,
+  RADIOLIB_LORAWAN_PERSISTENCE_VERSION    = RADIOLIB_LORAWAN_PERSISTENCE_SIZE + 1,
+  RADIOLIB_LORAWAN_PERSISTENCE_KEYS       = RADIOLIB_LORAWAN_PERSISTENCE_VERSION + 2,
+  RADIOLIB_LORAWAN_PERSISTENCE_JOIN_NONCE = RADIOLIB_LORAWAN_PERSISTENCE_KEYS + 4,
+  RADIOLIB_LORAWAN_PERSISTENCE_DEV_NONCE  = RADIOLIB_LORAWAN_PERSISTENCE_JOIN_NONCE + 3,
+  RADIOLIB_LORAWAN_PERSISTENCE_RJ_COUNT   = RADIOLIB_LORAWAN_PERSISTENCE_DEV_NONCE + 2,
+  RADIOLIB_LORAWAN_PERSISTENCE_TS004      = RADIOLIB_LORAWAN_PERSISTENCE_RJ_COUNT + 2,
+  RADIOLIB_LORAWAN_PERSISTENCE_TS009      = RADIOLIB_LORAWAN_PERSISTENCE_TS004 + 8,
+  RADIOLIB_LORAWAN_PERSISTENCE_RFU        = RADIOLIB_LORAWAN_PERSISTENCE_TS009 + 1,
+  RADIOLIB_LORAWAN_PERSISTENCE_SIGNATURE  = RADIOLIB_LORAWAN_PERSISTENCE_RFU + 5,
+  RADIOLIB_LORAWAN_PERSISTENCE_BUF_SIZE   = RADIOLIB_LORAWAN_PERSISTENCE_SIGNATURE + 4
 };
 
 enum LoRaWANSchemeSession_t {
@@ -295,7 +298,7 @@ enum LoRaWANSchemeSession_t {
   RADIOLIB_LORAWAN_SESSION_SNWK_SINT_KEY      = RADIOLIB_LORAWAN_SESSION_FNWK_SINT_KEY + RADIOLIB_AES128_KEY_SIZE,  // 16 bytes
   RADIOLIB_LORAWAN_SESSION_DEV_ADDR           = RADIOLIB_LORAWAN_SESSION_SNWK_SINT_KEY + RADIOLIB_AES128_KEY_SIZE,  // 4 bytes
   RADIOLIB_LORAWAN_SESSION_NONCES_SIGNATURE   = RADIOLIB_LORAWAN_SESSION_DEV_ADDR + sizeof(uint32_t),               // 2 bytes
-  RADIOLIB_LORAWAN_SESSION_FCNT_UP            = RADIOLIB_LORAWAN_SESSION_NONCES_SIGNATURE + sizeof(uint16_t),       // 4 bytes
+  RADIOLIB_LORAWAN_SESSION_FCNT_UP            = RADIOLIB_LORAWAN_SESSION_NONCES_SIGNATURE + sizeof(uint32_t),       // 4 bytes
   RADIOLIB_LORAWAN_SESSION_N_FCNT_DOWN        = RADIOLIB_LORAWAN_SESSION_FCNT_UP + sizeof(uint32_t),        // 4 bytes
   RADIOLIB_LORAWAN_SESSION_A_FCNT_DOWN        = RADIOLIB_LORAWAN_SESSION_N_FCNT_DOWN + sizeof(uint32_t),    // 4 bytes
   RADIOLIB_LORAWAN_SESSION_ADR_FCNT           = RADIOLIB_LORAWAN_SESSION_A_FCNT_DOWN + sizeof(uint32_t),    // 4 bytes
@@ -318,8 +321,8 @@ enum LoRaWANSchemeSession_t {
   RADIOLIB_LORAWAN_SESSION_AVAILABLE_CHANNELS = RADIOLIB_LORAWAN_SESSION_DL_CHANNELS + RADIOLIB_LORAWAN_MAX_NUM_DYNAMIC_CHANNELS*4, // 2 bytes
   RADIOLIB_LORAWAN_SESSION_MAC_QUEUE          = RADIOLIB_LORAWAN_SESSION_AVAILABLE_CHANNELS + RADIOLIB_LORAWAN_MAX_NUM_SUBBANDS,    // 12 bytes                   // 15 bytes
   RADIOLIB_LORAWAN_SESSION_MAC_QUEUE_LEN      = RADIOLIB_LORAWAN_SESSION_MAC_QUEUE + RADIOLIB_LORAWAN_FHDR_FOPTS_MAX_LEN,           // 1 byte
-  RADIOLIB_LORAWAN_SESSION_SIGNATURE          = RADIOLIB_LORAWAN_SESSION_MAC_QUEUE_LEN + sizeof(uint8_t),   // 2 bytes
-  RADIOLIB_LORAWAN_SESSION_BUF_SIZE           = RADIOLIB_LORAWAN_SESSION_SIGNATURE + sizeof(uint16_t)       // Session buffer size
+  RADIOLIB_LORAWAN_SESSION_SIGNATURE          = RADIOLIB_LORAWAN_SESSION_MAC_QUEUE_LEN + sizeof(uint8_t),   // 4 bytes
+  RADIOLIB_LORAWAN_SESSION_BUF_SIZE           = RADIOLIB_LORAWAN_SESSION_SIGNATURE + sizeof(uint32_t)       // Session buffer size
 };
 
 /*!
@@ -561,35 +564,46 @@ class LoRaWANNode {
     LoRaWANNode(PhysicalLayer* phy, const LoRaWANBand_t* band, uint8_t subBand = 0);
 
     /*!
-      \brief Returns the pointer to the internal buffer that holds the LW base parameters
-      \returns Pointer to uint8_t array of size RADIOLIB_LORAWAN_NONCES_BUF_SIZE
-    */
-    uint8_t* getBufferNonces();
-
-    /*!
-      \brief Fill the internal buffer that holds the LW base parameters with a supplied buffer
-      \param persistentBuffer Buffer that should match the internal format (previously extracted using getBufferNonces)
-      \returns \ref status_codes
-    */
-    int16_t setBufferNonces(const uint8_t* persistentBuffer);
-
-    /*!
       \brief Clear an active session. This requires the device to rejoin the network.
     */
     void clearSession();
 
-    /*!
-      \brief Returns the pointer to the internal buffer that holds the LW session parameters
-      \returns Pointer to uint8_t array of size RADIOLIB_LORAWAN_SESSION_BUF_SIZE
-    */
-    uint8_t* getBufferSession();
+    /*! \brief Callback signature for buffer save/load operations. */
+    typedef void (*BufferCb_t)(uint8_t* buf, size_t len);
 
     /*!
-      \brief Fill the internal buffer that holds the LW session parameters with a supplied buffer
-      \param persistentBuffer Buffer that should match the internal format (previously extracted using getBufferSession)
+      \brief Register a callback invoked by the library when the persistence buffer needs to be saved.
+      The callback receives a pointer to the serialized buffer and its length; the user should
+      write this data to non-volatile storage (flash, EEPROM, etc.).
+    */
+    void setCallbackStorePersistence(BufferCb_t cb);
+
+    /*!
+      \brief Register a callback invoked by the library when the persistence buffer needs to be loaded.
+      The callback receives a pointer to the buffer and its length; the user should fill it with
+      data previously saved by the savePersistenceBuffer callback.
+    */
+    void setCallbackRestorePersistence(BufferCb_t cb);
+
+    /*!
+      \brief Register a callback invoked by the library when the session buffer needs to be saved.
+      The callback receives a pointer to the serialized buffer and its length; the user should
+      write this data to persistent RAM on platforms that do not retain normal RAM during sleep.
+    */
+    void setCallbackStoreSession(BufferCb_t cb);
+
+    /*!
+      \brief Register a callback invoked by the library when the session buffer needs to be loaded.
+      The callback receives a pointer to the buffer and its length; the user should fill it with
+      data previously saved by the savePersistenceBuffer callback.
+    */
+    void setCallbackRestoreSession(BufferCb_t cb);
+
+    /*!
+      \brief Trigger the registered buffer callbacks to restore persistence and session buffers.
       \returns \ref status_codes
     */
-    int16_t setBufferSession(const uint8_t* persistentBuffer);
+    int16_t loadBuffers();
 
     /*!
       \brief Set the device credentials and activation configuration
@@ -847,6 +861,18 @@ class LoRaWANNode {
     void setActivityLeds(const uint32_t pins[4]);
 
     /*!
+      \brief Get the persistent buffer for a certain package.
+      NOTE: Do NOT use, for Packages only!
+    */
+    void getPersistencePackage(uint8_t pIndex, uint8_t* buff);
+
+    /*!
+      \brief Set the persistent buffer for a certain package.
+      NOTE: Do NOT use, for Packages only!
+    */
+    void setPersistencePackage(uint8_t pIndex, uint8_t* buff);
+
+    /*!
       \brief Set the exact time a transmission should occur. Note: this is the internal clock time.
       On Arduino platforms, this is the usual time supplied by millis().
       If the supplied time is larger than the current time, sendReceive() or uplink() will delay
@@ -996,7 +1022,7 @@ class LoRaWANNode {
     const LoRaWANBand_t* band = NULL;
 
     // a buffer that holds all LW base parameters that should persist at all times!
-    uint8_t bufferNonces[RADIOLIB_LORAWAN_NONCES_BUF_SIZE] = { 0 };
+    uint8_t bufferPersist[RADIOLIB_LORAWAN_PERSISTENCE_BUF_SIZE] = { 0 };
 
     // a buffer that holds all LW session parameters that preferably persist, but can be afforded to get lost
     uint8_t bufferSession[RADIOLIB_LORAWAN_SESSION_BUF_SIZE] = { 0 };
@@ -1024,7 +1050,7 @@ class LoRaWANNode {
     uint8_t nwkSEncKey[RADIOLIB_AES128_KEY_SIZE] = { 0 };
     uint8_t jSIntKey[RADIOLIB_AES128_KEY_SIZE] = { 0 };
 
-    uint16_t keyCheckSum = 0;
+    uint32_t keyCheckSum = 0;
     
     // device-specific parameters, persistent through sessions
     uint16_t devNonce = 0;
@@ -1125,11 +1151,29 @@ class LoRaWANNode {
     // user-provided sleep callback
     SleepCb_t sleepCb = nullptr;
 
+    // user-provided buffer callbacks
+    BufferCb_t storePersistenceBufferCb = nullptr;
+    BufferCb_t restorePersistenceBufferCb = nullptr;
+    BufferCb_t storeSessionBufferCb = nullptr;
+    BufferCb_t restoreSessionBufferCb = nullptr;
+
     // this will reset the device credentials, so the device starts completely new
-    void clearNonces();
+    void clearPersistence();
+
+    // trigger a save of the persistence buffer
+    void savePersistenceBuffer();
+
+    // load the persistence buffer from non-volatile storage.
+    int16_t loadPersistenceBuffer();
 
     // setup an empty session with default parameters
     void createSession();
+
+    // returns the pointer to the internal buffer that holds the LW session parameters
+    void saveSessionBuffer();
+
+    // fill the internal buffer that holds the LW session parameters with a supplied buffer
+    int16_t loadSessionBuffer();
 
     // setup Join-Request payload
     void composeJoinRequest(uint8_t* joinRequestMsg);
@@ -1248,10 +1292,11 @@ class LoRaWANNode {
     // function that allows sleeping via user-provided callback
     void sleepDelay(RadioLibTime_t ms, bool radioOff = true);
 
-    // 16-bit checksum method that takes a uint8_t array of even length and calculates the checksum
-    static uint16_t checkSum16(const uint8_t *key, uint16_t keyLen);
+    // checksum over a byte array, XOR-ing sizeof(T)-byte big-endian words
+    template<typename T>
+    static T checkSum(const uint8_t* buff, size_t size);
 
-    // check the integrity of a buffer using a 16-bit checksum located in the last two bytes of the buffer
+    // check the integrity of a buffer using a 32-bit checksum located in the last four bytes of the buffer
     static int16_t checkBufferCommon(const uint8_t *buffer, uint16_t size);
 
     // network-to-host conversion method - takes data from network packet and converts it to the host endians
@@ -1287,6 +1332,22 @@ void LoRaWANNode::hton(uint8_t* buff, T val, size_t size) {
   for(size_t i = 0; i < targetSize; i++) {
     *(buffPtr++) = val >> 8*i;
   }
+}
+
+template<typename T>
+T LoRaWANNode::checkSum(const uint8_t* buff, size_t size) {
+  T result = 0;
+  for(uint16_t i = 0; i < size; i += sizeof(T)) {
+    T word = 0;
+    for(size_t j = 0; j < sizeof(T); j++) {
+      word <<= 8;
+      if(i + j < size) {
+        word |= buff[i + j];
+      }
+    }
+    result ^= word;
+  }
+  return(result);
 }
 
 #endif

--- a/src/protocols/LoRaWAN/LoRaWAN.h
+++ b/src/protocols/LoRaWAN/LoRaWAN.h
@@ -1203,7 +1203,7 @@ class LoRaWANNode {
     int16_t receiveClassA(uint8_t dir, const LoRaWANChannel_t* dlChannel, uint8_t window, const RadioLibTime_t dlDelay, RadioLibTime_t tReference);
 
     // handle a Class C receive window with timeout (between Class A windows) or without (between uplinks)
-    int16_t receiveClassC(RadioLibTime_t timeout = 0);
+    int16_t receiveClassC(RadioLibTime_t tWindowEnd = 0);
 
     // open a series of Class A (and C) downlinks
     virtual int16_t receiveDownlink();

--- a/src/protocols/LoRaWAN/LoRaWAN.h
+++ b/src/protocols/LoRaWAN/LoRaWAN.h
@@ -1002,18 +1002,15 @@ class LoRaWANNode {
     void removePackage(uint8_t fPort);
 
     /*!
-      \brief Rx window padding in milliseconds
-      according to the spec, the Rx window must be at least enough time to effectively detect a preamble
-      but we pad it a bit on both sides (start and end) to make sure it is wide enough
-      The larger this number the more power will be consumed! So be careful about changing it.
-      For debugging purposes 50 is a reasonable start, but for production devices it should
-      be as low as possible.
-      0 is a valid time.
-
+      \brief Rx window padding in milliseconds.
+      NOTE: If your clock has a stable drift, use RADIOLIB_CLOCK_DRIFT_MS instead (see BuildOpt.h).
+      On any modern microcontroller it should not be necessary to use scanGuard.
+      However, if your clock is unstable, you can use e.g. scanGuard = 20 to widen
+      the Rx window by 20 milliseconds (open 10ms early, close 10ms late).
       500 is the **maximum** value, but it is not a good idea to go anywhere near that.
       If you have to go above 50 you probably have a bug somewhere. Check your device timing.
     */
-    RadioLibTime_t scanGuard = 10;
+    RadioLibTime_t scanGuard = 0;
 
 #if !RADIOLIB_GODMODE
   protected:

--- a/src/protocols/PhysicalLayer/PhysicalLayer.cpp
+++ b/src/protocols/PhysicalLayer/PhysicalLayer.cpp
@@ -136,6 +136,7 @@ int16_t PhysicalLayer::startReceive(uint32_t timeout, RadioLibIrqFlags_t irqFlag
   RadioModeConfig_t cfg = {
     .receive = {
       .timeout = timeout,
+      .syncSymbols = 0,
       .irqFlags = irqFlags,
       .irqMask = irqMask,
       .len = len,

--- a/src/protocols/PhysicalLayer/PhysicalLayer.h
+++ b/src/protocols/PhysicalLayer/PhysicalLayer.h
@@ -178,7 +178,10 @@ struct StandbyConfig_t {
 struct ReceiveConfig_t {
   /*! \brief  Raw timeout value. Some modules use this argument to specify operation mode (single vs. continuous receive). */
   uint32_t timeout;
-  
+
+  /*! \brief LoRa sync timeout, given as the number of LoRa symbols. */
+  uint16_t syncSymbols;
+
   /*! \brief Sets the IRQ flags. */
   RadioLibIrqFlags_t irqFlags;
   


### PR DESCRIPTION
We've had numerous issues with sensitivity and/or timing on the LoRaWAN Rx windows for higher spreading factors over the last few years. This worsened when we improved the timing of the stack with the mode staging as we then allowed less slack.

The problem is that the default timeout used for RxSingle is clock units for SX126x and later. When using just clock units, the radio latches onto any symbol and stays in Rx mode when it has received the physical preamble and header. However, on high SF, there are or can be sensitivity problems resulting in the radio not firing IRQs as tight as one would expect (although no clue why). For instance on SF12, the IRQ fires like 60ms later than should be expected, and this delay isn't logical or fixed across spreading factors.

Turns out that the system used on SX127x is available on all newer radios but just not _the_ default timeout for RxSingle. The SX127x has always used a symbol timeout value instead of clock units; if the radio doesn't catch that number of symbols it will generate RxTimeout like clockwork and otherwise stay in Rx mode until RxSingle-without-timeout completes.
This command/register is available on all newer radios separately under LoRaNumSymbTimeout (SX126x) or LoRaSynchTimeout (LR) and works combined with RxSingle with or without timeout.

This PR adds the symbol timeout to all LoRaWAN-supported LoRa radios and implements this for LoRaWAN Rx windows. As a result, the scanGuard can likely be dropped to 0ms on any decent/recent microcontroller (tested ESP32), window accuracy on high SF is finally as should be expected (i.e. it catches all downlinks), and Rx window length has dropped by up to 70% to a minimum of 16ms. In short, we're on par with Semtech's drivers.

Fixes #1806
Fixes #1790
Closes #1808 

Tested across all spreading factors on an ESP32-SX1262 with TTN. Other radios and LCTT to follow, waiting for ESP32-RadioHAT breakout unless someone else beats me to trying other radios.