### PR TITLE
[ESP-IDF] Follow-up improvements to EspHal

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -243,10 +243,14 @@ jobs:
 
   esp-build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [esp32, esp32s3, esp32c3]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      
+
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -261,16 +265,17 @@ jobs:
           cd esp-idf
           git checkout v5.4.3
           git submodule update --init --recursive
-      
+
       - name: Install ESP-IDF
         run: |
           cd ~/esp/esp-idf
-          ./install.sh esp32
-      
-      - name: Build the example
+          ./install.sh ${{ matrix.target }}
+
+      - name: Build the example for ${{ matrix.target }}
         run: |
           cd $PWD/examples/NonArduino/ESP-IDF
           . ~/esp/esp-idf/export.sh
+          idf.py set-target ${{ matrix.target }}
           idf.py build
           ../../../extras/test/ci/version.sh build/esp-sx1261.bin
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,16 @@ if(ESP_PLATFORM)
     REQUIRES esp_driver_gpio esp_driver_spi esp_driver_ledc esp_timer
   )
 
+  # EspHal::delay() uses vTaskDelay(pdMS_TO_TICKS(ms)); below 1 kHz tick rate
+  # small delays round to zero (delay(5) -> vTaskDelay(0)). arduino-esp32
+  # makes this a hard error; we warn so users can opt in to lower tick rates
+  # if they really know what they are doing.
+  if(DEFINED CONFIG_FREERTOS_HZ AND CONFIG_FREERTOS_HZ LESS 1000)
+    message(WARNING
+      "RadioLib EspHal: CONFIG_FREERTOS_HZ is ${CONFIG_FREERTOS_HZ}; "
+      "set it to 1000 for accurate delay() resolution.")
+  endif()
+
   return()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,9 +13,14 @@ if(ESP_PLATFORM)
   # required because ESP-IDF runs cmake in script mode
   # and needs idf_component_register()
 
+  # add the ESP-IDF HAL implementation, which was excluded by the filter above
+  file(GLOB RADIOLIB_ESP_IDF_HAL_SOURCES "src/hal/ESP-IDF/*.cpp")
+  list(APPEND RADIOLIB_SOURCES ${RADIOLIB_ESP_IDF_HAL_SOURCES})
+
   idf_component_register(
     SRCS ${RADIOLIB_SOURCES}
-    INCLUDE_DIRS . src 
+    INCLUDE_DIRS . src
+    REQUIRES esp_driver_gpio esp_driver_spi esp_driver_ledc esp_timer
   )
 
   return()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,16 +24,6 @@ if(ESP_PLATFORM)
     REQUIRES esp_driver_gpio esp_driver_spi esp_driver_ledc esp_timer
   )
 
-  # EspHal::delay() uses vTaskDelay(pdMS_TO_TICKS(ms)); below 1 kHz tick rate
-  # small delays round to zero (delay(5) -> vTaskDelay(0)). arduino-esp32
-  # makes this a hard error; we warn so users can opt in to lower tick rates
-  # if they really know what they are doing.
-  if(DEFINED CONFIG_FREERTOS_HZ AND CONFIG_FREERTOS_HZ LESS 1000)
-    message(WARNING
-      "RadioLib EspHal: CONFIG_FREERTOS_HZ is ${CONFIG_FREERTOS_HZ}; "
-      "set it to 1000 for accurate delay() resolution.")
-  endif()
-
   return()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,12 +13,13 @@ if(ESP_PLATFORM)
   # required because ESP-IDF runs cmake in script mode
   # and needs idf_component_register()
 
-  # add the ESP-IDF HAL implementation, which was excluded by the filter above
+  # the ESP-IDF HAL was excluded from RADIOLIB_SOURCES by the filter above;
+  # pass it directly to idf_component_register so RADIOLIB_SOURCES stays
+  # HAL-free, the same way other build environments handle it
   file(GLOB RADIOLIB_ESP_IDF_HAL_SOURCES "src/hal/ESP-IDF/*.cpp")
-  list(APPEND RADIOLIB_SOURCES ${RADIOLIB_ESP_IDF_HAL_SOURCES})
 
   idf_component_register(
-    SRCS ${RADIOLIB_SOURCES}
+    SRCS ${RADIOLIB_SOURCES} ${RADIOLIB_ESP_IDF_HAL_SOURCES}
     INCLUDE_DIRS . src
     REQUIRES esp_driver_gpio esp_driver_spi esp_driver_ledc esp_timer
   )

--- a/examples/NonArduino/ESP-IDF/README.md
+++ b/examples/NonArduino/ESP-IDF/README.md
@@ -2,6 +2,12 @@
 
 This example shows how to use RadioLib as ESP-IDF component, without the Arduino framework. To run in ESP-IDF (or on any other platform), RadioLib includes an internal hardware abstraction layer (HAL). This software layer takes care of basic interaction with the hardware, such as performing SPI transaction or GPIO operations.
 
+## FreeRTOS tick rate
+
+The ESP-IDF HAL implements `delay(ms)` as `vTaskDelay(pdMS_TO_TICKS(ms))`, so its resolution is the FreeRTOS tick. ESP-IDF defaults `CONFIG_FREERTOS_HZ` to `100` (10 ms per tick), which rounds small delays down — e.g. `delay(5)` becomes `vTaskDelay(0)` and does not wait at all.
+
+The Arduino ESP32 core works around this by forcing `CONFIG_FREERTOS_HZ=1000` (see the [arduino-esp32 CMakeLists.txt](https://github.com/espressif/arduino-esp32/blob/master/CMakeLists.txt)). This example does the same via `sdkconfig.defaults`. If you copy the HAL into your own ESP-IDF project, set `CONFIG_FREERTOS_HZ=1000` in your `sdkconfig` to get accurate 1 ms-resolution delays.
+
 ## Structure of the example
 
 * `main/CMakeLists.txt` - IDF component CMake file

--- a/examples/NonArduino/ESP-IDF/README.md
+++ b/examples/NonArduino/ESP-IDF/README.md
@@ -4,9 +4,9 @@ This example shows how to use RadioLib as ESP-IDF component, without the Arduino
 
 ## FreeRTOS tick rate
 
-The ESP-IDF HAL implements `delay(ms)` as `vTaskDelay(pdMS_TO_TICKS(ms))`, so its resolution is the FreeRTOS tick. ESP-IDF defaults `CONFIG_FREERTOS_HZ` to `100` (10 ms per tick), which rounds small delays down — e.g. `delay(5)` becomes `vTaskDelay(0)` and does not wait at all.
+The ESP-IDF HAL's `delay()` resolution depends on the FreeRTOS tick rate. The HAL refuses to build unless `CONFIG_FREERTOS_HZ=1000` so that radio timings — e.g. LoRaWAN RX1/RX2 windows that fire 1-2 ms after a transmit — are accurate. This example sets it via `sdkconfig.defaults`; do the same in any project that uses the HAL.
 
-The Arduino ESP32 core works around this by forcing `CONFIG_FREERTOS_HZ=1000` (see the [arduino-esp32 CMakeLists.txt](https://github.com/espressif/arduino-esp32/blob/master/CMakeLists.txt)). This example does the same via `sdkconfig.defaults`. If you copy the HAL into your own ESP-IDF project, set `CONFIG_FREERTOS_HZ=1000` in your `sdkconfig` to get accurate 1 ms-resolution delays.
+If you need to keep a lower tick rate, build with `-DRADIOLIB_RELAX_RTOS_TICK=1` to bypass the check. `delay()` will still be correct in that mode — it sleeps for the bulk of the wait and busy-waits the sub-tick remainder with `esp_rom_delay_us()` — but the busy-wait portion can be up to one tick period (10 ms at the IDF default of 100 Hz), which wastes CPU and power.
 
 ## Structure of the example
 

--- a/examples/NonArduino/ESP-IDF/main/main.cpp
+++ b/examples/NonArduino/ESP-IDF/main/main.cpp
@@ -16,6 +16,8 @@
 // include the library
 #include <RadioLib.h>
 
+#include "esp_log.h"
+
 // create a new instance of the HAL class
 EspHal* hal = new EspHal(5, 19, 27);
 

--- a/src/BuildOpt.h
+++ b/src/BuildOpt.h
@@ -232,7 +232,7 @@
   // ESP8266 boards
   #define RADIOLIB_PLATFORM                           "ESP8266"
 
-#elif defined(ESP32) || defined(ARDUINO_ARCH_ESP32) || defined(ESP_PLATFORM)
+#elif defined(ESP32) || defined(ARDUINO_ARCH_ESP32)
   #define RADIOLIB_ESP32
 
   // ESP32 boards
@@ -477,6 +477,27 @@
 
   #undef RADIOLIB_DEBUG_PORT
   #define RADIOLIB_DEBUG_PORT                         stdout
+
+  #define DEC 10
+  #define HEX 16
+  #define OCT 8
+  #define BIN 2
+
+  #include <stdint.h>
+
+#elif defined(ESP_PLATFORM)
+  // ESP-IDF (non-Arduino) build
+  #define RADIOLIB_PLATFORM                           "ESP-IDF"
+  #define RADIOLIB_ESP32
+
+  // ESP32 doesn't support tone(), but it can be emulated via LED control peripheral
+  #define RADIOLIB_TONE_UNSUPPORTED
+
+  #define RADIOLIB_NC                                 (0xFFFFFFFF)
+  #define RADIOLIB_NONVOLATILE
+  #define RADIOLIB_NONVOLATILE_READ_BYTE(addr)        (*(reinterpret_cast<uint8_t *>(reinterpret_cast<void *>(addr))))
+  #define RADIOLIB_NONVOLATILE_READ_DWORD(addr)       (*(reinterpret_cast<uint32_t *>(reinterpret_cast<void *>(addr))))
+  #define RADIOLIB_TYPE_ALIAS(type, alias)            using alias = type;
 
   #define DEC 10
   #define HEX 16

--- a/src/hal/ESP-IDF/EspHal.cpp
+++ b/src/hal/ESP-IDF/EspHal.cpp
@@ -25,26 +25,7 @@ EspHal::EspHal(int8_t sck, int8_t miso, int8_t mosi,
 
 EspHal::~EspHal() { term(); }
 
-void EspHal::init() {
-  if (!halInitialized) {
-    spiBegin();
-    // Install the application-wide GPIO ISR service once.
-    // Loosely accept duplicate installations (ESP_ERR_INVALID_STATE)
-    esp_err_t ret = gpio_install_isr_service(ESP_INTR_FLAG_IRAM);
-    if (ret != ESP_OK && ret != ESP_ERR_INVALID_STATE) {
-      ESP_LOGE("EspHal", "Failed to install GPIO ISR service: %s",
-               esp_err_to_name(ret));
-    }
-    halInitialized = true;
-  }
-}
-
-void EspHal::term() {
-  if (halInitialized) {
-    spiEnd();
-    halInitialized = false;
-  }
-}
+// implementations of pure virtual RadioLibHal methods
 
 void EspHal::pinMode(uint32_t pin, uint32_t mode) {
   if (pin == RADIOLIB_NC) {
@@ -131,71 +112,6 @@ long EspHal::pulseIn(uint32_t pin, uint32_t state, unsigned long timeout) {
   }
 
   return micros() - pulseStart;
-}
-
-void EspHal::pullUpDown(uint32_t pin, bool enable, bool up) {
-  if (pin == RADIOLIB_NC) {
-    return;
-  }
-
-  if (enable) {
-    gpio_set_pull_mode((gpio_num_t)pin,
-                       up ? GPIO_PULLUP_ONLY : GPIO_PULLDOWN_ONLY);
-  } else {
-    gpio_set_pull_mode((gpio_num_t)pin, GPIO_FLOATING);
-  }
-}
-
-void EspHal::yield() { taskYIELD(); }
-
-void EspHal::tone(uint32_t pin, unsigned int frequency,
-                  RadioLibTime_t duration) {
-  if (pin == RADIOLIB_NC) {
-    return;
-  }
-  (void)duration;
-
-  // Configure the LEDC timer + channel only once
-  if (tonePrevFreq == -1) {
-    ledc_timer_config_t timer_config = {};
-    timer_config.speed_mode = LEDC_LOW_SPEED_MODE;
-    timer_config.duty_resolution = LEDC_TIMER_10_BIT;
-    timer_config.timer_num = LEDC_TIMER_0;
-    timer_config.freq_hz = (frequency > 0) ? frequency : 1000;
-    timer_config.clk_cfg = LEDC_AUTO_CLK;
-    ledc_timer_config(&timer_config);
-
-    ledc_channel_config_t channel_config = {};
-    channel_config.gpio_num = (int)pin;
-    channel_config.speed_mode = LEDC_LOW_SPEED_MODE;
-    channel_config.channel = (ledc_channel_t)RADIOLIB_TONE_ESP32_CHANNEL;
-    channel_config.timer_sel = LEDC_TIMER_0;
-    channel_config.duty = 512; // 50% duty at 10-bit resolution
-    channel_config.hpoint = 0;
-    ledc_channel_config(&channel_config);
-  }
-
-  // Update the frequency only when it actually changes
-  if ((int32_t)frequency != tonePrevFreq) {
-    ledc_set_freq(LEDC_LOW_SPEED_MODE, LEDC_TIMER_0, frequency);
-    ledc_set_duty(LEDC_LOW_SPEED_MODE,
-                  (ledc_channel_t)RADIOLIB_TONE_ESP32_CHANNEL, 512);
-    ledc_update_duty(LEDC_LOW_SPEED_MODE,
-                     (ledc_channel_t)RADIOLIB_TONE_ESP32_CHANNEL);
-    tonePrevFreq = (int32_t)frequency;
-  }
-}
-
-void EspHal::noTone(uint32_t pin) {
-  if (pin == RADIOLIB_NC) {
-    return;
-  }
-  if (tonePrevFreq == -1) {
-    return; // never started
-  }
-  ledc_stop(LEDC_LOW_SPEED_MODE,
-            (ledc_channel_t)RADIOLIB_TONE_ESP32_CHANNEL, 0);
-  tonePrevFreq = -1;
 }
 
 void EspHal::spiBegin() {
@@ -315,6 +231,94 @@ void EspHal::spiEnd() {
     spi_bus_free(spiHost);
     busInitialized = false;
     ESP_LOGD("EspHal", "SPI bus freed");
+  }
+}
+
+// implementations of virtual RadioLibHal methods
+
+void EspHal::init() {
+  if (!halInitialized) {
+    spiBegin();
+    // Install the application-wide GPIO ISR service once.
+    // Loosely accept duplicate installations (ESP_ERR_INVALID_STATE)
+    esp_err_t ret = gpio_install_isr_service(ESP_INTR_FLAG_IRAM);
+    if (ret != ESP_OK && ret != ESP_ERR_INVALID_STATE) {
+      ESP_LOGE("EspHal", "Failed to install GPIO ISR service: %s",
+               esp_err_to_name(ret));
+    }
+    halInitialized = true;
+  }
+}
+
+void EspHal::term() {
+  if (halInitialized) {
+    spiEnd();
+    halInitialized = false;
+  }
+}
+
+void EspHal::tone(uint32_t pin, unsigned int frequency,
+                  RadioLibTime_t duration) {
+  if (pin == RADIOLIB_NC) {
+    return;
+  }
+  (void)duration;
+
+  // Configure the LEDC timer + channel only once
+  if (tonePrevFreq == -1) {
+    ledc_timer_config_t timer_config = {};
+    timer_config.speed_mode = LEDC_LOW_SPEED_MODE;
+    timer_config.duty_resolution = LEDC_TIMER_10_BIT;
+    timer_config.timer_num = LEDC_TIMER_0;
+    timer_config.freq_hz = (frequency > 0) ? frequency : 1000;
+    timer_config.clk_cfg = LEDC_AUTO_CLK;
+    ledc_timer_config(&timer_config);
+
+    ledc_channel_config_t channel_config = {};
+    channel_config.gpio_num = (int)pin;
+    channel_config.speed_mode = LEDC_LOW_SPEED_MODE;
+    channel_config.channel = (ledc_channel_t)RADIOLIB_TONE_ESP32_CHANNEL;
+    channel_config.timer_sel = LEDC_TIMER_0;
+    channel_config.duty = 512; // 50% duty at 10-bit resolution
+    channel_config.hpoint = 0;
+    ledc_channel_config(&channel_config);
+  }
+
+  // Update the frequency only when it actually changes
+  if ((int32_t)frequency != tonePrevFreq) {
+    ledc_set_freq(LEDC_LOW_SPEED_MODE, LEDC_TIMER_0, frequency);
+    ledc_set_duty(LEDC_LOW_SPEED_MODE,
+                  (ledc_channel_t)RADIOLIB_TONE_ESP32_CHANNEL, 512);
+    ledc_update_duty(LEDC_LOW_SPEED_MODE,
+                     (ledc_channel_t)RADIOLIB_TONE_ESP32_CHANNEL);
+    tonePrevFreq = (int32_t)frequency;
+  }
+}
+
+void EspHal::noTone(uint32_t pin) {
+  if (pin == RADIOLIB_NC) {
+    return;
+  }
+  if (tonePrevFreq == -1) {
+    return; // never started
+  }
+  ledc_stop(LEDC_LOW_SPEED_MODE,
+            (ledc_channel_t)RADIOLIB_TONE_ESP32_CHANNEL, 0);
+  tonePrevFreq = -1;
+}
+
+void EspHal::yield() { taskYIELD(); }
+
+void EspHal::pullUpDown(uint32_t pin, bool enable, bool up) {
+  if (pin == RADIOLIB_NC) {
+    return;
+  }
+
+  if (enable) {
+    gpio_set_pull_mode((gpio_num_t)pin,
+                       up ? GPIO_PULLUP_ONLY : GPIO_PULLDOWN_ONLY);
+  } else {
+    gpio_set_pull_mode((gpio_num_t)pin, GPIO_FLOATING);
   }
 }
 

--- a/src/hal/ESP-IDF/EspHal.cpp
+++ b/src/hal/ESP-IDF/EspHal.cpp
@@ -1,0 +1,321 @@
+// EspHal.cpp
+// Definitions for the ESP-IDF HAL.
+
+#include "EspHal.h"
+
+#if defined(ESP_PLATFORM)
+
+#include "driver/gpio.h"
+#include "driver/ledc.h"
+#include "esp_log.h"
+#include "esp_rom_sys.h" // For esp_rom_delay_us
+#include "esp_timer.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "sdkconfig.h"
+#include <cinttypes> // For PRIu32
+
+EspHal::EspHal(int8_t sck, int8_t miso, int8_t mosi,
+               spi_host_device_t host, uint32_t clockHz)
+    : RadioLibHal(GPIO_MODE_INPUT, GPIO_MODE_OUTPUT, 0, 1,
+                  GPIO_INTR_POSEDGE, GPIO_INTR_NEGEDGE),
+      spiSCK(sck), spiMISO(miso), spiMOSI(mosi), spiHost(host),
+      spiClockHz(clockHz), spiDevice(nullptr), busInitialized(false),
+      deviceAdded(false), halInitialized(false), tonePrevFreq(-1) {}
+
+EspHal::~EspHal() { term(); }
+
+void EspHal::init() {
+  if (!halInitialized) {
+    spiBegin();
+    // Install the application-wide GPIO ISR service once.
+    // Loosely accept duplicate installations (ESP_ERR_INVALID_STATE)
+    esp_err_t ret = gpio_install_isr_service(ESP_INTR_FLAG_IRAM);
+    if (ret != ESP_OK && ret != ESP_ERR_INVALID_STATE) {
+      ESP_LOGE("EspHal", "Failed to install GPIO ISR service: %s",
+               esp_err_to_name(ret));
+    }
+    halInitialized = true;
+  }
+}
+
+void EspHal::term() {
+  if (halInitialized) {
+    spiEnd();
+    halInitialized = false;
+  }
+}
+
+void EspHal::pinMode(uint32_t pin, uint32_t mode) {
+  if (pin == RADIOLIB_NC) {
+    return;
+  }
+
+  gpio_config_t conf = {
+      .pin_bit_mask = (1ULL << pin),
+      .mode = (mode == GPIO_MODE_OUTPUT) ? GPIO_MODE_OUTPUT : GPIO_MODE_INPUT,
+      .pull_up_en = GPIO_PULLUP_DISABLE,
+      .pull_down_en = GPIO_PULLDOWN_DISABLE,
+      .intr_type = GPIO_INTR_DISABLE,
+  };
+  gpio_config(&conf);
+}
+
+void EspHal::digitalWrite(uint32_t pin, uint32_t value) {
+  if (pin == RADIOLIB_NC) {
+    return;
+  }
+  gpio_set_level((gpio_num_t)pin, value);
+}
+
+uint32_t EspHal::digitalRead(uint32_t pin) {
+  if (pin == RADIOLIB_NC) {
+    return 0;
+  }
+  return gpio_get_level((gpio_num_t)pin);
+}
+
+void EspHal::attachInterrupt(uint32_t interruptNum,
+                             void (*interruptCb)(void), uint32_t mode) {
+  if (interruptNum == RADIOLIB_NC) {
+    return;
+  }
+
+  gpio_set_intr_type((gpio_num_t)interruptNum, (gpio_int_type_t)mode);
+  gpio_isr_handler_add((gpio_num_t)interruptNum, (gpio_isr_t)interruptCb,
+                       nullptr);
+}
+
+void EspHal::detachInterrupt(uint32_t interruptNum) {
+  if (interruptNum == RADIOLIB_NC) {
+    return;
+  }
+  gpio_isr_handler_remove((gpio_num_t)interruptNum);
+}
+
+void EspHal::delay(unsigned long ms) { vTaskDelay(pdMS_TO_TICKS(ms)); }
+
+void EspHal::delayMicroseconds(unsigned long us) { esp_rom_delay_us(us); }
+
+unsigned long EspHal::millis() {
+  return (unsigned long)(esp_timer_get_time() / 1000ULL);
+}
+
+unsigned long EspHal::micros() {
+  return (unsigned long)esp_timer_get_time();
+}
+
+long EspHal::pulseIn(uint32_t pin, uint32_t state, unsigned long timeout) {
+  if (pin == RADIOLIB_NC) {
+    return 0;
+  }
+
+  unsigned long startMicros = micros();
+  unsigned long currentMicros;
+
+  // Wait for pulse to start
+  while (this->digitalRead(pin) != state) {
+    currentMicros = micros();
+    if (currentMicros - startMicros >= timeout) {
+      return 0;
+    }
+  }
+
+  // Measure pulse duration
+  unsigned long pulseStart = micros();
+  while (this->digitalRead(pin) == state) {
+    currentMicros = micros();
+    if (currentMicros - pulseStart >= timeout) {
+      return 0;
+    }
+  }
+
+  return micros() - pulseStart;
+}
+
+void EspHal::pullUpDown(uint32_t pin, bool enable, bool up) {
+  if (pin == RADIOLIB_NC) {
+    return;
+  }
+
+  if (enable) {
+    gpio_set_pull_mode((gpio_num_t)pin,
+                       up ? GPIO_PULLUP_ONLY : GPIO_PULLDOWN_ONLY);
+  } else {
+    gpio_set_pull_mode((gpio_num_t)pin, GPIO_FLOATING);
+  }
+}
+
+void EspHal::yield() { taskYIELD(); }
+
+void EspHal::tone(uint32_t pin, unsigned int frequency,
+                  RadioLibTime_t duration) {
+  if (pin == RADIOLIB_NC) {
+    return;
+  }
+  (void)duration;
+
+  // Configure the LEDC timer + channel only once
+  if (tonePrevFreq == -1) {
+    ledc_timer_config_t timer_config = {};
+    timer_config.speed_mode = LEDC_LOW_SPEED_MODE;
+    timer_config.duty_resolution = LEDC_TIMER_10_BIT;
+    timer_config.timer_num = LEDC_TIMER_0;
+    timer_config.freq_hz = (frequency > 0) ? frequency : 1000;
+    timer_config.clk_cfg = LEDC_AUTO_CLK;
+    ledc_timer_config(&timer_config);
+
+    ledc_channel_config_t channel_config = {};
+    channel_config.gpio_num = (int)pin;
+    channel_config.speed_mode = LEDC_LOW_SPEED_MODE;
+    channel_config.channel = (ledc_channel_t)RADIOLIB_TONE_ESP32_CHANNEL;
+    channel_config.timer_sel = LEDC_TIMER_0;
+    channel_config.duty = 512; // 50% duty at 10-bit resolution
+    channel_config.hpoint = 0;
+    ledc_channel_config(&channel_config);
+  }
+
+  // Update the frequency only when it actually changes
+  if ((int32_t)frequency != tonePrevFreq) {
+    ledc_set_freq(LEDC_LOW_SPEED_MODE, LEDC_TIMER_0, frequency);
+    ledc_set_duty(LEDC_LOW_SPEED_MODE,
+                  (ledc_channel_t)RADIOLIB_TONE_ESP32_CHANNEL, 512);
+    ledc_update_duty(LEDC_LOW_SPEED_MODE,
+                     (ledc_channel_t)RADIOLIB_TONE_ESP32_CHANNEL);
+    tonePrevFreq = (int32_t)frequency;
+  }
+}
+
+void EspHal::noTone(uint32_t pin) {
+  if (pin == RADIOLIB_NC) {
+    return;
+  }
+  if (tonePrevFreq == -1) {
+    return; // never started
+  }
+  ledc_stop(LEDC_LOW_SPEED_MODE,
+            (ledc_channel_t)RADIOLIB_TONE_ESP32_CHANNEL, 0);
+  tonePrevFreq = -1;
+}
+
+void EspHal::spiBegin() {
+  ESP_LOGD("EspHal",
+           "Initializing SPI on host %d (SCK=%d, MISO=%d, MOSI=%d)", spiHost,
+           spiSCK, spiMISO, spiMOSI);
+
+  // Try to initialize the bus - it may already be initialized by another
+  // component (shared bus). While RadioLib does not
+  // allocate DMA-capable buffers and the transfers here are small,
+  // SPI_DMA_CH_AUTO is set because with SPI_DMA_DISABLED the SPI transaction
+  // is limited to 64 bytes (and our radio MTU can be much bigger).
+  spi_bus_config_t bus_config = {};
+  bus_config.mosi_io_num = spiMOSI;
+  bus_config.miso_io_num = spiMISO;
+  bus_config.sclk_io_num = spiSCK;
+  bus_config.quadwp_io_num = -1;
+  bus_config.quadhd_io_num = -1;
+  bus_config.data4_io_num = -1;
+  bus_config.data5_io_num = -1;
+  bus_config.data6_io_num = -1;
+  bus_config.data7_io_num = -1;
+  bus_config.max_transfer_sz = SOC_SPI_MAXIMUM_BUFFER_SIZE;
+  bus_config.flags = 0;
+  bus_config.isr_cpu_id = ESP_INTR_CPU_AFFINITY_AUTO;
+  bus_config.intr_flags = 0;
+
+  esp_err_t ret = spi_bus_initialize(spiHost, &bus_config, SPI_DMA_CH_AUTO);
+  if (ret == ESP_OK) {
+    busInitialized = true;
+    ESP_LOGD("EspHal", "SPI bus initialized successfully");
+  } else if (ret == ESP_ERR_INVALID_STATE) {
+    // Bus already initialized - this is OK for shared bus
+    busInitialized = false; // We didn't init it, so we won't free it
+    ESP_LOGD("EspHal", "SPI bus already initialized (shared bus)");
+  } else {
+    ESP_LOGE("EspHal", "Failed to initialize SPI bus: %s",
+             esp_err_to_name(ret));
+    return;
+  }
+
+  // Add the device. CS is left to RadioLib (software-driven via
+  // digitalWrite on the Module's csPin), so spics_io_num is -1.
+  spi_device_interface_config_t dev_config = {};
+  dev_config.command_bits = 0;
+  dev_config.address_bits = 0;
+  dev_config.dummy_bits = 0;
+  dev_config.mode = 0; // SPI mode 0 (CPOL=0, CPHA=0)
+  dev_config.clock_source = SPI_CLK_SRC_DEFAULT;
+  dev_config.duty_cycle_pos = 128; // 50% duty cycle
+  dev_config.cs_ena_pretrans = 0;
+  dev_config.cs_ena_posttrans = 0;
+  dev_config.clock_speed_hz = (int)spiClockHz;
+  dev_config.input_delay_ns = 0;
+  dev_config.spics_io_num = -1; // RadioLib drives CS in software
+  dev_config.flags = 0;
+  dev_config.queue_size = 1;
+  dev_config.pre_cb = nullptr;
+  dev_config.post_cb = nullptr;
+
+  ret = spi_bus_add_device(spiHost, &dev_config, &spiDevice);
+  if (ret != ESP_OK) {
+    ESP_LOGE("EspHal", "Failed to add SPI device: %s", esp_err_to_name(ret));
+    return;
+  }
+  deviceAdded = true;
+  ESP_LOGD("EspHal", "SPI device added (clock=%" PRIu32 " Hz, software CS)",
+           spiClockHz);
+}
+
+void EspHal::spiBeginTransaction() {
+  // Acquire the SPI bus for this device
+  if (spiDevice != nullptr) {
+    spi_device_acquire_bus(spiDevice, portMAX_DELAY);
+  }
+}
+
+void EspHal::spiTransfer(uint8_t *out, size_t len, uint8_t *in) {
+  if (spiDevice == nullptr) {
+    ESP_LOGE("EspHal", "SPI device not initialized!");
+    return;
+  }
+
+  if (len == 0) {
+    return;
+  }
+
+  spi_transaction_t trans = {};
+  trans.length = len * 8; // length in bits
+  trans.tx_buffer = out;
+  trans.rx_buffer = in;
+
+  esp_err_t ret = spi_device_polling_transmit(spiDevice, &trans);
+  if (ret != ESP_OK) {
+    ESP_LOGE("EspHal", "SPI transfer failed: %s", esp_err_to_name(ret));
+  }
+}
+
+void EspHal::spiEndTransaction() {
+  // Release the SPI bus
+  if (spiDevice != nullptr) {
+    spi_device_release_bus(spiDevice);
+  }
+}
+
+void EspHal::spiEnd() {
+  // Remove device from bus
+  if (deviceAdded && spiDevice != nullptr) {
+    spi_bus_remove_device(spiDevice);
+    spiDevice = nullptr;
+    deviceAdded = false;
+    ESP_LOGD("EspHal", "SPI device removed");
+  }
+
+  // Free the bus only if we initialized it
+  if (busInitialized) {
+    spi_bus_free(spiHost);
+    busInitialized = false;
+    ESP_LOGD("EspHal", "SPI bus freed");
+  }
+}
+
+#endif // ESP_PLATFORM

--- a/src/hal/ESP-IDF/EspHal.cpp
+++ b/src/hal/ESP-IDF/EspHal.cpp
@@ -15,6 +15,17 @@
 #include "sdkconfig.h"
 #include <cinttypes> // For PRIu32
 
+// EspHal::delay() uses vTaskDelay(pdMS_TO_TICKS(ms)) for the bulk of the
+// wait, so its resolution is the FreeRTOS tick. At the IDF default of
+// CONFIG_FREERTOS_HZ=100 the tick is 10 ms, which makes timing-sensitive
+// radio operations like LoRaWAN RX1/RX2 windows unreliable. Refuse to
+// build unless the user opts out explicitly via RADIOLIB_RELAX_RTOS_TICK.
+#if defined(CONFIG_FREERTOS_HZ) && (CONFIG_FREERTOS_HZ < 1000)
+  #if !defined(RADIOLIB_RELAX_RTOS_TICK) || (RADIOLIB_RELAX_RTOS_TICK != 1)
+    #error "RadioLib EspHal: CONFIG_FREERTOS_HZ is below 1000; set it to 1000 in sdkconfig for accurate delay() resolution, or define RADIOLIB_RELAX_RTOS_TICK=1 to bypass this check."
+  #endif
+#endif
+
 EspHal::EspHal(int8_t sck, int8_t miso, int8_t mosi,
                spi_host_device_t host, uint32_t clockHz)
     : RadioLibHal(GPIO_MODE_INPUT, GPIO_MODE_OUTPUT, 0, 1,

--- a/src/hal/ESP-IDF/EspHal.cpp
+++ b/src/hal/ESP-IDF/EspHal.cpp
@@ -74,7 +74,27 @@ void EspHal::detachInterrupt(uint32_t interruptNum) {
   gpio_isr_handler_remove((gpio_num_t)interruptNum);
 }
 
-void EspHal::delay(unsigned long ms) { vTaskDelay(pdMS_TO_TICKS(ms)); }
+void EspHal::delay(unsigned long ms) {
+  if (ms == 0) {
+    return;
+  }
+
+  // Hybrid sleep + busy-wait so the call is accurate even when
+  // CONFIG_FREERTOS_HZ < 1000. Sleep all-but-one tick under the
+  // scheduler, then busy-wait the remainder with microsecond precision.
+  // Worst-case busy-wait is one tick period (10 ms at the IDF default).
+  const uint64_t target_us = (uint64_t)esp_timer_get_time() + (uint64_t)ms * 1000ULL;
+
+  const TickType_t ticks = pdMS_TO_TICKS(ms);
+  if (ticks > 1) {
+    vTaskDelay(ticks - 1);
+  }
+
+  int64_t remaining_us = (int64_t)target_us - esp_timer_get_time();
+  if (remaining_us > 0) {
+    esp_rom_delay_us((uint32_t)remaining_us);
+  }
+}
 
 void EspHal::delayMicroseconds(unsigned long us) { esp_rom_delay_us(us); }
 

--- a/src/hal/ESP-IDF/EspHal.cpp
+++ b/src/hal/ESP-IDF/EspHal.cpp
@@ -23,7 +23,7 @@ EspHal::EspHal(int8_t sck, int8_t miso, int8_t mosi,
       spiClockHz(clockHz), spiDevice(nullptr), busInitialized(false),
       deviceAdded(false), halInitialized(false), tonePrevFreq(-1) {}
 
-EspHal::~EspHal() { term(); }
+EspHal::~EspHal() { EspHal::term(); }
 
 // implementations of pure virtual RadioLibHal methods
 

--- a/src/hal/ESP-IDF/EspHal.h
+++ b/src/hal/ESP-IDF/EspHal.h
@@ -7,16 +7,7 @@
 
 #if defined(ESP_PLATFORM)
 #include "RadioLib.h"
-#include "driver/gpio.h"
-#include "driver/ledc.h"
 #include "driver/spi_master.h"
-#include "esp_log.h"
-#include "esp_rom_sys.h" // For esp_rom_delay_us
-#include "esp_timer.h"
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
-#include "sdkconfig.h"
-#include <cinttypes> // For PRIu32
 
 // These are left undefined by the generic build; define them for the ESP-IDF HAL
 #if !defined(RADIOLIB_ESP32)
@@ -44,313 +35,46 @@ public:
    *                SPI_MASTER_FREQ_8M for SX12xx if supported by the module)
    */
   EspHal(int8_t sck, int8_t miso, int8_t mosi,
-         spi_host_device_t host = SPI2_HOST, uint32_t clockHz = 2000000)
-      : RadioLibHal(GPIO_MODE_INPUT, GPIO_MODE_OUTPUT, 0, 1,
-                    GPIO_INTR_POSEDGE, GPIO_INTR_NEGEDGE), spiSCK(sck),
-        spiMISO(miso), spiMOSI(mosi), spiHost(host), spiClockHz(clockHz),
-        spiDevice(nullptr), busInitialized(false), deviceAdded(false),
-        halInitialized(false), tonePrevFreq(-1) {}
+         spi_host_device_t host = SPI2_HOST, uint32_t clockHz = 2000000);
 
-  virtual ~EspHal() { term(); }
+  virtual ~EspHal();
 
-  void init() override {
-    if (!halInitialized) {
-      spiBegin();
-      // Install the application-wide GPIO ISR service once.
-      // Loosely accept duplicate installations (ESP_ERR_INVALID_STATE)
-      esp_err_t ret = gpio_install_isr_service(ESP_INTR_FLAG_IRAM);
-      if (ret != ESP_OK && ret != ESP_ERR_INVALID_STATE) {
-        ESP_LOGE("EspHal", "Failed to install GPIO ISR service: %s",
-                 esp_err_to_name(ret));
-      }
-      halInitialized = true;
-    }
-  }
-
-  void term() override {
-    if (halInitialized) {
-      spiEnd();
-      halInitialized = false;
-    }
-  }
+  void init() override;
+  void term() override;
 
   // GPIO operations
-  void pinMode(uint32_t pin, uint32_t mode) override {
-    if (pin == RADIOLIB_NC) {
-      return;
-    }
-
-    gpio_config_t conf = {
-        .pin_bit_mask = (1ULL << pin),
-        .mode = (mode == GPIO_MODE_OUTPUT) ? GPIO_MODE_OUTPUT : GPIO_MODE_INPUT,
-        .pull_up_en = GPIO_PULLUP_DISABLE,
-        .pull_down_en = GPIO_PULLDOWN_DISABLE,
-        .intr_type = GPIO_INTR_DISABLE,
-    };
-    gpio_config(&conf);
-  }
-
-  void digitalWrite(uint32_t pin, uint32_t value) override {
-    if (pin == RADIOLIB_NC) {
-      return;
-    }
-    gpio_set_level((gpio_num_t)pin, value);
-  }
-
-  uint32_t digitalRead(uint32_t pin) override {
-    if (pin == RADIOLIB_NC) {
-      return 0;
-    }
-    return gpio_get_level((gpio_num_t)pin);
-  }
-
+  void pinMode(uint32_t pin, uint32_t mode) override;
+  void digitalWrite(uint32_t pin, uint32_t value) override;
+  uint32_t digitalRead(uint32_t pin) override;
   void attachInterrupt(uint32_t interruptNum, void (*interruptCb)(void),
-                       uint32_t mode) override {
-    if (interruptNum == RADIOLIB_NC) {
-      return;
-    }
-
-    gpio_set_intr_type((gpio_num_t)interruptNum, (gpio_int_type_t)mode);
-    gpio_isr_handler_add((gpio_num_t)interruptNum, (gpio_isr_t)interruptCb,
-                         nullptr);
-  }
-
-  void detachInterrupt(uint32_t interruptNum) override {
-    if (interruptNum == RADIOLIB_NC) {
-      return;
-    }
-    gpio_isr_handler_remove((gpio_num_t)interruptNum);
-  }
+                       uint32_t mode) override;
+  void detachInterrupt(uint32_t interruptNum) override;
 
   // Timing functions
-  void delay(unsigned long ms) override { vTaskDelay(pdMS_TO_TICKS(ms)); }
-
-  void delayMicroseconds(unsigned long us) override { esp_rom_delay_us(us); }
-
-  unsigned long millis() override {
-    return (unsigned long)(esp_timer_get_time() / 1000ULL);
-  }
-
-  unsigned long micros() override {
-    return (unsigned long)esp_timer_get_time();
-  }
-
-  long pulseIn(uint32_t pin, uint32_t state, unsigned long timeout) override {
-    if (pin == RADIOLIB_NC) {
-      return 0;
-    }
-
-    unsigned long startMicros = micros();
-    unsigned long currentMicros;
-
-    // Wait for pulse to start
-    while (this->digitalRead(pin) != state) {
-      currentMicros = micros();
-      if (currentMicros - startMicros >= timeout) {
-        return 0;
-      }
-    }
-
-    // Measure pulse duration
-    unsigned long pulseStart = micros();
-    while (this->digitalRead(pin) == state) {
-      currentMicros = micros();
-      if (currentMicros - pulseStart >= timeout) {
-        return 0;
-      }
-    }
-
-    return micros() - pulseStart;
-  }
+  void delay(unsigned long ms) override;
+  void delayMicroseconds(unsigned long us) override;
+  unsigned long millis() override;
+  unsigned long micros() override;
+  long pulseIn(uint32_t pin, uint32_t state, unsigned long timeout) override;
 
   // GPIO pull-up/pull-down configuration
-  void pullUpDown(uint32_t pin, bool enable, bool up) override {
-    if (pin == RADIOLIB_NC) {
-      return;
-    }
-
-    if (enable) {
-      gpio_set_pull_mode((gpio_num_t)pin,
-                         up ? GPIO_PULLUP_ONLY : GPIO_PULLDOWN_ONLY);
-    } else {
-      gpio_set_pull_mode((gpio_num_t)pin, GPIO_FLOATING);
-    }
-  }
+  void pullUpDown(uint32_t pin, bool enable, bool up) override;
 
   // Yield to other FreeRTOS tasks so long RadioLib polling loops do not
   // starve the IDLE task and trip the task watchdog on default ESP-IDF config.
-  void yield() override { taskYIELD(); }
+  void yield() override;
 
   // Tone generation using the LEDC peripheral (lazily initialised on first use)
   void tone(uint32_t pin, unsigned int frequency,
-            RadioLibTime_t duration = 0) override {
-    if (pin == RADIOLIB_NC) {
-      return;
-    }
-    (void)duration;
-
-    // Configure the LEDC timer + channel only once
-    if (tonePrevFreq == -1) {
-      ledc_timer_config_t timer_config = {};
-      timer_config.speed_mode = LEDC_LOW_SPEED_MODE;
-      timer_config.duty_resolution = LEDC_TIMER_10_BIT;
-      timer_config.timer_num = LEDC_TIMER_0;
-      timer_config.freq_hz = (frequency > 0) ? frequency : 1000;
-      timer_config.clk_cfg = LEDC_AUTO_CLK;
-      ledc_timer_config(&timer_config);
-
-      ledc_channel_config_t channel_config = {};
-      channel_config.gpio_num = (int)pin;
-      channel_config.speed_mode = LEDC_LOW_SPEED_MODE;
-      channel_config.channel = (ledc_channel_t)RADIOLIB_TONE_ESP32_CHANNEL;
-      channel_config.timer_sel = LEDC_TIMER_0;
-      channel_config.duty = 512; // 50% duty at 10-bit resolution
-      channel_config.hpoint = 0;
-      ledc_channel_config(&channel_config);
-    }
-
-    // Update the frequency only when it actually changes
-    if ((int32_t)frequency != tonePrevFreq) {
-      ledc_set_freq(LEDC_LOW_SPEED_MODE, LEDC_TIMER_0, frequency);
-      ledc_set_duty(LEDC_LOW_SPEED_MODE,
-                    (ledc_channel_t)RADIOLIB_TONE_ESP32_CHANNEL, 512);
-      ledc_update_duty(LEDC_LOW_SPEED_MODE,
-                       (ledc_channel_t)RADIOLIB_TONE_ESP32_CHANNEL);
-      tonePrevFreq = (int32_t)frequency;
-    }
-  }
-
-  void noTone(uint32_t pin) override {
-    if (pin == RADIOLIB_NC) {
-      return;
-    }
-    if (tonePrevFreq == -1) {
-      return; // never started
-    }
-    ledc_stop(LEDC_LOW_SPEED_MODE,
-              (ledc_channel_t)RADIOLIB_TONE_ESP32_CHANNEL, 0);
-    tonePrevFreq = -1;
-  }
+            RadioLibTime_t duration = 0) override;
+  void noTone(uint32_t pin) override;
 
   // SPI operations using spi_master driver
-  void spiBegin() {
-    ESP_LOGD("EspHal", "Initializing SPI on host %d (SCK=%d, MISO=%d, MOSI=%d)",
-             spiHost, spiSCK, spiMISO, spiMOSI);
-
-    // Try to initialize the bus - it may already be initialized by another
-    // component (shared bus). While RadioLib does not
-    // allocate DMA-capable buffers and the transfers here are small,
-    // SPI_DMA_CH_AUTO is set because with SPI_DMA_DISABLED the SPI transaction
-    // is limited to 64 bytes (and our radio MTU can be much bigger).
-    spi_bus_config_t bus_config = {};
-    bus_config.mosi_io_num = spiMOSI;
-    bus_config.miso_io_num = spiMISO;
-    bus_config.sclk_io_num = spiSCK;
-    bus_config.quadwp_io_num = -1;
-    bus_config.quadhd_io_num = -1;
-    bus_config.data4_io_num = -1;
-    bus_config.data5_io_num = -1;
-    bus_config.data6_io_num = -1;
-    bus_config.data7_io_num = -1;
-    bus_config.max_transfer_sz = SOC_SPI_MAXIMUM_BUFFER_SIZE;
-    bus_config.flags = 0;
-    bus_config.isr_cpu_id = ESP_INTR_CPU_AFFINITY_AUTO;
-    bus_config.intr_flags = 0;
-
-    esp_err_t ret = spi_bus_initialize(spiHost, &bus_config, SPI_DMA_CH_AUTO);
-    if (ret == ESP_OK) {
-      busInitialized = true;
-      ESP_LOGD("EspHal", "SPI bus initialized successfully");
-    } else if (ret == ESP_ERR_INVALID_STATE) {
-      // Bus already initialized - this is OK for shared bus
-      busInitialized = false; // We didn't init it, so we won't free it
-      ESP_LOGD("EspHal", "SPI bus already initialized (shared bus)");
-    } else {
-      ESP_LOGE("EspHal", "Failed to initialize SPI bus: %s",
-               esp_err_to_name(ret));
-      return;
-    }
-
-    // Add the device. CS is left to RadioLib (software-driven via
-    // digitalWrite on the Module's csPin), so spics_io_num is -1.
-    spi_device_interface_config_t dev_config = {};
-    dev_config.command_bits = 0;
-    dev_config.address_bits = 0;
-    dev_config.dummy_bits = 0;
-    dev_config.mode = 0; // SPI mode 0 (CPOL=0, CPHA=0)
-    dev_config.clock_source = SPI_CLK_SRC_DEFAULT;
-    dev_config.duty_cycle_pos = 128; // 50% duty cycle
-    dev_config.cs_ena_pretrans = 0;
-    dev_config.cs_ena_posttrans = 0;
-    dev_config.clock_speed_hz = (int)spiClockHz;
-    dev_config.input_delay_ns = 0;
-    dev_config.spics_io_num = -1; // RadioLib drives CS in software
-    dev_config.flags = 0;
-    dev_config.queue_size = 1;
-    dev_config.pre_cb = nullptr;
-    dev_config.post_cb = nullptr;
-
-    ret = spi_bus_add_device(spiHost, &dev_config, &spiDevice);
-    if (ret != ESP_OK) {
-      ESP_LOGE("EspHal", "Failed to add SPI device: %s", esp_err_to_name(ret));
-      return;
-    }
-    deviceAdded = true;
-    ESP_LOGD("EspHal", "SPI device added (clock=%" PRIu32 " Hz, software CS)",
-             spiClockHz);
-  }
-
-  void spiBeginTransaction() {
-    // Acquire the SPI bus for this device
-    if (spiDevice != nullptr) {
-      spi_device_acquire_bus(spiDevice, portMAX_DELAY);
-    }
-  }
-
-  void spiTransfer(uint8_t *out, size_t len, uint8_t *in) {
-    if (spiDevice == nullptr) {
-      ESP_LOGE("EspHal", "SPI device not initialized!");
-      return;
-    }
-
-    if (len == 0) {
-      return;
-    }
-
-    spi_transaction_t trans = {};
-    trans.length = len * 8; // length in bits
-    trans.tx_buffer = out;
-    trans.rx_buffer = in;
-
-    esp_err_t ret = spi_device_polling_transmit(spiDevice, &trans);
-    if (ret != ESP_OK) {
-      ESP_LOGE("EspHal", "SPI transfer failed: %s", esp_err_to_name(ret));
-    }
-  }
-
-  void spiEndTransaction() {
-    // Release the SPI bus
-    if (spiDevice != nullptr) {
-      spi_device_release_bus(spiDevice);
-    }
-  }
-
-  void spiEnd() {
-    // Remove device from bus
-    if (deviceAdded && spiDevice != nullptr) {
-      spi_bus_remove_device(spiDevice);
-      spiDevice = nullptr;
-      deviceAdded = false;
-      ESP_LOGD("EspHal", "SPI device removed");
-    }
-
-    // Free the bus only if we initialized it
-    if (busInitialized) {
-      spi_bus_free(spiHost);
-      busInitialized = false;
-      ESP_LOGD("EspHal", "SPI bus freed");
-    }
-  }
+  void spiBegin();
+  void spiBeginTransaction();
+  void spiTransfer(uint8_t *out, size_t len, uint8_t *in);
+  void spiEndTransaction();
+  void spiEnd();
 
 private:
   int8_t spiSCK;

--- a/src/hal/ESP-IDF/EspHal.h
+++ b/src/hal/ESP-IDF/EspHal.h
@@ -177,6 +177,10 @@ public:
     }
   }
 
+  // Yield to other FreeRTOS tasks so long RadioLib polling loops do not
+  // starve the IDLE task and trip the task watchdog on default ESP-IDF config.
+  void yield() override { taskYIELD(); }
+
   // Tone generation using the LEDC peripheral (lazily initialised on first use)
   void tone(uint32_t pin, unsigned int frequency,
             RadioLibTime_t duration = 0) override {

--- a/src/hal/ESP-IDF/EspHal.h
+++ b/src/hal/ESP-IDF/EspHal.h
@@ -2,8 +2,8 @@
 // ESP-IDF HAL for RadioLib using spi_master driver
 // This avoids conflicts with other SPI devices on the same bus
 
-#ifndef RADIOLIB_ESP_IDF_HAL
-#define RADIOLIB_ESP_IDF_HAL
+#if !defined(_RADIOLIB_ESP_IDF_HAL_H)
+#define _RADIOLIB_ESP_IDF_HAL_H
 
 #if defined(ESP_PLATFORM)
 #include "RadioLib.h"
@@ -372,4 +372,4 @@ private:
   int32_t tonePrevFreq;
 };
 #endif
-#endif // RADIOLIB_ESP_IDF_HAL
+#endif // _RADIOLIB_ESP_IDF_HAL_H

--- a/src/hal/ESP-IDF/EspHal.h
+++ b/src/hal/ESP-IDF/EspHal.h
@@ -9,10 +9,9 @@
 #include "RadioLib.h"
 #include "driver/spi_master.h"
 
-// These are left undefined by the generic build; define them for the ESP-IDF HAL
-#if !defined(RADIOLIB_ESP32)
-#define RADIOLIB_ESP32
-#endif
+// RADIOLIB_ESP32 is now set by BuildOpt.h for ESP_PLATFORM builds.
+// RADIOLIB_TONE_ESP32_CHANNEL stays here because LEDC_CHANNEL_0 is only
+// visible via driver/ledc.h, which BuildOpt.h does not pull in.
 #if !defined(RADIOLIB_TONE_ESP32_CHANNEL)
 #define RADIOLIB_TONE_ESP32_CHANNEL (LEDC_CHANNEL_0)
 #endif

--- a/src/hal/ESP-IDF/EspHal.h
+++ b/src/hal/ESP-IDF/EspHal.h
@@ -39,42 +39,32 @@ public:
 
   virtual ~EspHal();
 
-  void init() override;
-  void term() override;
-
-  // GPIO operations
+  // implementations of pure virtual RadioLibHal methods
   void pinMode(uint32_t pin, uint32_t mode) override;
   void digitalWrite(uint32_t pin, uint32_t value) override;
   uint32_t digitalRead(uint32_t pin) override;
   void attachInterrupt(uint32_t interruptNum, void (*interruptCb)(void),
                        uint32_t mode) override;
   void detachInterrupt(uint32_t interruptNum) override;
-
-  // Timing functions
   void delay(unsigned long ms) override;
   void delayMicroseconds(unsigned long us) override;
   unsigned long millis() override;
   unsigned long micros() override;
   long pulseIn(uint32_t pin, uint32_t state, unsigned long timeout) override;
-
-  // GPIO pull-up/pull-down configuration
-  void pullUpDown(uint32_t pin, bool enable, bool up) override;
-
-  // Yield to other FreeRTOS tasks so long RadioLib polling loops do not
-  // starve the IDLE task and trip the task watchdog on default ESP-IDF config.
-  void yield() override;
-
-  // Tone generation using the LEDC peripheral (lazily initialised on first use)
-  void tone(uint32_t pin, unsigned int frequency,
-            RadioLibTime_t duration = 0) override;
-  void noTone(uint32_t pin) override;
-
-  // SPI operations using spi_master driver
   void spiBegin();
   void spiBeginTransaction();
   void spiTransfer(uint8_t *out, size_t len, uint8_t *in);
   void spiEndTransaction();
   void spiEnd();
+
+  // implementations of virtual RadioLibHal methods
+  void init() override;
+  void term() override;
+  void tone(uint32_t pin, unsigned int frequency,
+            RadioLibTime_t duration = 0) override;
+  void noTone(uint32_t pin) override;
+  void yield() override;
+  void pullUpDown(uint32_t pin, bool enable, bool up) override;
 
 private:
   int8_t spiSCK;

--- a/src/hal/ESP-IDF/EspHal.h
+++ b/src/hal/ESP-IDF/EspHal.h
@@ -18,18 +18,6 @@
 #include "sdkconfig.h"
 #include <cinttypes> // For PRIu32
 
-// Arduino-style macros for RadioLib compatibility
-#ifndef LOW
-#define LOW (0x0)
-#endif
-#ifndef HIGH
-#define HIGH (0x1)
-#endif
-#define INPUT (GPIO_MODE_INPUT)
-#define OUTPUT (GPIO_MODE_OUTPUT)
-#define RISING (GPIO_INTR_POSEDGE)
-#define FALLING (GPIO_INTR_NEGEDGE)
-
 // These are left undefined by the generic build; define them for the ESP-IDF HAL
 #if !defined(RADIOLIB_ESP32)
 #define RADIOLIB_ESP32
@@ -57,7 +45,8 @@ public:
    */
   EspHal(int8_t sck, int8_t miso, int8_t mosi,
          spi_host_device_t host = SPI2_HOST, uint32_t clockHz = 2000000)
-      : RadioLibHal(INPUT, OUTPUT, LOW, HIGH, RISING, FALLING), spiSCK(sck),
+      : RadioLibHal(GPIO_MODE_INPUT, GPIO_MODE_OUTPUT, 0, 1,
+                    GPIO_INTR_POSEDGE, GPIO_INTR_NEGEDGE), spiSCK(sck),
         spiMISO(miso), spiMOSI(mosi), spiHost(host), spiClockHz(clockHz),
         spiDevice(nullptr), busInitialized(false), deviceAdded(false),
         halInitialized(false), tonePrevFreq(-1) {}
@@ -93,7 +82,7 @@ public:
 
     gpio_config_t conf = {
         .pin_bit_mask = (1ULL << pin),
-        .mode = (mode == OUTPUT) ? GPIO_MODE_OUTPUT : GPIO_MODE_INPUT,
+        .mode = (mode == GPIO_MODE_OUTPUT) ? GPIO_MODE_OUTPUT : GPIO_MODE_INPUT,
         .pull_up_en = GPIO_PULLUP_DISABLE,
         .pull_down_en = GPIO_PULLDOWN_DISABLE,
         .intr_type = GPIO_INTR_DISABLE,


### PR DESCRIPTION
These changes are AI augmented follow up to the EspHal merged in #1793, originating from late #1798.

These are mostly polishing and streamlining changes, to follow the formats from other HALs. File split + reorderng might be too much, but I still decided to go for it. CI is a real value.

- Include guard `RADIOLIB_ESP_IDF_HAL` to `_RADIOLIB_ESP_IDF_HAL_H` to match the leading-underscore convention used by `Hal.h` and `ArduinoHal.h`.
- Drop file-scope `LOW`/`HIGH`/`INPUT`/`OUTPUT`/`RISING`/`FALLING` macros. They were defined as aliases for the IDF gpio enums but, because `EspHal.h` is reachable from `RadioLib.h` on ESP-IDF builds, the names leaked into every TU and could silently substitute user identifiers with the same name. Pass the IDF enums directly to the `RadioLibHal` base constructor, the same way `PicoHal` does.
- Implement `yield()` with `taskYIELD()`. The default `RadioLibHal::yield()` is an empty no-op, so on ESP-IDF the long polling loops (LoRa receive, channel-activity-detection) never relinquish the CPU. With the default sdkconfig the task watchdog watches IDLE, which can be starved and reset the chip.
- Split `EspHal.h` into `.h` + `.cpp` to match the `ArduinoHal` / `PicoHal` convention. Keeps `driver/ledc.h`, `esp_log.h`, `freertos/*.h`, etc. out of every TU that includes `RadioLib.h` on ESP-IDF builds. Wires the new `.cpp` into the IDF component build and adds `esp_driver_ledc` to `REQUIRES`.
- Align method order with the `RadioLibHal` base class. Reorder so pure-virtual overrides come first (in `Hal.h` order), then the virtual-with-default overrides — matching how `ArduinoHal.h` is laid out. Pure reordering, no logic change.
- CI: extend the `esp-build` job to a matrix over `esp32`, `esp32s3` and `esp32c3`. The merged HAL claims portability across ESP32 variants; this proves it on every PR. `fail-fast: false` so one chip failing does not cancel the others.