### PR TITLE
[LR2021] Fix setRfSwitchTable to allow non-contiguous DIO pins

### DIFF
--- a/src/modules/LR2021/LR2021_config.cpp
+++ b/src/modules/LR2021/LR2021_config.cpp
@@ -220,7 +220,7 @@ void LR2021::setRfSwitchTable(const uint32_t (&pins)[Module::RFSWITCH_MAX_PINS],
     uint8_t pull = dioNum == 0 ? RADIOLIB_LR2021_DIO_SLEEP_PULL_UP : RADIOLIB_LR2021_DIO_SLEEP_PULL_AUTO;
     // enable RF control for this pin and set the modes in which it is active
     (void)this->setDioFunction(dioNum + 5, RADIOLIB_LR2021_DIO_FUNCTION_RF_SWITCH, pull);
-    (void)this->setDioRfSwitchConfig(dioNum + 5, dioConfigs[i]);
+    (void)this->setDioRfSwitchConfig(dioNum + 5, dioConfigs[dioNum]);
   }
 }
 


### PR DESCRIPTION
This one liner fixes a bug in LR2021::setRfSwitchTable that makes it impossible to use non-contiguous DIO pins in the table.

The RF switch mode bitmap is built using ``dioConfigs[dioNum]`` but it's applied using ``dioConfigs[i]``. For non-contiguous DIO assignments this causes the configuration to be read from the wrong dioConfigs[] entries, resulting in incorrect (zeroed) RF switch configuration being applied to the DIO pins which are after the gap.

For example if you want to use an RF switch table with DIO5,6,9,10,11 (skipping DIO7 and 8) then the config for DIO9,10,11 would not be applied correctly.

https://github.com/jgromes/RadioLib/blob/217f8cf4bd8f7bc803ba5e9f6db0235fa37f0f9b/src/modules/LR2021/LR2021_config.cpp#L211-L223

Tested and confimed it works.