### PR TITLE
Add support for FLRC in getRSSI on LR2021

### DIFF
--- a/src/modules/LR2021/LR2021.cpp
+++ b/src/modules/LR2021/LR2021.cpp
@@ -1162,6 +1162,8 @@ float LR2021::getRSSI(bool packet, bool skipReceive) {
     state = this->getGfskPacketStatus(NULL, &rssi, NULL, NULL, NULL, NULL);
   } else if(modem == RADIOLIB_LR2021_PACKET_TYPE_OOK) {
     state = this->getOokPacketStatus(NULL, NULL, &rssi, NULL, NULL, NULL);
+  } else if (modem == RADIOLIB_LR2021_PACKET_TYPE_FLRC) {
+    state = this->getFlrcPacketStatus(NULL, &rssi, NULL, NULL);
   } else {
     return(0);
   }


### PR DESCRIPTION
This pull request adds support for FLRC modulation in the getRSSI() function on the LR2021.
The getFlrcPacketStatus() function already exists in `LR2021_cmds_flrc.cpp` so this change simply adds a call if the packet type is FLRC.