### PR TITLE
[LR2021] a fix for reply buffer offset in readRegMem32()

### DIFF
--- a/src/modules/LR2021/LR2021_cmds_chip_control.cpp
+++ b/src/modules/LR2021/LR2021_cmds_chip_control.cpp
@@ -62,7 +62,7 @@ int16_t LR2021::readRegMem32(uint32_t addr, uint32_t* data, size_t len) {
   // convert endians
   if(data && (state == RADIOLIB_ERR_NONE)) {
     for(size_t i = 0; i < len; i++) {
-      data[i] = ((uint32_t)rplBuff[2 + i*sizeof(uint32_t)] << 24) | ((uint32_t)rplBuff[3 + i*sizeof(uint32_t)] << 16) | ((uint32_t)rplBuff[4 + i*sizeof(uint32_t)] << 8) | (uint32_t)rplBuff[5 + i*sizeof(uint32_t)];
+      data[i] = ((uint32_t)rplBuff[i*sizeof(uint32_t)] << 24) | ((uint32_t)rplBuff[1 + i*sizeof(uint32_t)] << 16) | ((uint32_t)rplBuff[2 + i*sizeof(uint32_t)] << 8) | (uint32_t)rplBuff[3 + i*sizeof(uint32_t)];
     }
   }
 


### PR DESCRIPTION
Current logic of endian conversion

```
  // convert endians
  if(data && (state == RADIOLIB_ERR_NONE)) {
    for(size_t i = 0; i < len; i++) {
      data[i] = ((uint32_t)rplBuff[2 + i*sizeof(uint32_t)] << 24) | ((uint32_t)rplBuff[3 + i*sizeof(uint32_t)] << 16) | ((uint32_t)rplBuff[4 + i*sizeof(uint32_t)] << 8) | (uint32_t)rplBuff[5 + i*sizeof(uint32_t)];
    }
  }
```

does not look like an accurate one. 
For instance, an LR2021  MAGIC PRAM value (  0x600DB002  ) gets mis-read as 0xB0025000

A test on actual LR2021 hardware gives that `rplBuff` **contains valid  SPI response starting from very first byte**.

```
LR2021 RFIC is detected.
MAGIC PRAM value = 0x600DB002
PRAM patch loaded: true
Post-update PRAM version:  0x313

```

Source code of LR2021 driver from Semtech confirms that statement as well:


```
void lr20xx_regmem_fill_out_buffer_from_raw_buffer( uint32_t* out_buffer, const uint8_t* raw_buffer,
                                                    uint8_t out_buffer_length )
{
    for( uint8_t out_index = 0; out_index < out_buffer_length; out_index++ )
    {
        const uint8_t* raw_buffer_local = &raw_buffer[out_index * 4];

        out_buffer[out_index] = ( ( uint32_t ) raw_buffer_local[0] << 24 ) +
                                ( ( uint32_t ) raw_buffer_local[1] << 16 ) + ( ( uint32_t ) raw_buffer_local[2] << 8 ) +
                                ( ( uint32_t ) raw_buffer_local[3] << 0 );
    }
}

lr20xx_status_t lr20xx_regmem_read_regmem32( const void* context, const uint32_t address, uint32_t* buffer,
                                             const uint8_t length )
{
    uint8_t cbuffer[LR20XX_REGMEM_READ_REGMEM32_CMD_LENGTH];

    if( length > LR20XX_REGMEM_MAX_WRITE_READ_WORDS )
    {
        return LR20XX_STATUS_ERROR;
    }

    lr20xx_regmem_fill_cbuffer_opcode_address_length( cbuffer, LR20XX_REGMEM_READ_REGMEM32_OC, address, length );

    lr20xx_status_t status =
        ( lr20xx_status_t ) lr20xx_hal_read( context, cbuffer, LR20XX_REGMEM_READ_REGMEM32_CMD_LENGTH,
                                             ( uint8_t* ) buffer, ( uint16_t )( length * sizeof( uint32_t ) ) );

    if( status == LR20XX_STATUS_OK )
    {
        lr20xx_regmem_fill_out_buffer_from_raw_buffer( buffer, ( const uint8_t* ) buffer, length );
    }

    return status;
}

lr20xx_status_t lr20xx_patch_get_version( const void* context, lr20xx_patch_version_t* pram_version )
{
    // 1. Read the magic word register
    uint32_t              magic_word_read = 0;
    const lr20xx_status_t magic_word_read_status =
        lr20xx_regmem_read_regmem32( context, LR20XX_PATCH_MAGIC_WORD_ADDRESS, &magic_word_read, 1 );
    if( magic_word_read_status == LR20XX_STATUS_OK )
    {
        // 2. If magic word register content match expectation, a PRAM is loaded
        if( magic_word_read == LR20XX_PATCH_MAGIC_WORD_EXPECTED )
        {
            // 3. Read the PRAM type and version register
            uint32_t              pram_type_version_raw = 0;
            const lr20xx_status_t pram_type_version_read_status =
                lr20xx_regmem_read_regmem32( context, LR20XX_PATCH_TYPE_VERSION_ADDRESS, &pram_type_version_raw, 1 );
            if( pram_type_version_read_status == LR20XX_STATUS_OK )
            {
                pram_version->is_pram_loaded = true;
                pram_version->pram_type      = ( uint8_t ) ( pram_type_version_raw >> 16 );
                pram_version->pram_version   = ( uint8_t ) ( pram_type_version_raw >> 8 );
            }
            return pram_type_version_read_status;
        }
        else
        {
            pram_version->is_pram_loaded = false;
            pram_version->pram_type      = 0;
            pram_version->pram_version   = 0;
        }
    }
    return magic_word_read_status;
}
```
