### PR TITLE
[LoRaWAN] Rework package handling, add TS007

### DIFF
--- a/src/protocols/LoRaWAN/LoRaWANPacMan.cpp
+++ b/src/protocols/LoRaWAN/LoRaWANPacMan.cpp
@@ -6,49 +6,46 @@
 #include <string.h>
 
 // LoRaWANPackage implementation
-LoRaWANPackage::LoRaWANPackage(uint8_t ts, LoRaWANPackageManager* pacMan, LoRaWANNode* node, GetSecondsCb_t secondsCb)
-  : packageIdentifier(ts), lenUp(0), pacMan(pacMan), lorawanNode(node), getSeconds_cb(secondsCb) {
+LoRaWANPackage::LoRaWANPackage(uint8_t ts, LoRaWANPackageManager* pacMan, RadioLibHal* hal, LoRaWANNode* node, GetSecondsCb_t secondsCb)
+  : packageIdentifier(ts), pacMan(pacMan), hal(hal), lorawanNode(node), getSeconds_cb(secondsCb) {
   this->packageVersion = 0;
-  memset(this->dataUp, 0, sizeof(this->dataUp));
 }
 
-size_t LoRaWANPackage::processData(const uint8_t* data, size_t len, LoRaWANEvent_t* event) {
-  // Default implementation: assume the provided buffer is entirely consumed.
-  // Derived classes should override and return actual bytes consumed.
-  (void)data;
+size_t LoRaWANPackage::processData(const uint8_t* dataIn, size_t lenIn, uint8_t* dataOut, size_t* lenOut, LoRaWANEvent_t* event) {
+  // Default implementation: consume nothing and produce no answer.
+  // Derived classes override and return actual bytes consumed.
+  (void)dataIn;
+  (void)lenIn;
+  (void)dataOut;
   (void)event;
-  return(len);
+  *lenOut = 0;
+  return(0);
 }
 
-void LoRaWANPackage::getUplinkData(uint8_t* dataOut, size_t* lenOut) {
-  if(this->lenUp > 0) {
-    memcpy(dataOut, this->dataUp, this->lenUp);
-    *lenOut = (uint8_t)this->lenUp;
-    this->lenUp = 0;
-  } else {
-    *lenOut = 0;
-  }
+bool LoRaWANPackage::handleTask(RadioLibTime_t* tNext, bool* uplinkDue) {
+  // base package has no scheduled work
+  (void)tNext;
+  *uplinkDue = false;
+  return(false);
 }
 
-LoRaWANTaskInfo LoRaWANPackage::hasTask() {
-  LoRaWANTaskInfo task;
-  task.type = RADIOLIB_LORAWAN_TASK_NONE;
-  task.time = 0;
-
-  if(this->lenUp > 0) {
-    task.type = RADIOLIB_LORAWAN_TASK_UPLINK;
-    task.time = 0;
-  }
-
-  return(task);
+size_t LoRaWANPackage::buildUplink(uint8_t* dataOut) {
+  // base package has no uplink
+  (void)dataOut;
+  return(0);
 }
 
-void LoRaWANPackage::doAction() {
-  // default: no action
-}
+// #if defined(RADIOLIB_BUILD_ARDUINO)
+// // LoRaWANPackageManager implementation
+// LoRaWANPackageManager::LoRaWANPackageManager(LoRaWANNode* node, GetSecondsCb_t secondsCb) {
+//   RadioLibHal* hal = new ArduinoHal();
+
+//   return(LoRaWANPackageManager(hal, node, secondsCb));
+// }
+// #endif
 
 // LoRaWANPackageManager implementation
-LoRaWANPackageManager::LoRaWANPackageManager(LoRaWANNode* node, GetSecondsCb_t secondsCb) {
+LoRaWANPackageManager::LoRaWANPackageManager(RadioLibHal* hal, LoRaWANNode* node, GetSecondsCb_t secondsCb) {
   // initialize all packages to NULL and disabled
   for(uint8_t i = 0; i < RADIOLIB_LORAWAN_NUM_PACKAGES; i++) {
     this->packages[i] = NULL;
@@ -57,8 +54,27 @@ LoRaWANPackageManager::LoRaWANPackageManager(LoRaWANNode* node, GetSecondsCb_t s
   }
 
   // store node and callback reference
+  this->hal = hal;
   this->lorawanNode = node;
   this->getSecondsCb = secondsCb;
+
+  // if the user does not provide their own AES-128, use the software one
+  #if !RADIOLIB_CUSTOM_AES128
+  static RadioLibSoftwareAES128 RadioLibAES128Instance;
+  this->hal->aes128 = &RadioLibAES128Instance;
+  #endif
+
+  // Initialize the staging buffer, persistent TS007 buffer and transmission state
+  this->ansBufferLen = 0;
+  this->ansFPort = 0;
+  this->ts007BufferLen = 0;
+  this->commandToken = 0;
+  this->managerPending = false;
+  this->pendingBuildPackage = -1;
+  this->txCursor = 0;
+  this->txStop = 0;
+  this->txForceFrag = false;
+  this->txError = false;
 }
 
 int16_t LoRaWANPackageManager::enableTS003(uint8_t fPort, SetSecondsCb_t setSecondsFunc) {
@@ -88,8 +104,24 @@ int16_t LoRaWANPackageManager::enableTS003(uint8_t fPort, SetSecondsCb_t setSeco
   return(RADIOLIB_ERR_NONE);
 }
 
+int16_t LoRaWANPackageManager::enableTS007() {
+  // Check if node is not activated
+  if(this->lorawanNode == NULL || this->lorawanNode->isActivated()) {
+    return RADIOLIB_ERR_NETWORK_NOT_JOINED;
+  }
 
-int16_t LoRaWANPackageManager::enableTS009(PhysicalLayer* radio, DelaySecondsCb_t delayCb, UplinkIntervalCb_t intervalCb, RebootCb_t rebootCb) {
+  // TS007 is a manager-level package, not directly instantiated
+  // Just enable it in the manager
+  this->packagePorts[RADIOLIB_LORAWAN_PACKAGE_TS007] = RADIOLIB_LORAWAN_FPORT_TS007;
+  this->enabledPackages[RADIOLIB_LORAWAN_PACKAGE_TS007] = true;
+
+  // register FPort 225 so that multi-package downlinks are not blocked
+  this->lorawanNode->addAppPackage(RADIOLIB_LORAWAN_FPORT_TS007);
+
+  return RADIOLIB_ERR_NONE;
+}
+
+int16_t LoRaWANPackageManager::enableTS009(PhysicalLayer* radio, DelaySecondsCb_t delayCb, UplinkIntervalCb_t intervalCb, ConfirmedCb_t confirmedCb, RebootCb_t rebootCb) {
   // check if node is not activated
   if(this->lorawanNode == NULL || this->lorawanNode->isActivated()) {
     return(RADIOLIB_ERR_NETWORK_NOT_JOINED);
@@ -100,7 +132,7 @@ int16_t LoRaWANPackageManager::enableTS009(PhysicalLayer* radio, DelaySecondsCb_
 
   // create package if not already created
   if(this->packages[RADIOLIB_LORAWAN_PACKAGE_TS009] == NULL) {
-    this->packages[RADIOLIB_LORAWAN_PACKAGE_TS009] = new LoRaWANPackageTS009(this, this->lorawanNode, this->getSecondsCb);
+    this->packages[RADIOLIB_LORAWAN_PACKAGE_TS009] = new LoRaWANPackageTS009(this, this->hal, this->lorawanNode, this->getSecondsCb);
     this->packagePorts[RADIOLIB_LORAWAN_PACKAGE_TS009] = RADIOLIB_LORAWAN_FPORT_TS009;
   }
 
@@ -109,6 +141,7 @@ int16_t LoRaWANPackageManager::enableTS009(PhysicalLayer* radio, DelaySecondsCb_
   ts009->setPhysicalLayer(radio);
   ts009->setDelaySecondsCallback(delayCb);
   ts009->setUplinkIntervalCallback(intervalCb);
+  ts009->setConfirmedCallback(confirmedCb);
   ts009->setRebootCallback(rebootCb);
 
   // enable the package
@@ -130,25 +163,17 @@ void LoRaWANPackageManager::requestAppTime() {
   ts003->requestAppTime();
 }
 
-bool LoRaWANPackageManager::getConfirmed() {
-  LoRaWANPackageTS009* ts009 = static_cast<LoRaWANPackageTS009*>(this->packages[RADIOLIB_LORAWAN_PACKAGE_TS009]);
-  if(ts009 == NULL) {
-    return(false);
-  }
-  return(ts009->getConfirmed());
-}
-
 int16_t LoRaWANPackageManager::processDownlink(const uint8_t* data, size_t len, LoRaWANEvent_t* eventDown) {
   if(data == NULL) {
     return(RADIOLIB_ERR_NULL_POINTER);
   }
 
   // If the downlink arrived on a package-specific FPort (not the package
-  // manager's TS007 FPort), forward the entire payload to that package.
+  // manager's TS007 FPort), dispatch its commands to the package on that FPort.
   if(eventDown->fPort != RADIOLIB_LORAWAN_FPORT_TS007) {
     // Find package registered on this FPort
     for(uint8_t i = 0; i < RADIOLIB_LORAWAN_NUM_PACKAGES; i++) {
-      if(!this->enabledPackages[i]) { 
+      if(!this->enabledPackages[i]) {
         continue;
       }
       if(this->packagePorts[i] == eventDown->fPort) {
@@ -158,54 +183,234 @@ int16_t LoRaWANPackageManager::processDownlink(const uint8_t* data, size_t len, 
           return(RADIOLIB_ERR_NONE);
         }
         RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Routing %d bytes on FPort %d to package %d", len, eventDown->fPort, i);
-        // Forward entire payload to package; package returns bytes consumed
-        size_t consumed = pkg->processData(data, len, eventDown);
-        if(consumed == 0) {
-          RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Package on FPort %d consumed 0 bytes", eventDown->fPort);
+
+        // Drive the package command by command, collecting answers into the single
+        // manager answer buffer. The package processes one command per call and
+        // returns how many bytes it consumed.
+        size_t pos = 0;
+        size_t outLen = 0;
+        while(pos < len && outLen < sizeof(this->ansBuffer)) {
+          size_t aLen = 0;
+          size_t consumed = pkg->processData(&data[pos], len - pos, &this->ansBuffer[outLen], &aLen, eventDown);
+          if(consumed == 0) {
+            break;
+          }
+          pos += consumed;
+          outLen += aLen;
         }
-        // Package-specific answers remain in package buffer and will be
-        // exposed via hasTask()/getUplinkData(). Nothing more to do here.
+
+        if(outLen > 0) {
+          this->ansBufferLen = outLen;
+          this->ansFPort = eventDown->fPort;
+          this->txError = false;
+          this->txForceFrag = false;
+          this->txCursor = 0;
+          this->txStop = outLen - 1;
+          this->pendingBuildPackage = -1;
+          this->managerPending = true;
+        }
         return(RADIOLIB_ERR_NONE);
       }
     }
 
     // No package matched this FPort; nothing to do.
     RADIOLIB_DEBUG_PROTOCOL_PRINTLN("No package matched FPort %d, ignoring payload", eventDown->fPort);
+    return(RADIOLIB_ERR_NONE);
   }
 
+  // This is a multi-package access downlink on FPort 225 (TS007 section 3.1).
+  // These messages SHALL NOT be sent via multicast; drop them silently if they are.
+  if(eventDown->multicast) {
+    RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Multi-package downlink received on multicast, dropping");
+    return(RADIOLIB_ERR_NONE);
+  }
+
+  if(!this->enabledPackages[RADIOLIB_LORAWAN_PACKAGE_TS007]) {
+    RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Received FPort 225 downlink but TS007 is disabled");
+    return(RADIOLIB_ERR_NONE);
+  }
+
+  if(len == 0) {
+    return(RADIOLIB_ERR_NONE);
+  }
+
+  // A downlink that only contains a MultiPackBufferReq carries no Command Token and
+  // must be the single command (TS007 section 4.4). Package 0 needs no PackageID
+  // prefix, so such a downlink starts directly with CID 0x02.
+  if(data[0] == RADIOLIB_LORAWAN_TS007_CID_MULTI_PACK_BUFFER) {
+    if(len != 3) {
+      RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Received MultiPackBufferReq but other payload is present");
+      return(RADIOLIB_ERR_NONE);
+    }
+    uint8_t startByte = data[1];
+    uint8_t stopByte  = data[2];
+    RADIOLIB_DEBUG_PROTOCOL_PRINTLN("MultiPackBufferReq start=%d stop=%d", startByte, stopByte);
+    this->handleMultiPackBufferReq(startByte, stopByte);
+    return(RADIOLIB_ERR_NONE);
+  }
+
+  // Normal command set: the last byte is the Command Token; the rest is the body.
+  uint8_t token = data[len - 1];
+  size_t bodyLen = len - 1;
+
+  // Build the ANS buffer (answers only, no token) into the persistent TS007 buffer.
+  // Dispatch one command at a time, switching packages on a PackageID field. Whenever
+  // a request command is prefixed with a PackageID, that PackageID is also copied into
+  // the answer (once per run of consecutive same-package commands).
+  size_t outPos = 0;
+  size_t pos = 0;
+  uint8_t currentPkg = 0;       // first command belongs to package 0 unless prefixed
+  int16_t pkgPrefixByte = -1;   // PackageID byte to copy into the answer, if any
+
+  while(pos < bodyLen && outPos < sizeof(this->ts007Buffer)) {
+    // A PackageID field (bit 7 set) selects the package for the following run
+    if(data[pos] & RADIOLIB_LORAWAN_TS007_PACKAGE_ID_FLAG) {
+      pkgPrefixByte = data[pos];
+      currentPkg = data[pos] & ~RADIOLIB_LORAWAN_TS007_PACKAGE_ID_FLAG;
+      pos += 1;
+      if(pos >= bodyLen) {
+        break;
+      }
+    }
+
+    // Tentatively write the PackageID prefix; roll back if the command has no answer
+    size_t runStart = outPos;
+    bool wrotePrefix = false;
+    if(pkgPrefixByte >= 0) {
+      this->ts007Buffer[outPos++] = (uint8_t)pkgPrefixByte;
+      wrotePrefix = true;
+    }
+
+    // Dispatch a single command to the current package
+    size_t aLen = 0;
+    size_t consumed = 0;
+    if(currentPkg == RADIOLIB_LORAWAN_PACKAGE_TS007) {
+      consumed = this->processPackageManagerData(&data[pos], bodyLen - pos, &this->ts007Buffer[outPos], &aLen);
+
+    } else if(currentPkg < RADIOLIB_LORAWAN_NUM_PACKAGES &&
+              this->enabledPackages[currentPkg] && this->packages[currentPkg] != NULL) {
+      consumed = this->packages[currentPkg]->processData(&data[pos], bodyLen - pos, &this->ts007Buffer[outPos], &aLen, eventDown);
+
+    } else {
+      // Unknown or disabled package: we cannot know its command length, so stop.
+      RADIOLIB_DEBUG_PROTOCOL_PRINTLN("TS007 unknown/disabled package %d, stopping", currentPkg);
+      outPos = runStart;
+      break;
+    }
+
+    if(consumed == 0) {
+      // Nothing consumed: avoid an infinite loop
+      RADIOLIB_DEBUG_PROTOCOL_PRINTLN("TS007 package %d consumed 0 bytes, stopping", currentPkg);
+      outPos = runStart;
+      break;
+    }
+    pos += consumed;
+
+    if(aLen > 0) {
+      outPos += aLen;
+      pkgPrefixByte = -1;     // PackageID already emitted for this run
+    } else if(wrotePrefix) {
+      outPos = runStart;      // no answer: drop the dangling prefix, keep it for next cmd
+    }
+  }
+
+  // The TS007 buffer is sized to the maximum (128 bytes); store the answers and token
+  this->ts007BufferLen = outPos;
+  this->ansFPort = RADIOLIB_LORAWAN_FPORT_TS007;
+  this->commandToken = token;
+
+  // Schedule a proactive uplink of the full buffer; getUplinkData() decides at send
+  // time whether it fits in one frame or must be fragmented.
+  this->txError = false;
+  this->txForceFrag = false;
+  this->txCursor = 0;
+  this->txStop = (this->ts007BufferLen > 0) ? (this->ts007BufferLen - 1) : 0;
+  this->pendingBuildPackage = -1;
+  this->managerPending = true;
+
+  RADIOLIB_DEBUG_PROTOCOL_PRINTLN("TS007 built ANS buffer of %d bytes, token %d",
+                                  this->ts007BufferLen, this->commandToken);
   return(RADIOLIB_ERR_NONE);
 }
 
-LoRaWANTaskInfo LoRaWANPackageManager::hasTask() {
-  LoRaWANTaskInfo chosen = {
-    .type = RADIOLIB_LORAWAN_TASK_NONE,
-    .time = 0xFFFFFFFF
-  };
+void LoRaWANPackageManager::handleMultiPackBufferReq(uint8_t startByte, uint8_t stopByte) {
+  // Invalid request: no stored buffer, StartByte out of range, or StopByte < StartByte.
+  // Respond with a MultiPackBufferFrag carrying Error=0xFF (TS007 section 4.4).
+  this->ansFPort = RADIOLIB_LORAWAN_FPORT_TS007;
+  this->pendingBuildPackage = -1;
+  if(this->ts007BufferLen == 0 || startByte > this->ts007BufferLen - 1 || stopByte < startByte) {
+    this->txError = true;
+    this->managerPending = true;
+    RADIOLIB_DEBUG_PROTOCOL_PRINTLN("TS007 MultiPackBufferReq invalid, queueing error");
+    return;
+  }
 
+  // Valid request: retransmit ts007Buffer[startByte .. min(stopByte, len-1)] as fragments.
+  this->txError = false;
+  this->txForceFrag = true;
+  this->txCursor = startByte;
+  this->txStop = (stopByte > this->ts007BufferLen - 1) ? (this->ts007BufferLen - 1) : stopByte - 1; // TODO LCTT bug!
+  this->managerPending = true;
+}
+
+bool LoRaWANPackageManager::handleTask(RadioLibTime_t* tNext) {
+  // a staged uplink (TS007 response/fragment, dedicated-FPort answer, or scheduled
+  // package uplink) is due now
+  RadioLibTime_t tNow = this->getSecondsCb();
+
+  if(this->managerPending) {
+    *tNext = tNow + this->lorawanNode->timeUntilUplink(true);
+    return(true);
+  }
+
+  bool found = false;
+  RadioLibTime_t earliest = 0xFFFFFFFF;
+
+  // drive each package's scheduled task, letting it write any due uplink into the
+  // single manager answer buffer
   for(uint8_t i = 0; i < RADIOLIB_LORAWAN_NUM_PACKAGES; i++) {
     if(!this->enabledPackages[i] || this->packages[i] == NULL) {
       continue;
     }
 
-    LoRaWANTaskInfo task = this->packages[i]->hasTask();
-    if(task.type == RADIOLIB_LORAWAN_TASK_NONE) {
+    RadioLibTime_t t = 0;
+    bool uplinkDue = false;
+    if(!this->packages[i]->handleTask(&t, &uplinkDue)) {
       continue;
     }
 
-    // if the task is an action with time 0, return immediately
-    // do not take this shortcut for uplink tasks, as actions are instantaneous
-    // and the uplink can be transmitted right after
-    if(task.type == RADIOLIB_LORAWAN_TASK_ACTION && task.time == 0) {
-      return(task);
+    // an uplink is to be sent? apply dutycycle constraints
+    if(uplinkDue) {
+      t += this->lorawanNode->timeUntilUplink(true);
     }
 
-    // otherwise, track the earliest task across packages
-    if(task.time < chosen.time) {
-      chosen = task;
+    // an uplink is to be sent now? stage it and return. The payload bytes are not
+    // built here; they are produced by the package's buildUplink() at send time
+    // (getUplinkData) so time-sensitive data stays fresh despite any dutycycle delay.
+    if(t <= tNow && uplinkDue) {
+      this->ansFPort = this->packagePorts[i];
+      this->txError = false;
+      this->txForceFrag = false;
+      this->txCursor = 0;
+      this->pendingBuildPackage = i;
+      this->managerPending = true;
+      *tNext = tNow;
+      return(true);
+    }
+
+    // otherwise track the earliest task across packages
+    found = true;
+    if(t < earliest) {
+      earliest = t;
     }
   }
 
-  return(chosen);
+  if(found) {
+    *tNext = earliest;
+  } else {
+    *tNext = UINT32_MAX;
+  }
+  return(found);
 }
 
 bool LoRaWANPackageManager::getUplinkData(uint8_t* dataOut, size_t* lenOut, uint8_t* fPort) {
@@ -213,51 +418,155 @@ bool LoRaWANPackageManager::getUplinkData(uint8_t* dataOut, size_t* lenOut, uint
     return(false);
   }
 
-  RadioLibTime_t now = this->getSecondsCb();
-  
-  // find first package that reports an UPLINK task
-  for(uint8_t i = 0; i < RADIOLIB_LORAWAN_NUM_PACKAGES; i++) {
-    if(!this->enabledPackages[i] || this->packages[i] == NULL) {
-      continue;
-    }
-
-    LoRaWANTaskInfo task = this->packages[i]->hasTask();
-    if(task.type == RADIOLIB_LORAWAN_TASK_UPLINK) {
-      // only return uplink data if it's due (time <= now)
-      if(task.time <= now) {
-        this->packages[i]->getUplinkData(dataOut, lenOut);
-        *fPort = this->packagePorts[i];
-        return(*lenOut > 0);
-      }
-    }
-  }
-
-  *lenOut = 0;
-  return(false);
-}
-
-bool LoRaWANPackageManager::doAction() {
-  if(this->getSecondsCb == NULL) {
+  if(!this->managerPending) {
+    *lenOut = 0;
     return(false);
   }
-  RadioLibTime_t now = this->getSecondsCb();
 
-  for(uint8_t i = 0; i < RADIOLIB_LORAWAN_NUM_PACKAGES; i++) {
-    if(!this->enabledPackages[i] || this->packages[i] == NULL) {
-      continue;
+  *fPort = this->ansFPort;
+
+  // A plain (non multi-package) uplink is sent as-is on its package's FPort
+  if(this->ansFPort != RADIOLIB_LORAWAN_FPORT_TS007) {
+    // A scheduled package uplink is built now, at the moment of transmission, so
+    // time-sensitive data (e.g. the TS003 timestamp) is captured fresh.
+    if(this->pendingBuildPackage >= 0) {
+      *lenOut = this->packages[this->pendingBuildPackage]->buildUplink(dataOut);
+      this->pendingBuildPackage = -1;
+      this->managerPending = false;
+      return(*lenOut > 0);
     }
 
-    LoRaWANTaskInfo task = this->packages[i]->hasTask();
-    if(task.type == RADIOLIB_LORAWAN_TASK_ACTION) {
-      // if action is due now, execute it and return
-      if(task.time <= now) {
-        this->packages[i]->doAction();
-        return(true);
+    // Otherwise it is a prebuilt dedicated-FPort answer staged by processData
+    memcpy(dataOut, this->ansBuffer, this->ansBufferLen);
+    *lenOut = this->ansBufferLen;
+    this->managerPending = false;
+    return(true);
+  }
+
+  // TS007 multi-package uplink on FPort 225 (whole buffer, fragment, or error)
+
+  // Invalid MultiPackBufferReq: respond with MultiPackBufferFrag carrying Error=0xFF
+  if(this->txError) {
+    dataOut[0] = RADIOLIB_LORAWAN_TS007_CID_MULTI_PACK_BUFFER;
+    dataOut[1] = RADIOLIB_LORAWAN_TS007_ERROR;
+    *lenOut = 2;
+    this->txError = false;
+    this->managerPending = false;
+    return(true);
+  }
+
+  // Maximum applicative payload for the current data rate
+  size_t maxLen = this->lorawanNode->getMaxPayloadLen();
+
+  // Whole buffer: if it fits with the appended token, transmit it unmodified
+  if(!this->txForceFrag && this->txCursor == 0 && (this->ts007BufferLen + 1) <= maxLen) {
+    memcpy(dataOut, this->ts007Buffer, this->ts007BufferLen);
+    dataOut[this->ts007BufferLen] = this->commandToken;
+    *lenOut = this->ts007BufferLen + 1;
+    this->managerPending = false;
+    return(true);
+  }
+
+  // Otherwise fragment using MultiPackBufferFrag: [0x02][BaseByte][bytes][token]
+  // Each fragment carries up to (maxLen - 3) ANS bytes (CID + BaseByte + token).
+  size_t avail = (maxLen > 3) ? (maxLen - 3) : 1;
+  size_t remaining = (this->txStop >= this->txCursor) ? (this->txStop - this->txCursor + 1) : 0;
+  size_t chunk = (remaining < avail) ? remaining : avail;
+
+  dataOut[0] = RADIOLIB_LORAWAN_TS007_CID_MULTI_PACK_BUFFER;
+  dataOut[1] = (uint8_t)this->txCursor;
+  memcpy(&dataOut[2], &this->ts007Buffer[this->txCursor], chunk);
+  dataOut[2 + chunk] = this->commandToken;
+  *lenOut = chunk + 3;
+
+  this->txCursor += chunk;
+  if(this->txCursor > this->txStop) {
+    // all requested bytes sent; keep the ANS buffer for further retransmissions
+    this->managerPending = false;
+    this->txForceFrag = false;
+  }
+  return(true);
+}
+
+size_t LoRaWANPackageManager::processPackageManagerData(const uint8_t* dataDown, size_t lenDown, uint8_t* ansOut, size_t* ansLen) {
+  // Process a single TS007 Multi-Package Access package (PackageIdentifier 0) command:
+  //   0x00 PackageVersionReq -> PackageVersionAns
+  //   0x01 DevPackageReq     -> DevPackageAns
+  // 0x02 (MultiPackBufferReq) is handled separately as it must be the single command
+  // in a downlink, so it is treated as an unknown command here. The manager drives the
+  // command loop, so this processes only one command and returns the bytes consumed.
+
+  if(dataDown == NULL || ansOut == NULL || ansLen == NULL) {
+    return(0);
+  }
+
+  *ansLen = 0;
+  if(lenDown < 1) {
+    return(0);
+  }
+
+  size_t ansPos = 0;
+
+  switch(dataDown[0]) {
+    case(RADIOLIB_LORAWAN_TS007_CID_PKG_VERSION): {
+      // PackageVersionReq has no payload
+      ansOut[ansPos++] = RADIOLIB_LORAWAN_TS007_CID_PKG_VERSION;
+      ansOut[ansPos++] = RADIOLIB_LORAWAN_PACKAGE_TS007;              // PackageIdentifier (0)
+      ansOut[ansPos++] = RADIOLIB_LORAWAN_TS007_PACKAGE_VERSION_NUM;  // PackageVersion (1)
+      *ansLen = ansPos;
+
+      RADIOLIB_DEBUG_PROTOCOL_PRINTLN("TS007 PackageVersionAns: id=%d ver=%d",
+                                      RADIOLIB_LORAWAN_PACKAGE_TS007, RADIOLIB_LORAWAN_TS007_PACKAGE_VERSION_NUM);
+      return(1);
+
+    } break;
+
+    case(RADIOLIB_LORAWAN_TS007_CID_DEV_PACKAGE): {
+      // DevPackageReq has no payload
+
+      // DevPackageAns: [NbPackages][id, ver, port]* (TS007 section 4.2).
+      // NbPackages (low nibble) counts every package, including multi-package (TS007).
+      ansOut[ansPos++] = RADIOLIB_LORAWAN_TS007_CID_DEV_PACKAGE;
+
+      size_t nbPos = ansPos++;   // reserve the Nb Packages byte, fill in after counting
+      uint8_t total = 0;
+
+      // TS007 (multi-package access) itself is always present
+      ansOut[ansPos++] = RADIOLIB_LORAWAN_PACKAGE_TS007;
+      ansOut[ansPos++] = RADIOLIB_LORAWAN_TS007_PACKAGE_VERSION_NUM;
+      ansOut[ansPos++] = RADIOLIB_LORAWAN_FPORT_TS007;
+      total++;
+
+      // followed by each enabled package in identifier order
+      for(uint8_t i = 0; i < RADIOLIB_LORAWAN_NUM_PACKAGES; i++) {
+        if(i == RADIOLIB_LORAWAN_PACKAGE_TS007) {
+          continue;
+        }
+        if(this->enabledPackages[i] && this->packages[i] != NULL) {
+          ansOut[ansPos++] = i;
+          ansOut[ansPos++] = this->packages[i]->packageVersion;
+          ansOut[ansPos++] = this->packagePorts[i];
+          total++;
+        }
       }
+
+      ansOut[nbPos] = (total & 0x0F);
+      *ansLen = ansPos;
+
+      RADIOLIB_DEBUG_PROTOCOL_PRINTLN("TS007 DevPackageAns: %d packages", total);
+      return(1);
+
+    } break;
+
+    default: {
+      // Unknown command (or MultiPackBufferReq in an invalid position): stop here.
+      // The length of an unknown command is not derivable, so we cannot continue.
+      RADIOLIB_DEBUG_PROTOCOL_PRINTLN("TS007 unknown command 0x%02x, stopping", dataDown[0]);
+      return(0);
     }
   }
 
-  return(false);
+  return(0);
 }
 
 #endif

--- a/src/protocols/LoRaWAN/LoRaWANPacMan.cpp
+++ b/src/protocols/LoRaWAN/LoRaWANPacMan.cpp
@@ -90,7 +90,7 @@ int16_t LoRaWANPackageManager::enableTS003(uint8_t fPort, SetSecondsCb_t setSeco
 
   // create package if not already created
   if(this->packages[RADIOLIB_LORAWAN_PACKAGE_TS003] == NULL) {
-    this->packages[RADIOLIB_LORAWAN_PACKAGE_TS003] = new LoRaWANPackageTS003(this, this->lorawanNode, this->getSecondsCb);
+    this->packages[RADIOLIB_LORAWAN_PACKAGE_TS003] = new LoRaWANPackageTS003(this, this->hal, this->lorawanNode, this->getSecondsCb);
     this->packagePorts[RADIOLIB_LORAWAN_PACKAGE_TS003] = fPort;
   }
 

--- a/src/protocols/LoRaWAN/LoRaWANPacMan.h
+++ b/src/protocols/LoRaWAN/LoRaWANPacMan.h
@@ -66,10 +66,8 @@ class LoRaWANPackage {
 
     /*!
       \brief Execute any scheduled task that is due now and report when this package
-      next needs servicing. This performs scheduling decisions and side effects only;
-      it must NOT build uplink payload bytes nor advance transmit state. When an uplink
-      is due now it reports so via uplinkDue; the bytes are produced later by
-      buildUplink() at the actual moment of transmission.
+      next needs servicing. When an uplink is due now it reports so via uplinkDue; 
+      the bytes are produced later by buildUplink() at the actual moment of transmission.
       \param tNext Pointer that receives the time of the next task.
       \param uplinkDue Pointer set to true if an uplink is ready to be sent now.
       \returns true if the package has a pending or scheduled task, false otherwise
@@ -78,8 +76,7 @@ class LoRaWANPackage {
 
     /*!
       \brief Build the uplink that handleTask() reported as due, at the moment of
-      transmission, and advance the package's transmit schedule. Capturing time-
-      sensitive data (e.g. timestamps) here keeps it fresh despite dutycycle delays.
+      transmission, and advance the package's transmit schedule.
       \param dataOut Pointer to the manager's answer buffer (write uplink here)
       \returns Number of uplink bytes written (0 if nothing to send)
     */
@@ -187,9 +184,9 @@ class LoRaWANPackageManager {
 
     /*!
       \brief Execute any due tasks across all packages and report when the manager
-      next needs servicing. Returns at the first package reporting an uplink due now.
+      next needs servicing.
       \param tNext Pointer that receives the relative time (in seconds) until the
-      next task. Set to 0 if uplink data is ready to be sent now. It includes
+      next task. Returns 0 if uplink data is ready to be sent now. It includes
       dutycycle constraints if applicable.
       \returns true if any package has a pending or scheduled task, false otherwise
     */
@@ -203,19 +200,6 @@ class LoRaWANPackageManager {
       \returns true if data was fetched, false otherwise
     */
     bool getUplinkData(uint8_t* dataOut, size_t* lenOut, uint8_t* fPort);
-
-    /*!
-      \brief Process the TS007 multi-package access package's own commands
-      (PackageVersionReq, DevPackageReq). The MultiPackBufferReq command is handled
-      separately because it must be the single command in a downlink. Parsing stops
-      at the first PackageID field (bit 7 set) or unknown command.
-      \param dataDown Pointer to received command data (PackageID field already stripped)
-      \param lenDown Length of command data
-      \param ansOut Pointer to buffer for the answer bytes
-      \param ansLen Pointer to store answer length
-      \returns Number of bytes consumed from dataDown
-    */
-    size_t processPackageManagerData(const uint8_t* dataDown, size_t lenDown, uint8_t* ansOut, size_t* ansLen);
 
     bool isEnabledFPort(uint8_t fPort) {
       for(uint8_t i = 0; i < RADIOLIB_LORAWAN_NUM_PACKAGES; i++) {
@@ -233,6 +217,10 @@ class LoRaWANPackageManager {
     // Set up transmission of a MultiPackBufferReq answer (TS007 section 4.4).
     // Uses the persistent ANS buffer; sets the transmit cursor or the error flag.
     void handleMultiPackBufferReq(uint8_t startByte, uint8_t stopByte);
+
+    // Process the TS007 multi-package access package's own commands
+    // (PackageVersionReq, DevPackageReq).
+    size_t processPackageManagerData(const uint8_t* dataDown, size_t lenDown, uint8_t* ansOut, size_t* ansLen);
 
     RadioLibHal* hal;
     LoRaWANNode* lorawanNode;
@@ -252,7 +240,7 @@ class LoRaWANPackageManager {
 
     // Persistent TS007 ANS buffer (answers only, no Command Token). Kept in memory for
     // on-demand retransmission via MultiPackBufferReq until a new multi-package command
-    // set is received. Separate from ansBuffer so routine uplinks cannot clobber it.
+    // set is received. Separate from ansBuffer.
     uint8_t ts007Buffer[RADIOLIB_LORAWAN_TS007_ANS_BUFFER_SIZE];
     size_t ts007BufferLen;
     uint8_t commandToken;   // TS007 Command Token to append to FPort 225 uplinks

--- a/src/protocols/LoRaWAN/LoRaWANPacMan.h
+++ b/src/protocols/LoRaWAN/LoRaWANPacMan.h
@@ -24,28 +24,21 @@
 #define RADIOLIB_LORAWAN_FPORT_TS009                            (224)
 #define RADIOLIB_LORAWAN_FPORT_TS011                            (226)
 
+// TS007 Multi-Package Access package (PackageIdentifier 0) commands and constants
+#define RADIOLIB_LORAWAN_TS007_CID_PKG_VERSION                  (0x00)
+#define RADIOLIB_LORAWAN_TS007_CID_DEV_PACKAGE                  (0x01)
+#define RADIOLIB_LORAWAN_TS007_CID_MULTI_PACK_BUFFER            (0x02)
+#define RADIOLIB_LORAWAN_TS007_PACKAGE_VERSION_NUM              (1)
+#define RADIOLIB_LORAWAN_TS007_ERROR                            (0xFF)
+
+// A PackageID field has bit 7 set; CommandIDs are always < 128
+#define RADIOLIB_LORAWAN_TS007_PACKAGE_ID_FLAG                  (0x80)
+
+// Maximum size of the ANS buffer (TS007 section 3.1)
+#define RADIOLIB_LORAWAN_TS007_ANS_BUFFER_SIZE                  (128)
 
 // Forward-declare the manager so it can be friended by LoRaWANPackage
 class LoRaWANPackageManager;
-
-/*!
-  \enum LoRaWANTaskType_t
-  \brief Possible LoRaWAN task types.
-*/
-enum LoRaWANTaskType_t {
-  RADIOLIB_LORAWAN_TASK_NONE = 0,
-  RADIOLIB_LORAWAN_TASK_ACTION,
-  RADIOLIB_LORAWAN_TASK_UPLINK
-};
-
-/*!
-  \struct LoRaWANTaskInfo
-  \brief Structure displaying pending LoRaWAN task information.
-*/
-struct LoRaWANTaskInfo {
-  LoRaWANTaskType_t type;   // NONE / ACTION / UPLINK
-  RadioLibTime_t time;      // Time of the task (0 = immediate / no deadline)
-};
 
 /*!
   \class LoRaWANPackage
@@ -60,31 +53,37 @@ class LoRaWANPackage {
     LoRaWANPackage(const LoRaWANPackage& obj) = delete;
 
     /*!
-      \brief Process a sequence of package commands and return how many bytes were consumed
-      \param data Pointer to incoming data
-      \param len Length of incoming data
+      \brief Process a single package command, writing any answer into the buffer
+      provided by the package manager.
+      \param dataIn Pointer to incoming command data
+      \param lenIn Length of incoming data
+      \param dataOut Pointer to the manager's answer buffer (write answer here)
+      \param lenOut Pointer that receives the number of answer bytes written
       \param event Downlink event details
       \returns Number of bytes consumed
     */
-    virtual size_t processData(const uint8_t* data, size_t len, LoRaWANEvent_t* event);
+    virtual size_t processData(const uint8_t* dataIn, size_t lenIn, uint8_t* dataOut, size_t* lenOut, LoRaWANEvent_t* event);
 
     /*!
-      \brief Query the next scheduled task for this package
-      \returns `LoRaWANTaskInfo` containing task type and time
+      \brief Execute any scheduled task that is due now and report when this package
+      next needs servicing. This performs scheduling decisions and side effects only;
+      it must NOT build uplink payload bytes nor advance transmit state. When an uplink
+      is due now it reports so via uplinkDue; the bytes are produced later by
+      buildUplink() at the actual moment of transmission.
+      \param tNext Pointer that receives the time of the next task.
+      \param uplinkDue Pointer set to true if an uplink is ready to be sent now.
+      \returns true if the package has a pending or scheduled task, false otherwise
     */
-    virtual LoRaWANTaskInfo hasTask();
+    virtual bool handleTask(RadioLibTime_t* tNext, bool* uplinkDue);
 
     /*!
-      \brief Perform an ACTION task (if any). Default no-op.
+      \brief Build the uplink that handleTask() reported as due, at the moment of
+      transmission, and advance the package's transmit schedule. Capturing time-
+      sensitive data (e.g. timestamps) here keeps it fresh despite dutycycle delays.
+      \param dataOut Pointer to the manager's answer buffer (write uplink here)
+      \returns Number of uplink bytes written (0 if nothing to send)
     */
-    virtual void doAction();
-
-    /*!
-      \brief Get uplink data for UPLINK tasks. Returns internal buffer.
-      \param dataOut Pointer to uplink buffer
-      \param lenOut Pointer to uplink length
-    */
-    void getUplinkData(uint8_t* dataOut, size_t* lenOut);
+    virtual size_t buildUplink(uint8_t* dataOut);
 
     /*!
       \brief Get current time via the stored callback
@@ -96,25 +95,25 @@ class LoRaWANPackage {
       }
       return(0);
     }
-    
+
 #if !RADIOLIB_GODMODE
   protected:
 #endif
-    
+
     /*!
       \brief Default constructor.
       \param pacMan Pointer to the package manager for persistence handling
+      \param hal Pointer to RadioLib HAL
       \param node Pointer to the LoRaWAN node
       \param secondsCb Pointer to getSeconds() function for time handling
     */
-    LoRaWANPackage(uint8_t ts, LoRaWANPackageManager* pacMan, LoRaWANNode* node, GetSecondsCb_t secondsCb);
+    LoRaWANPackage(uint8_t ts, LoRaWANPackageManager* pacMan, RadioLibHal* hal, LoRaWANNode* node, GetSecondsCb_t secondsCb);
 
     uint8_t packageIdentifier;
     uint8_t packageVersion;
-    uint8_t dataUp[255];
-    size_t lenUp = 0;
 
     LoRaWANPackageManager* pacMan;
+    RadioLibHal* hal;
     LoRaWANNode* lorawanNode;
     GetSecondsCb_t getSeconds_cb;
 
@@ -133,14 +132,16 @@ class LoRaWANPackageManager {
     typedef void (*SetSecondsCb_t)(RadioLibTime_t seconds);
     typedef void (*DelaySecondsCb_t)(RadioLibTime_t seconds);
     typedef void (*UplinkIntervalCb_t)(RadioLibTime_t intervalSeconds);
+    typedef void (*ConfirmedCb_t)(bool confirmed);
     typedef void (*RebootCb_t)();
 
     /*!
       \brief Create a package manager
+      \param hal Pointer to RadioLib HAL
       \param node Pointer to the LoRaWAN node
       \param getSeconds Pointer to getSeconds() function for time handling
     */    
-    LoRaWANPackageManager(LoRaWANNode* node, GetSecondsCb_t secondsCb);
+    LoRaWANPackageManager(RadioLibHal* hal, LoRaWANNode* node, GetSecondsCb_t secondsCb);
 
     // Package enable methods
     /*!
@@ -151,30 +152,29 @@ class LoRaWANPackageManager {
     */
     int16_t enableTS003(uint8_t fPort, SetSecondsCb_t setSecondsFunc);
 
-    // Package enablement methods
     /*!
-      \brief Enable TS009 Certification Protocol package
-      \param radio Pointer to the PhysicalLayer radio instance for RF testing
-      \param delayCb Callback to delay for a number of seconds during RF testing
-      \param intervalCb Callback to set the uplink interval for the device
-      \param rebootCb Callback to perform a device reboot
+      \brief Enable TS007 Multi-package Access Control package
+      \returns Status code
+    */
+    int16_t enableTS007();
+
+    /*!
+      \brief Enable TS009 Certification Protocol package.
+      \param radio Pointer to the PhysicalLayer radio instance for RF testing.
+      \param delayCb Callback to delay for a number of seconds during RF testing.
+      \param intervalCb Callback to set the uplink interval for the device.
+      \param confirmedCb Callback to set whether subsequent uplinks should be confirmed.
+      \param rebootCb Callback to perform a device reboot.
       \returns \ref status_codes
     */
-    int16_t enableTS009(PhysicalLayer* radio, DelaySecondsCb_t delayCb, UplinkIntervalCb_t intervalCb, RebootCb_t rebootCb);
+    int16_t enableTS009(PhysicalLayer* radio, DelaySecondsCb_t delayCb, UplinkIntervalCb_t intervalCb, ConfirmedCb_t confirmedCb, RebootCb_t rebootCb);
 
     // TS003
     /*!
-      \brief Send an application time request
+      \brief Send an application time request.
       \returns \ref status_codes
     */
     void requestAppTime();
-    
-    // TS009
-    /*!
-      \brief Check whether subsequent uplinks should be confirmed
-      \returns true if uplinks should be confirmed, false otherwise
-    */
-    bool getConfirmed();
 
     /*!
       \brief Process a multi-package downlink payload (TS007 section 3.1).
@@ -186,10 +186,14 @@ class LoRaWANPackageManager {
     int16_t processDownlink(const uint8_t* data, size_t len, LoRaWANEvent_t* eventDown);
 
     /*!
-      \brief Query the next scheduled task across all packages and return the first
-      \returns LoRaWANTaskInfo struct with time and action fields
+      \brief Execute any due tasks across all packages and report when the manager
+      next needs servicing. Returns at the first package reporting an uplink due now.
+      \param tNext Pointer that receives the relative time (in seconds) until the
+      next task. Set to 0 if uplink data is ready to be sent now. It includes
+      dutycycle constraints if applicable.
+      \returns true if any package has a pending or scheduled task, false otherwise
     */
-    LoRaWANTaskInfo hasTask();
+    bool handleTask(RadioLibTime_t* tNext);
 
     /*!
       \brief Fetch uplink data from the first package reporting an UPLINK task
@@ -201,20 +205,17 @@ class LoRaWANPackageManager {
     bool getUplinkData(uint8_t* dataOut, size_t* lenOut, uint8_t* fPort);
 
     /*!
-      \brief Execute the first applicable ACTION task (calls package->doAction()).
-      \returns true if an action was performed, false otherwise
-    */
-    bool doAction();
-
-    /*!
-      \brief Process TS007 package management commands at the manager level
-      \param dataDown Pointer to received downlink data
-      \param lenDown Length of downlink data
-      \param ansOut Pointer to buffer for answer
+      \brief Process the TS007 multi-package access package's own commands
+      (PackageVersionReq, DevPackageReq). The MultiPackBufferReq command is handled
+      separately because it must be the single command in a downlink. Parsing stops
+      at the first PackageID field (bit 7 set) or unknown command.
+      \param dataDown Pointer to received command data (PackageID field already stripped)
+      \param lenDown Length of command data
+      \param ansOut Pointer to buffer for the answer bytes
       \param ansLen Pointer to store answer length
       \returns Number of bytes consumed from dataDown
     */
-    size_t processPackageManagerData(uint8_t* dataDown, size_t lenDown, uint8_t* ansOut, size_t* ansLen);
+    size_t processPackageManagerData(const uint8_t* dataDown, size_t lenDown, uint8_t* ansOut, size_t* ansLen);
 
     bool isEnabledFPort(uint8_t fPort) {
       for(uint8_t i = 0; i < RADIOLIB_LORAWAN_NUM_PACKAGES; i++) {
@@ -228,7 +229,12 @@ class LoRaWANPackageManager {
 #if !RADIOLIB_GODMODE
   protected:
 #endif
-    
+
+    // Set up transmission of a MultiPackBufferReq answer (TS007 section 4.4).
+    // Uses the persistent ANS buffer; sets the transmit cursor or the error flag.
+    void handleMultiPackBufferReq(uint8_t startByte, uint8_t stopByte);
+
+    RadioLibHal* hal;
     LoRaWANNode* lorawanNode;
     LoRaWANPackage* packages[RADIOLIB_LORAWAN_NUM_PACKAGES];
     uint8_t packagePorts[RADIOLIB_LORAWAN_NUM_PACKAGES];
@@ -236,7 +242,30 @@ class LoRaWANPackageManager {
 
     // Time handler functions
     GetSecondsCb_t getSecondsCb;
-    
+
+    // Staging buffer for a plain (non multi-package) uplink: a dedicated-FPort answer
+    // or a scheduled package uplink. Packages write here (via the dataOut buffer they
+    // are handed); it is overwritten on each newly staged uplink.
+    uint8_t ansBuffer[255];
+    size_t ansBufferLen;
+    uint8_t ansFPort;       // FPort on which the staged uplink will be sent (225 = TS007)
+
+    // Persistent TS007 ANS buffer (answers only, no Command Token). Kept in memory for
+    // on-demand retransmission via MultiPackBufferReq until a new multi-package command
+    // set is received. Separate from ansBuffer so routine uplinks cannot clobber it.
+    uint8_t ts007Buffer[RADIOLIB_LORAWAN_TS007_ANS_BUFFER_SIZE];
+    size_t ts007BufferLen;
+    uint8_t commandToken;   // TS007 Command Token to append to FPort 225 uplinks
+
+    // Transmission state for a pending uplink (TS007 fragments are sent over several
+    // calls; a plain package uplink is sent in one)
+    bool managerPending;    // a staged uplink is due now
+    int8_t pendingBuildPackage; // package index that builds its uplink at send time, or -1 = prebuilt buffer
+    size_t txCursor;        // next BaseByte to transmit (TS007 fragmentation)
+    size_t txStop;          // last TS007 ANS buffer index to transmit (inclusive)
+    bool txForceFrag;       // always wrap in MultiPackBufferFrag (Req response)
+    bool txError;           // next uplink is the [0x02][0xFF] error frame
+
 };
 
 #endif

--- a/src/protocols/LoRaWAN/LoRaWANPacMan.h
+++ b/src/protocols/LoRaWAN/LoRaWANPacMan.h
@@ -151,7 +151,7 @@ class LoRaWANPackageManager {
 
     /*!
       \brief Enable TS007 Multi-package Access Control package
-      \returns Status code
+      \returns \ref status_codes
     */
     int16_t enableTS007();
 

--- a/src/protocols/LoRaWAN/LoRaWANPackageTS003.cpp
+++ b/src/protocols/LoRaWAN/LoRaWANPackageTS003.cpp
@@ -2,9 +2,9 @@
 
 #include "LoRaWANPackageTS003.h"
 
-LoRaWANPackageTS003::LoRaWANPackageTS003(LoRaWANPackageManager* pacMan, LoRaWANNode* node, GetSecondsCb_t secondsCb)
-  : LoRaWANPackage(RADIOLIB_LORAWAN_PACKAGE_TS003, pacMan, node, secondsCb),
-    setSeconds(NULL), tokenReq(0), transmissions(0), periodicity(0), nextAppReqTime(0) {
+LoRaWANPackageTS003::LoRaWANPackageTS003(LoRaWANPackageManager* pacMan, RadioLibHal* hal, LoRaWANNode* node, GetSecondsCb_t secondsCb)
+  : LoRaWANPackage(RADIOLIB_LORAWAN_PACKAGE_TS003, pacMan, hal, node, secondsCb),
+    setSeconds(NULL), tokenReq(0), transmissions(0), periodicity(0), nextAppReqTime(0), forceReq(false) {
   this->packageVersion = 2;
 }
 
@@ -12,35 +12,35 @@ void LoRaWANPackageTS003::setSecondsCb(SetSecondsCb_t cb) {
   this->setSeconds = cb;
 }
 
-LoRaWANTaskInfo LoRaWANPackageTS003::hasTask() {
-  LoRaWANTaskInfo task;
-  task.type = RADIOLIB_LORAWAN_TASK_NONE;
-  task.time = 0;
+bool LoRaWANPackageTS003::handleTask(RadioLibTime_t* tNext, bool* uplinkDue) {
+  *uplinkDue = false;
 
   RadioLibTime_t nowSec = this->getSeconds();
 
-  // check for any pending uplinks
-  if(this->lenUp > 0) {
-    task.type = RADIOLIB_LORAWAN_TASK_UPLINK;
-    task.time = nowSec;
-    return(task);
-  }
-
   // check if we are doing AppTimeReq at all
   if(this->nextAppReqTime == 0) {
-    return(task);
+    return(false);
   }
 
-  task.type = RADIOLIB_LORAWAN_TASK_UPLINK;
-  task.time = this->nextAppReqTime;
-
-  // if next time is in the future, schedule for that time
+  // if next time is in the future, report its time
   if(this->nextAppReqTime > nowSec) {
-    return(task);
+    *tNext = this->nextAppReqTime;
+    return(true);
   }
 
-  // if next time is now or in the past, trigger AppTimeReq and schedule next one
-  this->requestAppTime();
+  // if next time is now or in the past, an AppTimeReq uplink is due now. The payload
+  // (and schedule advance) is produced by buildUplink() at the moment of transmission
+  // so the timestamp it carries is fresh, even if the send is delayed by dutycycle.
+  *uplinkDue = true;
+  *tNext = nowSec;
+  return(true);
+}
+
+size_t LoRaWANPackageTS003::buildUplink(uint8_t* dataOut) {
+  RadioLibTime_t nowSec = this->getSeconds();
+
+  // build the AppTimeReq with the current time, captured here at send time
+  size_t len = this->buildAppTimeReq(dataOut);
 
   // if there are forced retransmissions, ignore periodicity
   if(this->transmissions > 0) {
@@ -56,120 +56,126 @@ LoRaWANTaskInfo LoRaWANPackageTS003::hasTask() {
   else {
     this->nextAppReqTime = 0;
   }
-  
-  return(task);
+
+  return(len);
 }
 
-void LoRaWANPackageTS003::doAction() {
-  return;
-}
-
-size_t LoRaWANPackageTS003::processData(const uint8_t* dataDown, size_t lenDown, LoRaWANEvent_t* event) {
+size_t LoRaWANPackageTS003::processData(const uint8_t* dataDown, size_t lenDown, uint8_t* dataOut, size_t* lenOut, LoRaWANEvent_t* event) {
   (void)event;
 
-  size_t procLen = 0;
-  this->lenUp = 0;
+  *lenOut = 0;
+  if(lenDown < 1) {
+    return(0);
+  }
 
-  while (procLen < lenDown) {
-    RADIOLIB_DEBUG_PROTOCOL_PRINTLN("CID = %02x, len = %d", dataDown[procLen], lenDown - procLen - 1);
-  
-    switch(dataDown[procLen]) {
-      case(RADIOLIB_LORAWAN_TS003_PACKAGE_VERSION): {
-        // no downlink payload
-        procLen += 1;
+  RADIOLIB_DEBUG_PROTOCOL_PRINTLN("CID = %02x, len = %d", dataDown[0], lenDown - 1);
 
-        this->dataUp[this->lenUp + 0] = RADIOLIB_LORAWAN_TS003_PACKAGE_VERSION;
-        this->dataUp[this->lenUp + 1] = this->packageIdentifier;
-        this->dataUp[this->lenUp + 2] = this->packageVersion;
-        this->lenUp += 3;
-        
-        RADIOLIB_DEBUG_PROTOCOL_PRINTLN("PackageIdentifier: %d, PackageVersion: %d", 
-                                        this->dataUp[1], this->dataUp[2]);
-  
-      } break;
-      case(RADIOLIB_LORAWAN_TS003_APP_TIME): {
-        uint8_t tokenAns = dataDown[procLen + 5] & 0x0F;
-        if(tokenAns != this->tokenReq) {
-          procLen += 6;         // skip payload
-          break;
-        }
-        this->tokenReq += 1;
-        this->tokenReq %= 16;
-        uint32_t uCorrection = 0;
-        uCorrection |= (uint32_t)dataDown[procLen + 1];
-        uCorrection |= (uint32_t)dataDown[procLen + 2] <<  8;
-        uCorrection |= (uint32_t)dataDown[procLen + 3] << 16;
-        uCorrection |= (uint32_t)dataDown[procLen + 4] << 24;
-        procLen += 6;
-        int32_t correction = (int32_t)uCorrection;
+  switch(dataDown[0]) {
+    case(RADIOLIB_LORAWAN_TS003_PACKAGE_VERSION): {
+      // no downlink payload
+      dataOut[0] = RADIOLIB_LORAWAN_TS003_PACKAGE_VERSION;
+      dataOut[1] = this->packageIdentifier;
+      dataOut[2] = this->packageVersion;
+      *lenOut = 3;
 
-        RADIOLIB_DEBUG_PROTOCOL_PRINTLN("TimeCorrection: %d, TokenAns: %d", correction, tokenAns);
+      RADIOLIB_DEBUG_PROTOCOL_PRINTLN("PackageIdentifier: %d, PackageVersion: %d",
+                                      dataOut[1], dataOut[2]);
+      return(1);
 
-        // apply time correction via callback
-        this->setSeconds(this->getSeconds() + correction);
+    } break;
+    case(RADIOLIB_LORAWAN_TS003_APP_TIME): {
+      uint8_t tokenAns = dataDown[5] & 0x0F;
+      if(tokenAns != this->tokenReq) {
+        return(6);            // skip payload
+      }
+      this->tokenReq += 1;
+      this->tokenReq %= 16;
+      uint32_t uCorrection = 0;
+      uCorrection |= (uint32_t)dataDown[1];
+      uCorrection |= (uint32_t)dataDown[2] <<  8;
+      uCorrection |= (uint32_t)dataDown[3] << 16;
+      uCorrection |= (uint32_t)dataDown[4] << 24;
+      int32_t correction = (int32_t)uCorrection;
 
-        // clear pending AppTimeReq uplink transmissions
-        this->transmissions = 0;
+      RADIOLIB_DEBUG_PROTOCOL_PRINTLN("TimeCorrection: %d, TokenAns: %d", correction, tokenAns);
 
-        // if correction is min/max value, trigger another AppTimeReq
-        if(uCorrection == (uint32_t)0x7FFFFFFF || uCorrection == (uint32_t)0x80000000) {
-          this->nextAppReqTime = this->getSeconds();
+      // apply time correction via callback
+      this->setSeconds(this->getSeconds() + correction);
 
-        // otherwise, schedule next AppTimeReq based on periodicity (if set)
-        } else if(this->periodicity) {
-          this->nextAppReqTime = this->getSeconds() + this->periodicity - 30 + (rand() % 60);
-        } else {
-          this->nextAppReqTime = 0;
-        }
-  
-      } break;
-      case(RADIOLIB_LORAWAN_TS003_APP_TIME_PERIODICITY): {
-        uint32_t period = dataDown[procLen + 1];
-        procLen += 2;
+      // clear pending AppTimeReq uplink transmissions
+      this->transmissions = 0;
 
-        this->dataUp[this->lenUp + 0] = RADIOLIB_LORAWAN_TS003_APP_TIME_PERIODICITY;
-        this->dataUp[this->lenUp + 1] = 0;
-        RadioLibTime_t now = this->getSeconds();
-        this->dataUp[this->lenUp + 2] = (uint8_t)((now >> 0)  & 0xFF);
-        this->dataUp[this->lenUp + 3] = (uint8_t)((now >> 8)  & 0xFF);
-        this->dataUp[this->lenUp + 4] = (uint8_t)((now >> 16) & 0xFF);
-        this->dataUp[this->lenUp + 5] = (uint8_t)((now >> 24) & 0xFF);
-        this->lenUp += 6;
+      // if correction is min/max value, trigger another AppTimeReq
+      if(uCorrection == (uint32_t)0x7FFFFFFF || uCorrection == (uint32_t)0x80000000) {
+        this->nextAppReqTime = this->getSeconds();
 
-        RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Period: %lu, Time: %lu", period, now);
-        this->periodicity = 128 << period;
+      // otherwise, schedule next AppTimeReq based on periodicity (if set)
+      } else if(this->periodicity) {
         this->nextAppReqTime = this->getSeconds() + this->periodicity - 30 + (rand() % 60);
-        
-      } break;
-      case(RADIOLIB_LORAWAN_TS003_FORCE_DEVICE_RESYNC): {
-        uint8_t trans = dataDown[procLen + 1] & 0x0F;
-        procLen += 2;
+      } else {
+        this->nextAppReqTime = 0;
+      }
+      return(6);
 
-        RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Forced transmissions: %d", trans);
-        if(trans > 0) {
-          this->nextAppReqTime = this->getSeconds();
-          trans--;
-        }
-        this->transmissions = trans;
+    } break;
+    case(RADIOLIB_LORAWAN_TS003_APP_TIME_PERIODICITY): {
+      uint32_t period = dataDown[1];
 
-      } break;
+      dataOut[0] = RADIOLIB_LORAWAN_TS003_APP_TIME_PERIODICITY;
+      dataOut[1] = 0;
+      RadioLibTime_t now = this->getSeconds();
+      dataOut[2] = (uint8_t)((now >> 0)  & 0xFF);
+      dataOut[3] = (uint8_t)((now >> 8)  & 0xFF);
+      dataOut[4] = (uint8_t)((now >> 16) & 0xFF);
+      dataOut[5] = (uint8_t)((now >> 24) & 0xFF);
+      *lenOut = 6;
+
+      RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Period: %lu, Time: %lu", period, now);
+      this->periodicity = 128 << period;
+      this->nextAppReqTime = this->getSeconds() + this->periodicity - 30 + (rand() % 60);
+      return(2);
+
+    } break;
+    case(RADIOLIB_LORAWAN_TS003_FORCE_DEVICE_RESYNC): {
+      uint8_t trans = dataDown[1] & 0x0F;
+
+      RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Forced transmissions: %d", trans);
+      if(trans > 0) {
+        this->nextAppReqTime = this->getSeconds();
+        trans--;
+      }
+      this->transmissions = trans;
+      return(2);
+
+    } break;
+    default: {
+      // unknown command: length is not derivable, consume nothing
+      RADIOLIB_DEBUG_PROTOCOL_PRINTLN("TS003 unknown command 0x%02x, stopping", dataDown[0]);
+      return(0);
     }
   }
 
-  return(procLen);
+  return(0);
 }
 
 int16_t LoRaWANPackageTS003::requestAppTime(bool force) {
-  this->dataUp[0] = RADIOLIB_LORAWAN_TS003_APP_TIME;
-  
-  RadioLibTime_t now = this->getSeconds();
-  this->dataUp[1] = (uint8_t)((now >> 0)  & 0xFF);
-  this->dataUp[2] = (uint8_t)((now >> 8)  & 0xFF);
-  this->dataUp[3] = (uint8_t)((now >> 16) & 0xFF);
-  this->dataUp[4] = (uint8_t)((now >> 24) & 0xFF);
-  this->dataUp[5] = (uint8_t)force << 4 | (this->tokenReq & 0x0F);
-  this->lenUp = 6;
+  // schedule an AppTimeReq; handleTask() reports it due and buildUplink() builds it
+  this->forceReq = force;
+  this->nextAppReqTime = this->getSeconds();
   return(RADIOLIB_ERR_NONE);
+}
+
+size_t LoRaWANPackageTS003::buildAppTimeReq(uint8_t* dataOut) {
+  dataOut[0] = RADIOLIB_LORAWAN_TS003_APP_TIME;
+
+  RadioLibTime_t now = this->getSeconds();
+  dataOut[1] = (uint8_t)((now >> 0)  & 0xFF);
+  dataOut[2] = (uint8_t)((now >> 8)  & 0xFF);
+  dataOut[3] = (uint8_t)((now >> 16) & 0xFF);
+  dataOut[4] = (uint8_t)((now >> 24) & 0xFF);
+  dataOut[5] = (uint8_t)this->forceReq << 4 | (this->tokenReq & 0x0F);
+  this->forceReq = false;
+  return(6);
 }
 
 #endif

--- a/src/protocols/LoRaWAN/LoRaWANPackageTS003.h
+++ b/src/protocols/LoRaWAN/LoRaWANPackageTS003.h
@@ -26,14 +26,19 @@ class LoRaWANPackageTS003 : public LoRaWANPackage {
     LoRaWANPackageTS003(const LoRaWANPackageTS003& obj) = delete;
 
     /*!
-      \brief Process downlink data for the TS003 application time package
-      \param dataDown Pointer to received downlink data
-      \param lenDown Length of downlink data
+      \brief Process a single TS003 command, writing any answer into the provided buffer
+      \param dataDown Pointer to received command data
+      \param lenDown Length of command data
+      \param dataOut Pointer to the manager's answer buffer
+      \param lenOut Pointer that receives the number of answer bytes written
+      \param event Pointer to downlink event data
+      \returns Number of bytes consumed
     */
-    size_t processData(const uint8_t* dataDown, size_t lenDown, LoRaWANEvent_t* event) override;
+    size_t processData(const uint8_t* dataDown, size_t lenDown, uint8_t* dataOut, size_t* lenOut, LoRaWANEvent_t* event) override;
 
     /*!
-      \brief Send an application time request
+      \brief Schedule an application time request to be sent at the next opportunity
+      \param force Require a response, even if the clock is already in sync
       \returns \ref status_codes
     */
     int16_t requestAppTime(bool force = false);
@@ -46,25 +51,35 @@ class LoRaWANPackageTS003 : public LoRaWANPackage {
     void setSecondsCb(SetSecondsCb_t setSecondsCb);
 
     /*!
-      \brief Find out what the next task is and when it occurs
-      \returns `LoRaWANTaskInfo` containing task type and time
+      \brief Report when the next AppTimeReq is due and whether one is due now.
+      Does not build the payload (see buildUplink).
+      \param tNext Pointer that receives the time of the next task
+      \param uplinkDue Pointer set to true if an AppTimeReq uplink is due now
+      \returns true if a task is pending or scheduled, false otherwise
     */
-    LoRaWANTaskInfo hasTask() override;
+    bool handleTask(RadioLibTime_t* tNext, bool* uplinkDue) override;
 
     /*!
-      \brief Perform an ACTION task (if any).
+      \brief Build the due AppTimeReq with the current time and advance the schedule.
+      Called at the moment of transmission so the timestamp stays fresh.
+      \param dataOut Pointer to the manager's answer buffer
+      \returns Number of uplink bytes written
     */
-    void doAction() override;
+    size_t buildUplink(uint8_t* dataOut) override;
 
 #if !RADIOLIB_GODMODE
   protected:
 #endif
+
+    // build an AppTimeReq into the provided buffer; returns the number of bytes written
+    size_t buildAppTimeReq(uint8_t* dataOut);
 
     SetSecondsCb_t setSeconds;      // callback to configure current GPS time in seconds since epoch
     uint8_t tokenReq;               // validation of AppTimeReq response
     uint8_t transmissions;          // maximum number of AppTimeReq (re)transmissions
     uint32_t periodicity;           // requested interval between AppTimeReq transmissions (s)
     RadioLibTime_t nextAppReqTime;  // next scheduled AppTimeReq transmission
+    bool forceReq;                  // set the force bit on the next AppTimeReq
 
 #if !RADIOLIB_GODMODE
   private:
@@ -76,8 +91,8 @@ class LoRaWANPackageTS003 : public LoRaWANPackage {
       \param node Pointer to the LoRaWAN node
       \param secondsCb Pointer to getSeconds() function
     */
-    LoRaWANPackageTS003(LoRaWANPackageManager* pacMan, LoRaWANNode* node, GetSecondsCb_t secondsCb);
-
+    LoRaWANPackageTS003(LoRaWANPackageManager* pacMan, RadioLibHal* hal, LoRaWANNode* node, GetSecondsCb_t secondsCb);
+    
     // allow LoRaWANPackageManager to access the private constructor
     friend LoRaWANPackageManager;
 };

--- a/src/protocols/LoRaWAN/LoRaWANPackageTS009.cpp
+++ b/src/protocols/LoRaWAN/LoRaWANPackageTS009.cpp
@@ -5,22 +5,25 @@
 #include "LoRaWANPackageTS009.h"
 #include <string.h>
 
-LoRaWANPackageTS009::LoRaWANPackageTS009(LoRaWANPackageManager* pacMan, LoRaWANNode* node, GetSecondsCb_t secondsCb)
-  : LoRaWANPackage(RADIOLIB_LORAWAN_PACKAGE_TS009, pacMan, node, secondsCb),
-    radioModule(NULL), delaySecondsCallback(NULL), uplinkIntervalCallback(NULL), rebootCallback(NULL) {
+LoRaWANPackageTS009::LoRaWANPackageTS009(LoRaWANPackageManager* pacMan, RadioLibHal* hal, LoRaWANNode* node, GetSecondsCb_t secondsCb)
+  : LoRaWANPackage(RADIOLIB_LORAWAN_PACKAGE_TS009, pacMan, hal, node, secondsCb),
+    radio(NULL), delaySecondsCallback(NULL), uplinkIntervalCallback(NULL), confirmedCallback(NULL), rebootCallback(NULL) {
   this->packageVersion = 1;
+
+  // retrieve whether the package is allowed to be enabled
+  this->lorawanNode->getPersistencePackage(RADIOLIB_LORAWAN_PERSISTENCE_TS009, &this->enabled);
+  if(!this->enabled) {
+    return;
+  }
 
   // default configuration for certification testing
   this->lorawanNode->setDatarate(5);
   this->lorawanNode->setADR(false);
   this->lorawanNode->setDutyCycle(true, 3600000);
-
-  // LCTT has terrible timing
-  this->lorawanNode->scanGuard = 150;
 }
 
 void LoRaWANPackageTS009::setPhysicalLayer(PhysicalLayer* radio) {
-  this->radioModule = radio;
+  this->radio = radio;
 }
 
 void LoRaWANPackageTS009::setDelaySecondsCallback(DelaySecondsCb_t delayCb) {
@@ -31,31 +34,32 @@ void LoRaWANPackageTS009::setUplinkIntervalCallback(UplinkIntervalCb_t intervalC
   this->uplinkIntervalCallback = intervalCb;
 }
 
+void LoRaWANPackageTS009::setConfirmedCallback(ConfirmedCb_t confirmedCb) {
+  this->confirmedCallback = confirmedCb;
+}
+
 void LoRaWANPackageTS009::setRebootCallback(RebootCb_t rebootCb) {
   this->rebootCallback = rebootCb;
 }
 
-bool LoRaWANPackageTS009::getConfirmed() {
-  return(this->confirmed);
-}
-
-size_t LoRaWANPackageTS009::processData(const uint8_t* dataDown, size_t lenDown, LoRaWANEvent_t* event) {
+size_t LoRaWANPackageTS009::processData(const uint8_t* dataDown, size_t lenDown, uint8_t* dataOut, size_t* lenOut, LoRaWANEvent_t* event) {
   (void)event;
-  if(lenDown == 0 || dataDown == NULL) {
+  *lenOut = 0;
+  if(!this->enabled || lenDown == 0 || dataDown == NULL) {
     return(0);
   }
 
-  RADIOLIB_DEBUG_PROTOCOL_PRINTLN("TS009 CID = 0x%02x, len = %d", dataDown[0], lenDown - 1);
+  RADIOLIB_DEBUG_PROTOCOL_PRINTLN("CID = 0x%02x, len = %d", dataDown[0], lenDown - 1);
 
-  this->lenUp = 0;
+  size_t len = 0;
 
   switch(dataDown[0]) {
     case(RADIOLIB_LORAWAN_TS009_PACKAGE_VERSION): {
-      this->lenUp = 3;
-      this->dataUp[1] = RADIOLIB_LORAWAN_PACKAGE_TS009;
-      this->dataUp[2] = 1;
+      len = 3;
+      dataOut[1] = RADIOLIB_LORAWAN_PACKAGE_TS009;
+      dataOut[2] = 1;
       RADIOLIB_DEBUG_PROTOCOL_PRINTLN("PackageIdentifier: %d, PackageVersion: %d", 
-                              this->dataUp[1], this->dataUp[2]);
+                                      dataOut[1], dataOut[2]);
     } break;
 
     case(RADIOLIB_LORAWAN_TS009_DUT_RESET): {
@@ -78,7 +82,7 @@ size_t LoRaWANPackageTS009::processData(const uint8_t* dataDown, size_t lenDown,
         uint8_t classType = dataDown[1];
         if(this->lorawanNode) {
           this->lorawanNode->setClass(classType);
-          RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Switching to class: %s", (classType == 0) ? "A" : (classType == 1 ? "B" : "C"));
+          RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Switching to Class %c", "ABC"[classType]);
         }
       }
     } break;
@@ -121,11 +125,15 @@ size_t LoRaWANPackageTS009::processData(const uint8_t* dataDown, size_t lenDown,
       if(lenDown > 1) {
         switch(dataDown[1]) {
           case 1:
-            this->confirmed = false;
+            if(this->confirmedCallback) {
+              this->confirmedCallback(false);
+            }
             RADIOLIB_DEBUG_PROTOCOL_PRINTLN("TX Frames: Unconfirmed");
             break;
           case 2:
-            this->confirmed = true;
+            if(this->confirmedCallback) {
+              this->confirmedCallback(true);
+            }
             RADIOLIB_DEBUG_PROTOCOL_PRINTLN("TX Frames: Confirmed");
             break;
           default:
@@ -137,23 +145,23 @@ size_t LoRaWANPackageTS009::processData(const uint8_t* dataDown, size_t lenDown,
     case(RADIOLIB_LORAWAN_TS009_ECHO_PAYLOAD): {
       if(lenDown > 1) {
         for(size_t i = 1; i < lenDown; i++) {
-          this->dataUp[i] = dataDown[i] + 1;
+          dataOut[i] = dataDown[i] + 1;
         }
         // clip to maximum payload size
-        this->lenUp = RADIOLIB_MIN(lenDown, this->lorawanNode->getMaxPayloadLen());
-        RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Echoing %d bytes with increment", this->lenUp - 1);
+        len = RADIOLIB_MIN(lenDown, this->lorawanNode->getMaxPayloadLen());
+        RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Echoing %d bytes with increment", len - 1);
       }
     } break;
 
     case(RADIOLIB_LORAWAN_TS009_RX_APP_CNT): {
       if(this->lorawanNode) {
-        this->lenUp = 3;
+        len = 3;
         uint16_t aFcntDown16 = (uint16_t)this->lorawanNode->getRxFCnt();
         for(uint8_t i = 0; i < RADIOLIB_LORAWAN_MAX_NUM_MC_GROUPS; i++) {
           aFcntDown16 += (uint16_t)this->lorawanNode->getRxFCntMulticast(i);
         }
-        this->dataUp[1] = aFcntDown16 & 0xFF;
-        this->dataUp[2] = aFcntDown16 >> 8;
+        dataOut[1] = aFcntDown16 & 0xFF;
+        dataOut[2] = aFcntDown16 >> 8;
         RADIOLIB_DEBUG_PROTOCOL_PRINTLN("aFCntDown16: %d", aFcntDown16);
       }
     } break;
@@ -176,12 +184,22 @@ size_t LoRaWANPackageTS009::processData(const uint8_t* dataDown, size_t lenDown,
       }
     } break;
 
-    case(RADIOLIB_LORAWAN_TS009_PING_SLOT_INFO): {
-      RADIOLIB_DEBUG_PROTOCOL_PRINTLN("PingSlotInfo not implemented");
+    case(RADIOLIB_LORAWAN_TS009_FRAG_SESSION_CNT): {
+      if(this->lorawanNode) {
+        uint8_t nonceBuf[8];
+        this->lorawanNode->getPersistencePackage(RADIOLIB_LORAWAN_PERSISTENCE_TS004, nonceBuf);
+        uint8_t fragIndex = dataDown[1] & 0x03;
+        len = 4;
+        dataOut[1] = fragIndex;
+        dataOut[2] = nonceBuf[fragIndex * 2];
+        dataOut[3] = nonceBuf[fragIndex * 2 + 1];
+        RADIOLIB_DEBUG_PROTOCOL_PRINTLN("FragSession index: %d, Cnt: %d", fragIndex, 
+                                        (nonceBuf[fragIndex * 2 + 1] << 8) | nonceBuf[fragIndex * 2]);
+      }
     } break;
 
     case(RADIOLIB_LORAWAN_TS009_TX_CW): {
-      if(lenDown > 6 && this->radioModule) {
+      if(lenDown > 6 && this->radio) {
         uint16_t timeout = ((uint16_t)dataDown[2] << 8) | (uint16_t)dataDown[1];
         uint32_t freqRaw = ((uint32_t)dataDown[5] << 16) | ((uint32_t)dataDown[4] << 8) | 
                            ((uint32_t)dataDown[3]);
@@ -190,42 +208,47 @@ size_t LoRaWANPackageTS009::processData(const uint8_t* dataDown, size_t lenDown,
 
         RADIOLIB_DEBUG_PROTOCOL_PRINTLN("TX CW: %7.3f MHz, %d dBm, %d s", freq, txPower, timeout);
 
-        this->radioModule->setFrequency(freq);
-        this->radioModule->setOutputPower(txPower);
-        this->radioModule->transmitDirect();
+        this->radio->setFrequency(freq);
+        this->radio->setOutputPower(txPower);
+        this->radio->transmitDirect();
         this->delaySecondsCallback(timeout);
-        this->radioModule->standby();
+        this->radio->standby();
       }
     } break;
 
     case(RADIOLIB_LORAWAN_TS009_DUT_FPORT224_DISABLE): {
       RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Disabling package");
       this->enabled = false;
+      const uint8_t* flag = &this->enabled;
+      this->lorawanNode->setPersistencePackage(RADIOLIB_LORAWAN_PERSISTENCE_TS009, flag);
+      
+      // give flash saving some time before rebooting
+      this->hal->delay(100);
       this->reboot();
 
     } break;
 
     case(RADIOLIB_LORAWAN_TS009_DUT_VERSIONS): {
-      this->lenUp = 13;
-      this->dataUp[1] = RADIOLIB_VERSION_MAJOR;
-      this->dataUp[2] = RADIOLIB_VERSION_MINOR;
-      this->dataUp[3] = RADIOLIB_VERSION_PATCH;
-      this->dataUp[4] = RADIOLIB_VERSION_EXTRA;
+      len = 13;
+      dataOut[1] = RADIOLIB_VERSION_MAJOR;
+      dataOut[2] = RADIOLIB_VERSION_MINOR;
+      dataOut[3] = RADIOLIB_VERSION_PATCH;
+      dataOut[4] = RADIOLIB_VERSION_EXTRA;
 
-      this->dataUp[5] = 1;
+      dataOut[5] = 1;
 #if (LORAWAN_VERSION == 1)
-      this->dataUp[6] = 1;
-      this->dataUp[7] = 0;
+      dataOut[6] = 1;
+      dataOut[7] = 0;
 #else
-      this->dataUp[6] = 0;
-      this->dataUp[7] = 4;
+      dataOut[6] = 0;
+      dataOut[7] = 4;
 #endif
-      this->dataUp[8] = 0;
+      dataOut[8] = 0;
 
-      this->dataUp[9] = 1;
-      this->dataUp[10] = 0;
-      this->dataUp[11] = 4;
-      this->dataUp[12] = 0;
+      dataOut[9] = 1;
+      dataOut[10] = 0;
+      dataOut[11] = 4;
+      dataOut[12] = 0;
 
       RADIOLIB_DEBUG_PROTOCOL_PRINTLN("Device versions requested");
     } break;
@@ -236,10 +259,11 @@ size_t LoRaWANPackageTS009::processData(const uint8_t* dataDown, size_t lenDown,
   }
 
   // if data was set, copy the command ID
-  if(this->lenUp > 0) {
-    this->dataUp[0] = dataDown[0];
+  if(len > 0) {
+    dataOut[0] = dataDown[0];
   }
 
+  *lenOut = len;
   return(lenDown);
 }
 

--- a/src/protocols/LoRaWAN/LoRaWANPackageTS009.h
+++ b/src/protocols/LoRaWAN/LoRaWANPackageTS009.h
@@ -20,7 +20,8 @@
 #define RADIOLIB_LORAWAN_TS009_RX_APP_CNT_RESET       (0x0A)
 #define RADIOLIB_LORAWAN_TS009_LINK_CHECK             (0x20)
 #define RADIOLIB_LORAWAN_TS009_DEVICE_TIME            (0x21)
-#define RADIOLIB_LORAWAN_TS009_PING_SLOT_INFO         (0x22)
+#define RADIOLIB_LORAWAN_TS009_FRAG_SESSION_CNT       (0x52)
+#define RADIOLIB_LORAWAN_TS009_RELAY_MODE_CTRL        (0x53)
 #define RADIOLIB_LORAWAN_TS009_TX_CW                  (0x7D)
 #define RADIOLIB_LORAWAN_TS009_DUT_FPORT224_DISABLE   (0x7E)
 #define RADIOLIB_LORAWAN_TS009_DUT_VERSIONS           (0x7F)
@@ -34,6 +35,7 @@ class LoRaWANPackageTS009 : public LoRaWANPackage {
 
     typedef void (*DelaySecondsCb_t)(RadioLibTime_t seconds);
     typedef void (*UplinkIntervalCb_t)(RadioLibTime_t intervalSeconds);
+    typedef void (*ConfirmedCb_t)(bool confirmed);
     typedef void (*RebootCb_t)();
 
     // copy constructor is removed to prevent users from creating copies of this class
@@ -55,32 +57,32 @@ class LoRaWANPackageTS009 : public LoRaWANPackage {
     void setUplinkIntervalCallback(UplinkIntervalCb_t intervalCb);
 
     /*!
+      \brief Set confirmed callback (for TX_FRAMES_CTRL command)
+    */
+    void setConfirmedCallback(ConfirmedCb_t confirmedCb);
+
+    /*!
       \brief Set reboot callback (for DUT_RESET command)
     */
     void setRebootCallback(RebootCb_t rebootCb);
 
     /*!
-      \brief Check whether subsequent uplinks should be confirmed
-      \returns true if uplinks should be confirmed, false otherwise
-    */
-    bool getConfirmed();
-
-    /*!
       \brief Process downlink data for TS009 LCTT package
       \param dataDown Pointer to received downlink data
       \param lenDown Length of downlink data
-      \returns Number of bytes consumed
+      \param eventDown Pointer to downlink event data
+      \returns Number of bytes processed
     */
-    size_t processData(const uint8_t* dataDown, size_t lenDown, LoRaWANEvent_t* event) override;
+    size_t processData(const uint8_t* dataDown, size_t lenDown, uint8_t* dataOut, size_t* lenOut, LoRaWANEvent_t* event) override;
 
 #if !RADIOLIB_GODMODE
   protected:
 #endif
 
-    PhysicalLayer* radioModule;
-    bool confirmed = false;
+    PhysicalLayer* radio;
     DelaySecondsCb_t delaySecondsCallback;
     UplinkIntervalCb_t uplinkIntervalCallback;
+    ConfirmedCb_t confirmedCallback;
     RebootCb_t rebootCallback;
 
     void reboot() {
@@ -100,7 +102,7 @@ class LoRaWANPackageTS009 : public LoRaWANPackage {
       \param node Pointer to the LoRaWAN node
       \param secondsCb Pointer to getSeconds() function
     */
-    LoRaWANPackageTS009(LoRaWANPackageManager* pacMan, LoRaWANNode* node, GetSecondsCb_t secondsCb);
+    LoRaWANPackageTS009(LoRaWANPackageManager* pacMan, RadioLibHal* hal, LoRaWANNode* node, GetSecondsCb_t secondsCb);
 
     uint8_t enabled = false;
     


### PR DESCRIPTION
This PR adds TS007 - which admittedly is not in use anywhere to my knowledge, but it means that the package manager is fully functional.

TS003 and TS009 are reworked to fully integrate with the package manager, instead of being a hybrid between their old standalone state and the later added package manager.

Disclaimer: some of the (doxygen) comments are autocompleted by an LLM.

One point for review: the package manager needs access to the HAL. It cannot access the HAL from PHY currently so I added it to the initializer, however this requires a manual instance of ArduinoHal on the Arduino platforms, where it instead is typically automatically constructed within the Module constructor. I am happy to force the user to instantiate the HAL and supply it to the Module too because any use of the Package Manager should be done by a decently experienced user, but it is a point for review nonetheless.

Example to be updated soon - I have the certification sketch ready but will review all examples anyway.

TS003, TS007 and TS009 all pass certification testing on an ESP32-S3 and an STM32WLE5 using LCTT.