### PR TITLE
[ESP-IDF] Don't build EspHal for Arduino targets

### DIFF
--- a/src/hal/ESP-IDF/EspHal.cpp
+++ b/src/hal/ESP-IDF/EspHal.cpp
@@ -3,7 +3,12 @@
 
 #include "EspHal.h"
 
-#if defined(ESP_PLATFORM)
+// Only build the native ESP-IDF HAL for pure ESP-IDF targets. Under Arduino
+// (including Arduino-ESP32, which also defines ESP_PLATFORM) RadioLib uses
+// ArduinoHal instead, and this file's IDF spi_master driver code may not even
+// compile against the older ESP-IDF bundled with the Arduino core. Mirrors the
+// RADIOLIB_BUILD_ARDUINO guard in ArduinoHal.cpp.
+#if defined(ESP_PLATFORM) && !defined(ARDUINO)
 
 #include "driver/gpio.h"
 #include "driver/ledc.h"
@@ -353,4 +358,4 @@ void EspHal::pullUpDown(uint32_t pin, bool enable, bool up) {
   }
 }
 
-#endif // ESP_PLATFORM
+#endif // ESP_PLATFORM && !ARDUINO

--- a/src/hal/ESP-IDF/EspHal.h
+++ b/src/hal/ESP-IDF/EspHal.h
@@ -5,7 +5,11 @@
 #if !defined(_RADIOLIB_ESP_IDF_HAL_H)
 #define _RADIOLIB_ESP_IDF_HAL_H
 
-#if defined(ESP_PLATFORM)
+// Only expose the native ESP-IDF HAL for pure ESP-IDF targets. Arduino builds
+// (Arduino-ESP32 also defines ESP_PLATFORM) use ArduinoHal instead. Note this
+// guard runs before RadioLib.h is included, so it must test the compiler's
+// predefined ARDUINO macro directly rather than RADIOLIB_BUILD_ARDUINO.
+#if defined(ESP_PLATFORM) && !defined(ARDUINO)
 #include "RadioLib.h"
 #include "driver/spi_master.h"
 
@@ -77,5 +81,5 @@ private:
   bool halInitialized;
   int32_t tonePrevFreq;
 };
-#endif
+#endif // ESP_PLATFORM && !ARDUINO
 #endif // _RADIOLIB_ESP_IDF_HAL_H


### PR DESCRIPTION
EspHal only compiles clean with ESP-IDF above 5.2 - the older arduino versons in platformio lack the neccessary headers. Sadly Arduino also defines ESP_PLATFORM since it is built on ESP-IDF, so those builds fail to compile even though EspHal is never used there.

Gate the HAL on `!defined(ARDUINO)` so it only builds for pure ESP-IDF, mirroring the RADIOLIB_BUILD_ARDUINO guard in ArduinoHal.cpp. The header guard runs before RadioLib.h is included, so it tests the predefined ARDUINO macro directly rather than RADIOLIB_BUILD_ARDUINO.

This is a quick shot fix that may or may not require additional changes. 

Example: https://github.com/meshtastic/firmware/actions/runs/28668405797/job/85033145387?pr=10854

Arduino builds should not even try to compile a different HAL.