### PR TITLE
Lr2021 cad scanchannel fix

### DIFF
--- a/src/modules/LR2021/LR2021.cpp
+++ b/src/modules/LR2021/LR2021.cpp
@@ -421,11 +421,21 @@ int16_t LR2021::scanChannel() {
 
 int16_t LR2021::scanChannel(const ChannelScanConfig_t &cfg) {
   // set mode to CAD
-  int state = startChannelScan(cfg);
+  int16_t state = startChannelScan(cfg);
   RADIOLIB_ASSERT(state);
 
-  // wait for channel activity detected or timeout
-  while(!this->mod->hal->digitalRead(this->mod->getIrq())) {
+  // Wait for the CAD to finish. The LR2021 latches the CadDone (and CadDetected) interrupt in the IRQ status
+  // register, but does not assert it on the DIO pin when the CAD exits back to standby (the CAD_ONLY exit
+  // mode used here). Polling the DIO pin (as Rx/Tx do) therefore never completes and hangs forever, so poll
+  // the IRQ status register instead, bounded by a timeout derived from the CAD duration as a safety net.
+  uint8_t symbols = (cfg.cad.symNum == RADIOLIB_LR2021_CAD_PARAM_DEFAULT) ? 2 : cfg.cad.symNum;
+  RadioLibTime_t symbolTime = (this->bandwidthKhz > 0.0f) ? (RadioLibTime_t)(((uint32_t)1 << this->spreadingFactor) / this->bandwidthKhz) : 0;
+  RadioLibTime_t timeout = (RadioLibTime_t)(symbols + 8) * symbolTime + 20;
+  RadioLibTime_t start = this->mod->hal->millis();
+  while(!(getIrqStatus() & (RADIOLIB_LR2021_IRQ_CAD_DETECTED | RADIOLIB_LR2021_IRQ_CAD_DONE))) {
+    if(this->mod->hal->millis() - start >= timeout) {
+      return(RADIOLIB_ERR_RX_TIMEOUT);
+    }
     this->mod->hal->yield();
   }
 

--- a/src/modules/LR2021/LR2021_commands.h
+++ b/src/modules/LR2021/LR2021_commands.h
@@ -335,9 +335,9 @@
 #define RADIOLIB_LR2021_TIMESTAMP_SOURCE_HEADER                 (0x04UL << 0)   //  3     0                       LoRa header
 
 // RADIOLIB_LR2021_CMD_SET_CAD_PARAMS
-#define RADIOLIB_LR2021_CAD_EXIT_MODE_FALLBACK                  (0x00UL << 0)   //  1     0     CAD exit mode: the configured fallback mode
-#define RADIOLIB_LR2021_CAD_EXIT_MODE_TX                        (0x01UL << 0)   //  1     0                    Tx
-#define RADIOLIB_LR2021_CAD_EXIT_MODE_RX                        (0x02UL << 0)   //  1     0                    Rx
+#define RADIOLIB_LR2021_CAD_EXIT_MODE_FALLBACK                  (0x00UL << 0)   //  7     0     CAD exit mode: CAD only, return to the configured fallback mode (datasheet CAD_ONLY)
+#define RADIOLIB_LR2021_CAD_EXIT_MODE_RX                        (0x01UL << 0)   //  7     0                   stay in Rx if activity is detected (datasheet CAD_RX)
+#define RADIOLIB_LR2021_CAD_EXIT_MODE_TX                        (0x10UL << 0)   //  7     0                   go to Tx if no activity is detected / LBT (datasheet CAD_LBT)
 #define RADIOLIB_LR2021_CAD_PARAM_DEFAULT                       (0xFFUL << 0)   //  7     0     used by the CAD methods to specify default parameter value
 
 // RADIOLIB_LR2021_CMD_SEL_PA


### PR DESCRIPTION
Fixes an LR2021 `scanChannel()` that hangs forever on an idle channel, plus a related CAD exit-mode constant mismatch. Full root-cause writeup and hardware evidence are in #1830 .

**Goal**

Two commits:

1. **`scanChannel()` polls the IRQ status register instead of the DIO pin.** On the LR2021 the CadDone interrupt latches in the IRQ status register but is never asserted on the DIO pin when the CAD exits to standby (the CAD_ONLY mode `scanChannel()` uses). The wait loop polled the pin, so it never returned. It now polls the status register (which `getChannelScanResult()` already reads), bounded by a timeout derived from the CAD duration as a safety net. This is the remaining half of the freeze #1727 addressed: that PR fixed the CAD command so CadDone fires; this fixes the wait so `scanChannel()` actually returns.

2. **Corrects the CAD exit-mode constants** to match datasheet Table 6-18 (`CAD_RX = 0x01`, `CAD_LBT/TX = 0x10`). RadioLib had `TX = 0x01` / `RX = 0x02`; `0x02` is not a valid exit mode and the chip returns a command error for it (observed on hardware).

**Why upstream**

LR2021 CAD / `scanChannel()` is unusable without this - any idle-channel scan hangs the caller indefinitely. The constant fix stops anyone using the (currently wrong) TX/RX exit modes from writing an invalid value.

**Foreseen impacts**

- `LR2021::scanChannel()` behavior changes from "block forever" to "return in ~19 ms" (or `RADIOLIB_ERR_RX_TIMEOUT` if a scan never completes). No API/signature change; no other module is touched.
- The exit-mode constant values change, but RadioLib only uses `FALLBACK` (0x00) internally, so the default CAD path is unaffected. This only matters for code that references `CAD_EXIT_MODE_TX` / `CAD_EXIT_MODE_RX` directly.

**Testing**

Hardware-tested on a Semtech LR2021 (ESP32-S3): `scanChannel()` previously hung; it now returns `RADIOLIB_CHANNEL_FREE` in ~19 ms, repeatably. The idle / CHANNEL_FREE path is verified end-to-end; the DETECTED path uses the same status-register read but I could not stage live traffic on my bench to exercise it. I have not run the Raspberry Pi runtime CI locally - the change is LR2021-specific and should not affect other platforms.

Written with AI assistance.
