### PR TITLE
Fix AX25Frame::operator= writing through unallocated buffers

### DIFF
--- a/src/protocols/AX25/AX25.cpp
+++ b/src/protocols/AX25/AX25.cpp
@@ -108,6 +108,12 @@ AX25Frame::~AX25Frame() {
 }
 
 AX25Frame& AX25Frame::operator=(const AX25Frame& frame) {
+  // guard against self-assignment - required since the buffers owned by
+  // "this" are freed below before being (re)populated from "frame"
+  if(this == &frame) {
+    return(*this);
+  }
+
   // destination callsign/SSID
   memcpy(this->destCallsign, frame.destCallsign, strlen(frame.destCallsign));
   this->destCallsign[strlen(frame.destCallsign)] = '\0';
@@ -118,12 +124,32 @@ AX25Frame& AX25Frame::operator=(const AX25Frame& frame) {
   this->srcCallsign[strlen(frame.srcCallsign)] = '\0';
   this->srcSSID = frame.srcSSID;
 
-  // repeaters
+  // repeaters - free any buffers this frame already owns, then (re)allocate
+  // to match the size actually needed for the incoming frame
+  #if !RADIOLIB_STATIC_ONLY
+    if(this->numRepeaters > 0) {
+      for(uint8_t i = 0; i < this->numRepeaters; i++) {
+        delete[] this->repeaterCallsigns[i];
+      }
+      delete[] this->repeaterCallsigns;
+      delete[] this->repeaterSSIDs;
+    }
+  #endif
   this->numRepeaters = frame.numRepeaters;
-  for(uint8_t i = 0; i < this->numRepeaters; i++) {
-    memcpy(this->repeaterCallsigns[i], frame.repeaterCallsigns[i], strlen(frame.repeaterCallsigns[i]));
+  if(this->numRepeaters > 0) {
+    #if !RADIOLIB_STATIC_ONLY
+      this->repeaterCallsigns = new char*[this->numRepeaters];
+      for(uint8_t i = 0; i < this->numRepeaters; i++) {
+        this->repeaterCallsigns[i] = new char[strlen(frame.repeaterCallsigns[i]) + 1];
+      }
+      this->repeaterSSIDs = new uint8_t[this->numRepeaters];
+    #endif
+    for(uint8_t i = 0; i < this->numRepeaters; i++) {
+      memcpy(this->repeaterCallsigns[i], frame.repeaterCallsigns[i], strlen(frame.repeaterCallsigns[i]));
+      this->repeaterCallsigns[i][strlen(frame.repeaterCallsigns[i])] = '\0';
+    }
+    memcpy(this->repeaterSSIDs, frame.repeaterSSIDs, this->numRepeaters);
   }
-  memcpy(this->repeaterSSIDs, frame.repeaterSSIDs, this->numRepeaters);
 
   // control field
   this->control = frame.control;
@@ -135,9 +161,19 @@ AX25Frame& AX25Frame::operator=(const AX25Frame& frame) {
   // PID field
   this->protocolID = frame.protocolID;
 
-  // info field
+  // info field - same free-then-(re)allocate pattern as above
+  #if !RADIOLIB_STATIC_ONLY
+    if(this->infoLen > 0) {
+      delete[] this->info;
+    }
+  #endif
   this->infoLen = frame.infoLen;
-  memcpy(this->info, frame.info, this->infoLen);
+  if(this->infoLen > 0) {
+    #if !RADIOLIB_STATIC_ONLY
+      this->info = new uint8_t[this->infoLen];
+    #endif
+    memcpy(this->info, frame.info, this->infoLen);
+  }
 
   return(*this);
 }

--- a/src/protocols/AX25/AX25.cpp
+++ b/src/protocols/AX25/AX25.cpp
@@ -28,6 +28,7 @@ AX25Frame::AX25Frame(const char* destCallsign, uint8_t destSSID, const char* src
   // set repeaters
   this->numRepeaters = 0;
   #if !RADIOLIB_STATIC_ONLY
+    this->info = NULL;
     this->repeaterCallsigns = NULL;
     this->repeaterSSIDs = NULL;
   #endif
@@ -64,6 +65,12 @@ AX25Frame::AX25Frame(const AX25Frame& frame)
   strncpy(this->destCallsign, frame.destCallsign, RADIOLIB_AX25_MAX_CALLSIGN_LEN + 1);
   strncpy(this->srcCallsign, frame.srcCallsign, RADIOLIB_AX25_MAX_CALLSIGN_LEN + 1);
 
+  #if !RADIOLIB_STATIC_ONLY
+    this->info = NULL;
+    this->repeaterCallsigns = NULL;
+    this->repeaterSSIDs = NULL;
+  #endif
+
   if(frame.infoLen) {
     #if !RADIOLIB_STATIC_ONLY
       this->info = new uint8_t[frame.infoLen];
@@ -92,17 +99,24 @@ AX25Frame::AX25Frame(const AX25Frame& frame)
 AX25Frame::~AX25Frame() {
   #if !RADIOLIB_STATIC_ONLY
     // deallocate info field
-    if(infoLen > 0) {
+    if(this->info != NULL) {
       delete[] this->info;
+      this->info = NULL;
     }
 
     // deallocate repeaters
-    if(this->numRepeaters > 0) {
+    if(this->repeaterCallsigns != NULL) {
       for(uint8_t i = 0; i < this->numRepeaters; i++) {
-        delete[] this->repeaterCallsigns[i];
+        if(this->repeaterCallsigns[i] != NULL) {
+          delete[] this->repeaterCallsigns[i];
+        }
       }
       delete[] this->repeaterCallsigns;
+      this->repeaterCallsigns = NULL;
+    }
+    if(this->repeaterSSIDs != NULL) {
       delete[] this->repeaterSSIDs;
+      this->repeaterSSIDs = NULL;
     }
   #endif
 }
@@ -127,12 +141,18 @@ AX25Frame& AX25Frame::operator=(const AX25Frame& frame) {
   // repeaters - free any buffers this frame already owns, then (re)allocate
   // to match the size actually needed for the incoming frame
   #if !RADIOLIB_STATIC_ONLY
-    if(this->numRepeaters > 0) {
+    if(this->repeaterCallsigns != NULL) {
       for(uint8_t i = 0; i < this->numRepeaters; i++) {
-        delete[] this->repeaterCallsigns[i];
+        if(this->repeaterCallsigns[i] != NULL) {
+          delete[] this->repeaterCallsigns[i];
+        }
       }
       delete[] this->repeaterCallsigns;
+      this->repeaterCallsigns = NULL;
+    }
+    if(this->repeaterSSIDs != NULL) {
       delete[] this->repeaterSSIDs;
+      this->repeaterSSIDs = NULL;
     }
   #endif
   this->numRepeaters = frame.numRepeaters;
@@ -163,8 +183,9 @@ AX25Frame& AX25Frame::operator=(const AX25Frame& frame) {
 
   // info field - same free-then-(re)allocate pattern as above
   #if !RADIOLIB_STATIC_ONLY
-    if(this->infoLen > 0) {
+    if(this->info != NULL) {
       delete[] this->info;
+      this->info = NULL;
     }
   #endif
   this->infoLen = frame.infoLen;


### PR DESCRIPTION
## What

`AX25Frame::operator=` copies into `this->info`, `this->repeaterCallsigns` and `this->repeaterSSIDs` without ever (re)allocating them first. In the default dynamic-memory build (`RADIOLIB_STATIC_ONLY == 0`), these are raw pointer members that constructors only allocate when `infoLen`/`numRepeaters` is non-zero. A frame built via the info-less/repeater-less constructor overload therefore has these pointers indeterminate, and assigning a frame that *does* have an info field or repeaters onto it writes through that indeterminate pointer:

```cpp
AX25Frame dst("DEST", 0, "SRC", 0, 0x03);           // no info, no repeaters
AX25Frame src("DEST", 0, "SRC", 0, 0x03, 0xF0, payload, 8);
dst = src;                                          // segfault (dst.info never allocated)
```

Reproduced on a clean host build (real repo sources, no mocks): the above sequence reliably segfaults before this change.

## Fix

Mirror the allocation pattern already used by the copy constructor, and the freeing pattern already used by the destructor: free any buffer `this` currently owns, then allocate fresh buffers sized to match the source frame before copying. Added a self-assignment guard, which becomes required once the operator frees its own buffers before copying (otherwise self-assignment would free the very buffer it's about to read from).

Verified locally (built the actual library target via CMake, MinGW g++): the crash repro above no longer crashes and copies correctly; also checked the repeaters variant, self-assignment, shrink/grow reassignment, and a 200k-iteration reassignment loop for leaks (working-set growth ~0.1 bytes/iteration, not the ~512 bytes/iteration a real leak would show).

## Disclosure

Per this repo's CONTRIBUTING.md AI-use policy: this fix was produced with AI assistance (Claude), with the bug independently verified by compiling and running the reproduction above against current `master`, and the fix independently compiled and tested before submission.
