### PR TITLE
[MOD] Fix setRfSwitchTable Doxygen to match 5-pin array size

### DIFF
--- a/src/Module.h
+++ b/src/Module.h
@@ -435,7 +435,7 @@ class Module {
 
 
       \param pins A reference to an array of pins to control. This
-      should always be an array of 3 elements. If you need less pins,
+      should always be an array of 5 elements. If you need less pins,
       use RADIOLIB_NC for the unused elements.
 
       \param table A reference to an array of pin values to use for each
@@ -470,7 +470,7 @@ class Module {
       \code
       // In global scope, define the pin array and mode table
       static const uint32_t rfswitch_pins[] =
-                             {PA0,  PA1,  RADIOLIB_NC};
+                             {PA0,  PA1,  RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC};
       static const Module::RfSwitchMode_t rfswitch_table[] = {
         {Module::MODE_IDLE,  {LOW,  LOW}},
         {Module::MODE_RX,    {HIGH, LOW}},


### PR DESCRIPTION
The `setRfSwitchTable` doc comment in `Module.h` still says the `pins` argument "should always be an array of 3 elements" and its inline example uses a 3-element initializer — leftovers from before f78b3ccc9 raised `RFSWITCH_MAX_PINS` to 5. Since the parameter is `const uint32_t (&)[RFSWITCH_MAX_PINS]`, the documented example doesn't compile.

This updates the text and the example to the 5-element form used by the STM32WLx examples. Documentation only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)