### PR TITLE
[LR2021] Fix configFifoIrq()

### DIFF
--- a/src/modules/LR2021/LR2021.h
+++ b/src/modules/LR2021/LR2021.h
@@ -890,7 +890,7 @@ class LR2021: public LRxxxx {
     int16_t setDioIrqConfig(uint8_t dio, uint32_t irq);
     int16_t clearIrqState(uint32_t irq);
     int16_t getAndClearIrqStatus(uint32_t* irq);
-    int16_t configFifoIrq(uint8_t rxFifoIrq, uint8_t txFifoIrq, uint8_t rxHighThreshold, uint8_t txHighThreshold);
+    int16_t configFifoIrq(uint8_t rxFifoIrq, uint8_t txFifoIrq, uint16_t rxHighThreshold, uint16_t txLowThreshold, uint16_t rxLowThreshold, uint16_t txHighThreshold);
     int16_t getFifoIrqFlags(uint8_t* rxFifoFlags, uint8_t* txFifoFlags);
     int16_t clearFifoIrqFlags(uint8_t rxFifoFlags, uint8_t txFifoFlags);
     int16_t getAndClearFifoIrqFlags(uint8_t* rxFifoFlags, uint8_t* txFifoFlags);

--- a/src/modules/LR2021/LR2021_cmds_chip_control.cpp
+++ b/src/modules/LR2021/LR2021_cmds_chip_control.cpp
@@ -240,8 +240,19 @@ int16_t LR2021::getAndClearIrqStatus(uint32_t* irq) {
   return(state);
 }
 
-int16_t LR2021::configFifoIrq(uint8_t rxFifoIrq, uint8_t txFifoIrq, uint8_t rxHighThreshold, uint8_t txHighThreshold) {
-  uint8_t buff[] = { rxFifoIrq, txFifoIrq, rxHighThreshold, txHighThreshold };
+int16_t LR2021::configFifoIrq(uint8_t rxFifoIrq, uint8_t txFifoIrq, uint16_t rxHighThreshold, uint16_t txLowThreshold, uint16_t rxLowThreshold, uint16_t txHighThreshold) {
+  uint8_t buff[] = {
+	rxFifoIrq,
+	txFifoIrq,
+	(uint8_t)((rxHighThreshold >> 8) & 0xFF),
+	(uint8_t)(rxHighThreshold & 0xFF),
+	(uint8_t)((txLowThreshold >> 8) & 0xFF),
+	(uint8_t)(txLowThreshold & 0xFF),
+	(uint8_t)((rxLowThreshold >> 8) & 0xFF),
+	(uint8_t)(rxLowThreshold & 0xFF),
+	(uint8_t)((txHighThreshold >> 8) & 0xFF),
+	(uint8_t)(txHighThreshold & 0xFF),
+	};
   return(this->SPIcommand(RADIOLIB_LR2021_CMD_CONFIG_FIFO_IRQ, true, buff, sizeof(buff)));
 }
 


### PR DESCRIPTION
Fixes LR2021 configFifoIrq() behavior.
Closes https://github.com/jgromes/RadioLib/issues/1848 issue.