### PR TITLE
[LR2021] fix CR constants from the datasheet, add missing header mode check

### DIFF
--- a/src/modules/LR2021/LR2021.cpp
+++ b/src/modules/LR2021/LR2021.cpp
@@ -1190,6 +1190,11 @@ uint8_t LR2021::randomByte() {
 }
 
 int16_t LR2021::getLoRaRxHeaderInfo(uint8_t* cr, bool* hasCRC){
+  // check if in explicit header mode, as LR11x0, SX126x, SX127x and SX128x do
+  if(this->headerType == RADIOLIB_LRXXXX_LORA_HEADER_IMPLICIT) {
+    return(RADIOLIB_ERR_WRONG_MODEM);
+  }
+
   return(this->getLoRaPacketStatus(cr, hasCRC, NULL, NULL, NULL, NULL));
 }
 

--- a/src/modules/LR2021/LR2021_commands.h
+++ b/src/modules/LR2021/LR2021_commands.h
@@ -386,7 +386,9 @@
 #define RADIOLIB_LR2021_LORA_CR_4_8                             (0x04UL << 0)   //  3     0                       4/8
 #define RADIOLIB_LR2021_LORA_CR_4_5_LI                          (0x05UL << 0)   //  3     0                       4/5 long interleaver
 #define RADIOLIB_LR2021_LORA_CR_4_6_LI                          (0x06UL << 0)   //  3     0                       4/6 long interleaver
-#define RADIOLIB_LR2021_LORA_CR_4_7_LI                          (0x07UL << 0)   //  3     0                       4/7 long interleaver
+#define RADIOLIB_LR2021_LORA_CR_4_8_LI                          (0x07UL << 0)   //  3     0                       4/8 long interleaver
+#define RADIOLIB_LR2021_LORA_CR_4_6_LI_CONV                     (0x08UL << 0)   //  3     0                       4/6 long interleaver, convolutional
+#define RADIOLIB_LR2021_LORA_CR_4_8_LI_CONV                     (0x09UL << 0)   //  3     0                       4/8 long interleaver, convolutional
 #define RADIOLIB_LR2021_LORA_LDRO_DISABLED                      (0x00UL << 0)   //  1     0     LDRO/PPM configuration: disabled
 #define RADIOLIB_LR2021_LORA_LDRO_ENABLED                       (0x01UL << 0)   //  1     0                             enabled
 


### PR DESCRIPTION
Per LR2021 datasheet Rev 1.1 Table 9-4, cr 0x07 is long interleaver
coding rate 4/8, not 4/7. Long interleaved 4/7 does not exist, which
setCodingRate() already reflects by mapping 4/8 long interleaved onto
0x07, and LR11x0 names the same value RADIOLIB_LR11X0_LORA_CR_4_8_LONG.

The same table defines 0x08 and 0x09 as long interleaver convolutional
4/6 and 4/8. These are LR2021 only, incompatible with SX126x, SX127x,
SX128x and LR11x0, and were missing.

Also add the explicit header mode check that LR11x0, SX126x, SX127x and
SX128x already perform before reporting received header information.