### PR TITLE
[LR11xx] fix actual coding rate return

### DIFF
--- a/src/modules/LR11x0/LR11x0_commands.cpp
+++ b/src/modules/LR11x0/LR11x0_commands.cpp
@@ -673,7 +673,7 @@ int16_t LR11x0::getLoRaRxHeaderInfo(uint8_t* cr, bool* hasCRC) {
   int16_t state = this->SPIcommand(RADIOLIB_LR11X0_CMD_GET_LORA_RX_HEADER_INFOS, false, buff, sizeof(buff));
 
   // pass the replies
-  if(cr) { *cr = (buff[0] & 0x70) >> 4; }
+  if(cr) { *cr = buff[0] & RADIOLIB_LR11X0_LAST_HEADER_CR_MASK; }
   if(hasCRC) { *hasCRC = (buff[0] & RADIOLIB_LR11X0_LAST_HEADER_CRC_ENABLED) != 0; }
 
   return(state);

--- a/src/modules/LR11x0/LR11x0_commands.h
+++ b/src/modules/LR11x0/LR11x0_commands.h
@@ -450,6 +450,7 @@
 // RADIOLIB_LR11X0_CMD_GET_LORA_RX_HEADER_INFOS
 #define RADIOLIB_LR11X0_LAST_HEADER_CRC_ENABLED                 (0x01UL << 4)   //  4     4     last header CRC: enabled
 #define RADIOLIB_LR11X0_LAST_HEADER_CRC_DISABLED                (0x00UL << 4)   //  4     4                      disabled
+#define RADIOLIB_LR11X0_LAST_HEADER_CR_MASK                     (0x07UL << 0)   //  2     0     last header coding rate
 
 // RADIOLIB_LR11X0_CMD_WIFI_SCAN
 #define RADIOLIB_LR11X0_WIFI_SCAN_802_11_B                      (0x01UL << 0)   //  7     0     Wi-Fi type to scan: 802.11b


### PR DESCRIPTION
Per LR1110 User Manual Rev 2.3 Table 7-18, the GetLoRaRxHeaderInfos response byte is RFU(7:5), CRC(4), RFU(3), coding_rate(2:0). Reading (buff[0] & 0x70) >> 4 skipped the coding rate entirely and returned the CRC flag in its place, so getLoRaRxHeaderInfo() reported coding rate 1 for every packet received with CRC enabled, and 0 for every packet without.