### PR TITLE
fix fabs() parentheses in setRxbandwidth

### DIFF
--- a/src/modules/CC1101/CC1101.cpp
+++ b/src/modules/CC1101/CC1101.cpp
@@ -542,7 +542,7 @@ int16_t CC1101::setRxBandwidth(float rxBw) {
   for(int8_t e = 3; e >= 0; e--) {
     for(int8_t m = 3; m >= 0; m --) {
       float point = (RADIOLIB_CC1101_CRYSTAL_FREQ * 1000000.0f)/(8 * (m + 4) * ((uint32_t)1 << e));
-      if(fabs((rxBw * 1000.0f - point) <= 1000.0f)) {
+      if(fabs(rxBw * 1000.0f - point) <= 1000.0f) {
         // set Rx channel filter bandwidth
         return(SPIsetRegValue(RADIOLIB_CC1101_REG_MDMCFG4, (e << 6) | (m << 4), 7, 4));
       }


### PR DESCRIPTION
As written, it was setting RX bandwidth (register `MDMCFG4`) to the first `point` value >= `rxBw * 1000 + 1000`:
* `fabs((rxBw * 1000.0f - point) <= 1000.0f)`

 It seems the intent is to set it to the first `point` value *within 1kHz of* the desired bandwidth (otherwise why bother with `fabs()`?):
* `fabs(rxBw * 1000.0f - point) <= 1000.0f`